### PR TITLE
chore: CI on every PR, a bug issue form, triage labels, and the process in CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Something base does that it should not, or does not do that it should.
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: base version
+      description: Paste the output of `base --version`.
+      placeholder: base 0.13.15
+    validations:
+      required: true
+  - type: dropdown
+    id: host
+    attributes:
+      label: Host and OS
+      options:
+        - Claude Code on Windows
+        - Claude Code on WSL or Linux
+        - Claude Code on macOS
+        - Codex
+        - Antigravity
+        - Other (say which below)
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: What you saw. Paste the exact output or error text.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: The commands, in order, from a state someone else can reach.
+      placeholder: |
+        base scaffold /tmp/x
+        cd /tmp/x
+        base rule add --domain x --text "..."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround, if you found one
+      description: This line is shown on the Known issues page while the bug is open.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community and support
+    url: https://www.skool.com/claude-code-titans-9203
+    about: Questions and how-do-I threads go here, not in the issue tracker.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Title in conventional form: feat(scope): ..., fix(scope): ..., chore: ... -->
+
+## What and why
+
+<!-- One paragraph. What changes for a user of base, and why now. -->
+
+Closes #
+
+## Checklist
+
+- [ ] `cargo test` is green locally (it includes the base-help coach gate)
+- [ ] The CLI changed? Then `BASE_REGEN_DOCS=1 cargo test --bin base help_docs` was run and a new command has its line in `commands.md` and its pair in `qa.md`
+- [ ] A bug fix names its issue above so the close and the Known issues page follow the merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+# Every pull request and every push to main runs the full test suite, which
+# includes the base-help coach gate (src/help_docs.rs). Until this existed,
+# nothing ran before a merge; the release workflow was the first test.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      - name: cargo test
+        run: cargo test
+
+  # Advisory until the three pre-existing never_loop denies in src/crud are
+  # cleared; then drop continue-on-error and it becomes a required check.
+  clippy:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# How base is developed
+
+Small team, mostly one person and Claude Code sessions. The process is the least that keeps a release honest.
+
+## Bugs
+
+A bug is a GitHub issue, filed with the bug form (it asks for the version, the host, what happens, how to reproduce, and a workaround). That is the only bug tracker; a bug noted in a handoff, a fork doc or a chat is not tracked until it is an issue.
+
+Labels the pipeline reads:
+
+| Label | Meaning |
+| --- | --- |
+| `bug` | applied by the form |
+| `confirmed` | reproduced, or established from the source; it belongs on the Known issues page |
+| `needs-info` | cannot be reproduced from what was given |
+| `not-a-bug` | works as designed; say why in a comment |
+| `fixed-in:<version>` | applied at release time to every issue closed since the previous tag |
+
+## Changes
+
+Every change is a branch and a pull request, even a one-line one. The PR title is a conventional commit (`feat(scope): …`, `fix(scope): …`, `chore: …`); the body says what changes for a user and why, and names the issue it closes (`Closes #N`) so the close and the Known issues page follow the merge. CI runs `cargo test` on the PR; merge when it is green, squash, and delete the branch.
+
+`cargo test` includes the base-help coach gate. If the CLI changed, run `BASE_REGEN_DOCS=1 cargo test --bin base help_docs` and, for a new command, add its line to `claude/skills/base-help/references/commands.md` and a pair to `qa.md`. The gate names exactly what is missing.
+
+## Releases
+
+`scripts/release.sh <version> --push` from a clean `main`. It bumps the version, lets cargo rewrite the lock, regenerates the coach, runs the suite, commits, tags and pushes; the Release workflow builds the binaries after its own docs gate passes. Never edit `Cargo.lock` by hand and never tag by hand.
+
+## Where things are discussed
+
+Questions and how-do-I threads go to the community, not the issue tracker. Design decisions that outlive a PR are logged in the graph with `base decision log`.


### PR DESCRIPTION
Until now nothing ran before a merge: pushes went straight to main and the
Release workflow was the first place tests ran. Bugs lived in handoffs, fork
docs and chat; the repo's ten issues carried no labels.

- .github/workflows/ci.yml: cargo test on every pull request and push to
  main (includes the base-help coach gate). Clippy runs as an advisory job
  until the three pre-existing never_loop denies in src/crud are cleared.
- .github/ISSUE_TEMPLATE/bug.yml: a bug form asking for version, host, what
  happens, how to reproduce, expected, workaround; labels the issue bug.
  Structured sections are what lets the Known issues page render from
  issues later (fork basemode-docs-autosync).
- .github/pull_request_template.md: conventional title, what and why,
  Closes #N, the three checks that matter.
- CONTRIBUTING.md: the whole process on one page: bugs are issues, every
  change is a PR that CI must pass, releases go through scripts/release.sh.
- Labels confirmed / needs-info / not-a-bug created on the repo (outside
  this diff).

This PR is the first to go through the process it describes.

Closes #

- [x] cargo test green locally on this tree (75b901d suite, no source change here)
- [x] CLI unchanged
- [ ] not a bug fix

https://claude.ai/code/session_015DxacShh1efh25PXEsDxEa