### PR TITLE
fix(crud,signal): avoid UTF-8 char-boundary panic in slugify truncation

### DIFF
--- a/src/crud/mod.rs
+++ b/src/crud/mod.rs
@@ -72,7 +72,13 @@ pub fn slugify(name: &str) -> String {
     if full.len() <= 80 {
         return full;
     }
-    let truncated = &full[..80];
+    // Truncate to at most 80 bytes, backing off to a UTF-8 char boundary so a
+    // multi-byte char (e.g. 'μ') straddling byte 80 doesn't panic the slice.
+    let mut cut = 80;
+    while cut > 0 && !full.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let truncated = &full[..cut];
     match truncated.rfind('-') {
         Some(pos) if pos > 20 => truncated[..pos].to_string(),
         _ => truncated.to_string(),
@@ -376,6 +382,20 @@ mod tests {
         assert_eq!(slugify("CaseGate v2"), "casegate-v2");
         assert_eq!(slugify("hello--world"), "hello-world");
         assert_eq!(slugify("  spaced  "), "spaced");
+    }
+
+    #[test]
+    fn slugify_does_not_panic_on_multibyte_at_truncation_boundary() {
+        // Regression: a 2-byte char ('μ') straddling byte 80 used to panic the
+        // `&full[..80]` slice ("not a char boundary"). See the fractal-alternate
+        // journal concept "...participation measure μ".
+        let label = "x".repeat(79) + "μ"; // slug = 79 bytes + μ (bytes 79..81)
+        let s = slugify(&label);
+        assert!(s.len() <= 80);
+        assert!(s.chars().all(|c| c.is_alphanumeric() || c == '-'));
+        // and the real-world label that crashed
+        let real = "market depth L2 participation measure μ ".repeat(3);
+        let _ = slugify(&real); // must not panic
     }
 
     #[test]

--- a/src/signal/flow_resurface.rs
+++ b/src/signal/flow_resurface.rs
@@ -363,7 +363,13 @@ fn mention_threshold_scan(cwd: &Path, ns: &NamespaceConfig, threshold: u32) -> R
             let count = row.get("count").map(|t| crud::term_display(t.into())).unwrap_or_default();
             // Truncate long text for signal display
             let preview = if text.len() > 80 {
-                format!("{}...", &text[..80])
+                // Back off to a UTF-8 char boundary so a multi-byte char at byte 80
+                // doesn't panic the slice.
+                let mut cut = 80;
+                while cut > 0 && !text.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                format!("{}...", &text[..cut])
             } else {
                 text
             };


### PR DESCRIPTION
## Problem

`base graph extract` panics on a Markdown corpus when an extracted concept label
contains a multi-byte UTF-8 character positioned so a byte falls across the 80-byte
truncation boundary in `slugify()`:

```
thread 'main' panicked at src/crud/mod.rs:75:26:
end byte index 80 is not a char boundary; it is inside 'μ' (bytes 79..81) of `...participation-measure-μ`
```

`slugify()` keeps alphanumeric chars (so Greek/accented letters survive), then does a
raw **byte** slice `&full[..80]`. When byte 80 lands inside a multi-byte char, Rust
panics and the entire extract run dies partway through the corpus.

## Fix

Back off to the nearest UTF-8 char boundary before slicing, in the two spots that
fixed-offset byte-slice arbitrary text:

- `src/crud/mod.rs` — `slugify()` (the reported crash)
- `src/signal/flow_resurface.rs` — signal-preview truncation (`&text[..80]`, same
  hazard on unicode signal text)

`&hex[..32]` (ASCII hash) and `&known_vars[..7]` (Vec slice) were reviewed and left
as-is — neither is a UTF-8 char-boundary hazard.

## Test

Added a regression test in `crud::tests` exercising a 2-byte char straddling byte 80
plus the real-world label that crashed. `cargo test slugify` passes.
