### PR TITLE
fix(sync): GC stale domain metadata before re-upsert

### DIFF
--- a/src/domain/sync.rs
+++ b/src/domain/sync.rs
@@ -55,9 +55,26 @@ fn sync_domain_list(
         let domain_slug = crud::slugify(&domain_def.name);
         let domain_iri = crud::build_iri(ns, "domain", &domain_slug);
 
-        // UPSERT domain metadata — never delete. Graph is additive.
-        // Sync only ensures the domain entity exists with current trigger config.
-        // Rules, decisions, notes are graph-native and never touched by sync.
+        // UPSERT domain metadata. Rules, decisions, notes are graph-native and
+        // never touched by sync.
+        //
+        // The re-asserted properties below (name/status/promptKeyword/
+        // fileKeyword/triggerPath) are idempotent in RDF — duplicate INSERT DATA
+        // triples don't duplicate-store. updatedAt is the one non-idempotent
+        // triple in the block: its value changes every sync, so it accumulates a
+        // new byte-distinct quad on every run instead of upserting. GC it first,
+        // scoped to exactly the properties this block re-asserts, so it can never
+        // reach rdf:type or hasRule.
+        let domain_gc = format!(
+            "{pfx}\n\
+             DELETE {{ GRAPH <{graph}> {{ <{domain_iri}> ?p ?o . }} }}\n\
+             WHERE  {{ GRAPH <{graph}> {{ <{domain_iri}> ?p ?o .\n\
+                      FILTER(?p IN ({p}:name, {p}:status, {p}:promptKeyword,\n\
+                                    {p}:fileKeyword, {p}:triggerPath, {p}:updatedAt)) }} }}"
+        );
+        store
+            .update(&domain_gc)
+            .with_context(|| format!("Failed to GC stale domain metadata for '{}'", domain_def.name))?;
 
         // Insert domain entity (upsert via INSERT DATA — duplicates are idempotent in RDF)
         let prompt_kw_triples: String = domain_def


### PR DESCRIPTION
## Summary

`domain.sync`'s UPSERT block re-asserts six properties on every domain
(`name`, `status`, `promptKeyword`, `fileKeyword`, `triggerPath`, `updatedAt`)
via `INSERT DATA`, with no domain-level `DELETE` anywhere in the file. Five of
those six are naturally idempotent in RDF — duplicate triples don't
duplicate-store — but `updatedAt` is stamped with `now()` on every call, so
it's byte-distinct each time and accumulates forever instead of upserting.

On a live install this measured out to ~47% of total quads being redundant
timestamps (51 `updatedAt` quads on one domain after repeated syncs). Same
root cause opens a latent path for ghost triggers: a keyword removed from
`domains.toml` stops being asserted going forward but is never retracted from
the graph, so a deleted trigger can keep matching, and a rename can leave two
`name`/`status` values live on the same subject.

## Fix

Adds a `DELETE` immediately before the `INSERT DATA`, scoped by an explicit
`FILTER` over exactly the six properties the block re-asserts:

```sparql
DELETE { GRAPH <{graph}> { <{domain_iri}> ?p ?o . } }
WHERE  { GRAPH <{graph}> { <{domain_iri}> ?p ?o .
         FILTER(?p IN ({p}:name, {p}:status, {p}:promptKeyword,
                       {p}:fileKeyword, {p}:triggerPath, {p}:updatedAt)) } }
```

The explicit property list is load-bearing — a bare `?p ?o` delete would take
`rdf:type` and every `hasRule` edge with it. Both are excluded from the
FILTER, so domain typing and the rule graph (already GC'd separately, further
down in the same function) are untouched.

The fix is also the migration: since the DELETE matches by pattern rather
than by fact id, the first sync after this patch collapses all accumulated
timestamps per domain down to one and evicts any ghost triggers —
self-healing existing installs through the tool's own normal write path. No
manual migration step, no `graph compact`/`apply-ops` needed (both were
evaluated and don't apply here — `compact` dedups identical quads and these
are byte-distinct; `apply-ops` retires by fact id, which locally-produced
deltas don't have, so an unknown id is silently counted as applied while
removing nothing).

## Known tradeoff

Before this patch, `sync_domain_list` was crash-safe by construction — the
removed comment said "never delete, additive only," meaning a process kill
mid-sync could only leave *extra* stale data, never *missing* data. This
patch introduces a narrow window: the GC `DELETE` and the `INSERT DATA` are
two separate, non-transactional `store.update()` calls, so a process killed
between them leaves that domain's `name`/`status`/keywords gone until the
next successful sync (still typed `ops:Domain`, still linked to its rules —
just missing identity properties in between). This mirrors the existing
`rule_gc`/rule-insert pattern further down in the same function, but it's the
first time that two-call gap applies to a domain's own identity fields rather
than a child rule. Self-heals on the next sync; flagging it because it's a
real, if narrow, change to the file's stated invariant, not because it needs
fixing here.

## Test plan

- [x] Full local audit suite (97 checks) green before and after, no
      regressions
- [x] `cargo test` — existing `sync_is_idempotent` and related domain-sync
      tests pass unchanged
- [x] Live workspace, 10 domains: one `base domain sync` post-patch brought
      `updatedAt` quads from 589 → 10 and total graph size from 1301 → 718
      lines
- [x] Re-ran `base domain sync` repeatedly afterward — quad count and
      `updatedAt` count both stayed flat (no regrowth)
- [x] Confirmed the FILTER can't reach `rdf:type` or `hasRule` by inspecting
      the query and checking rule-graph counts pre/post
- [ ] Would appreciate a maintainer sanity-check on whether any other caller
      relies on multiple `updatedAt` values surviving on a domain subject
      (I didn't find one, but it's their call)
