### PR TITLE
docs(changelog): CHANGELOG.md, generated from the tags by scripts/changelog.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+Every released version of base, newest first. Each entry is generated from the commits
+between that release's tag and the one before it, by `scripts/changelog.py`.
+`scripts/release.sh` writes the top section when it cuts a release, and `cargo test`
+fails when the version in `Cargo.toml` has no entry here.
+
+Releases before 0.13.3 are tagged in the repository but are not written up.
+
+## 0.13.15 (2026-09-03)
+
+### Fixed
+
+- **base-help**: hold the coach to the binary — generated cli.md, enforced stamps, release script
+
+### Changed
+
+- src/help_docs.rs is a source file, not an executable
+
+## 0.13.14 (2026-09-02)
+
+*No user-visible changes.*
+
+## 0.13.13 (2026-09-02)
+
+*No user-visible changes.*
+
+## 0.13.12 (2026-09-02)
+
+*No user-visible changes.*
+
+## 0.13.11 (2026-09-02)
+
+### Added
+
+- **automap**: workspace boots — hubs two levels deep, nested apps map themselves, Bash and wsl first contact, one build at a time
+
+## 0.13.10 (2026-09-01)
+
+### Added
+
+- **automap**: no app goes without a code map — bare folders, read-only contact, big trees, missing hooks
+
+## 0.13.9 (2026-09-01)
+
+### Added
+
+- **hooks**: every app gets a code map on first contact — session-start and Stop build it, never by hand
+
+## 0.13.8 (2026-09-01)
+
+### Fixed
+
+- **hooks**: the Stop-hook AST refresh survives a cwd change — dirty marks get a global-tier copy
+
+## 0.13.7 (2026-09-01)
+
+### Fixed
+
+- **ast**: match paths below the app root on Windows — normalise the stored sourceFile in SPARQL
+
+## 0.13.6 (2026-09-01)
+
+### Fixed
+
+- **ast**: `ast query --file` is linear again — sourceFile pattern back inside the first BGP
+
+## 0.13.5 (2026-09-01)
+
+- **Skill backups move out of `~/.claude/skills`.** When an update replaced `base-help`, the previous copy was kept beside it as `base-help.bak-<timestamp>`, and Claude Code loaded that backup as a second, stale skill. Backups now live under `~/.base-gbl/backups/skills/`. If you already have a `*.bak-*` directory in `~/.claude/skills`, move or delete it.
+
+Windows installs older than 0.13.4: see the v0.13.4 notes for the one-time bootstrap.
+
+### Fixed
+
+- **install**: park replaced skills under ~/.base-gbl/backups/skills, not inside ~/.claude/skills
+
+## 0.13.4 (2026-09-01)
+
+- **Self-update works on Windows.** The updater is `base.exe` itself, and Windows refuses to rename a file over a running image, so every hook-spawned update since 0.13.0 downloaded the release and failed the last step in silence. The running binary is now renamed aside (`base.exe.old`) and the new one renamed in; a side-by-side extensionless `base` (Git Bash) is refreshed too.
+- **`~/.base-gbl/update.log`**: one line per swap or failure, background or manual. The silent path finally leaves a trace.
+
+**One-time step for Windows installs older than 0.13.4:** the old binary cannot replace itself, so install this release by downloading `base-windows-x86_64.zip` below (or `npx chrisai`). From here on it updates in place at session start.
+
+### Fixed
+
+- **update**: swap a running Windows binary by renaming it aside, and leave a trace
+
+## 0.13.3 (2026-09-01)
+
+- **Relay wake contract** (#11, #13): the hook-injected block explains what the relay is, that everything it touches stays under `~/.base-gbl/.base/relay-inbox/`, where the instruction comes from and how to switch it off. It names the operator from `base operator init` (or says "the operator"). New `[relay]` section: `base config set relay.enabled false` / `base config set relay.wake_nudge false`.
+- **Nudge throttle on Windows** (#13): the 180 s cooldown never engaged because a zero-byte write does not move mtime on Windows; it now sets the mtime explicitly.
+- **`base scaffold` on Windows** (#13): the workspace path is written in a TOML-safe form instead of the verbatim `\\?\` path that broke `base config`.
+- **Skills install** (#12): reports when `~/.claude/skills` is a symlink; `BASE_SKILLS_DIR` overrides the destination.
+- **Domain sync** (#14, thanks @PulseCheckAI): `updatedAt` no longer accumulates one quad per sync.
+
+**Windows note:** the silent self-update in this release cannot replace its own running binary; that is fixed in v0.13.4. Install this or later by downloading the zip or `npx chrisai`.
+
+### Added
+
+- **doctor**: record the coach's version and report when it lags
+- **update**: refresh the bundled skill after a binary swap
+- **sync**: ring a running app after a graph write (R7)
+- **sync**: publish the hook command table as JSON (R4)
+- **sync**: capture deltas at the SPARQL write sites behind a pairing gate (R1b)
+- **sync**: carry the delta on the five fact-producing writes (R1a)
+- **sync**: stamp origin on every changes.jsonl record
+- **sync**: base graph apply-ops — apply inbound fact ops into the local graph
+- **changelog**: append every successful graph write to changes.jsonl
+
+### Fixed
+
+- **relay,install,scaffold**: answer issues [#11](https://github.com/ChristopherKahler/base/issues/11), [#12](https://github.com/ChristopherKahler/base/issues/12) and [#13](https://github.com/ChristopherKahler/base/issues/13)
+- **sync**: GC stale domain metadata before re-upsert
+- **sync**: stop dying on backslashed relative paths in triple inserts
+- **base-help**: import the v0.12.3 bank and correct it against 0.13.2
+- **tier**: resolve --global directly instead of walking up into the workspace tier
+- **sync**: let a first pull create graph.nq instead of refusing
+- **plugin**: resolve manifest paths to one shape on Windows and unix
+- **tests**: stop workspace resolution walking out of the sandbox
+- **tests**: isolate cargo test from the real global graph

--- a/scripts/changelog-notes/0.13.3.md
+++ b/scripts/changelog-notes/0.13.3.md
@@ -1,0 +1,7 @@
+- **Relay wake contract** (#11, #13): the hook-injected block explains what the relay is, that everything it touches stays under `~/.base-gbl/.base/relay-inbox/`, where the instruction comes from and how to switch it off. It names the operator from `base operator init` (or says "the operator"). New `[relay]` section: `base config set relay.enabled false` / `base config set relay.wake_nudge false`.
+- **Nudge throttle on Windows** (#13): the 180 s cooldown never engaged because a zero-byte write does not move mtime on Windows; it now sets the mtime explicitly.
+- **`base scaffold` on Windows** (#13): the workspace path is written in a TOML-safe form instead of the verbatim `\\?\` path that broke `base config`.
+- **Skills install** (#12): reports when `~/.claude/skills` is a symlink; `BASE_SKILLS_DIR` overrides the destination.
+- **Domain sync** (#14, thanks @PulseCheckAI): `updatedAt` no longer accumulates one quad per sync.
+
+**Windows note:** the silent self-update in this release cannot replace its own running binary; that is fixed in v0.13.4. Install this or later by downloading the zip or `npx chrisai`.

--- a/scripts/changelog-notes/0.13.4.md
+++ b/scripts/changelog-notes/0.13.4.md
@@ -1,0 +1,4 @@
+- **Self-update works on Windows.** The updater is `base.exe` itself, and Windows refuses to rename a file over a running image, so every hook-spawned update since 0.13.0 downloaded the release and failed the last step in silence. The running binary is now renamed aside (`base.exe.old`) and the new one renamed in; a side-by-side extensionless `base` (Git Bash) is refreshed too.
+- **`~/.base-gbl/update.log`**: one line per swap or failure, background or manual. The silent path finally leaves a trace.
+
+**One-time step for Windows installs older than 0.13.4:** the old binary cannot replace itself, so install this release by downloading `base-windows-x86_64.zip` below (or `npx chrisai`). From here on it updates in place at session start.

--- a/scripts/changelog-notes/0.13.5.md
+++ b/scripts/changelog-notes/0.13.5.md
@@ -1,0 +1,3 @@
+- **Skill backups move out of `~/.claude/skills`.** When an update replaced `base-help`, the previous copy was kept beside it as `base-help.bak-<timestamp>`, and Claude Code loaded that backup as a second, stale skill. Backups now live under `~/.base-gbl/backups/skills/`. If you already have a `*.bak-*` directory in `~/.claude/skills`, move or delete it.
+
+Windows installs older than 0.13.4: see the v0.13.4 notes for the one-time bootstrap.

--- a/scripts/changelog-notes/README.md
+++ b/scripts/changelog-notes/README.md
@@ -1,0 +1,13 @@
+# Release notes written by hand
+
+`scripts/changelog.py` emits `<version>.md` from this directory as the opening
+paragraph of that version's `CHANGELOG.md` section, above the generated Added /
+Fixed / Changed lists. Use one when a release needs an explanation the commit
+subjects cannot carry: a one-time install step, a behaviour change someone has
+to act on.
+
+The three files here are the release notes written for 0.13.3, 0.13.4 and 0.13.5,
+recovered from their GitHub releases during the backfill. Every other release
+before 0.13.15 had only the install template as its body.
+
+Most releases need no file. The generated lists are the entry.

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Write CHANGELOG.md sections from the commits between two release tags.
+
+One generator, two callers. `scripts/release.sh` runs `section` on every release
+and prepends the result; the historical 0.13.3-0.13.15 backfill was produced by
+`file` over the same code. That is deliberate: if the backfill had been typed by
+hand, the first generated entry would have looked nothing like the entries above
+it and nobody would have noticed until it shipped.
+
+    scripts/changelog.py section v0.13.15 HEAD 0.13.16 [--date D] [--prepend F]
+    scripts/changelog.py file v0.13.2 v0.13.3 ... v0.13.15 > CHANGELOG.md
+
+Classification of each commit subject, which is why the repo writes conventional
+subjects:
+
+    feat(scope): ...        Added
+    fix(scope): ...         Fixed, with every issue its body closes linked
+    Revert "<subject>"      dropped, together with the commit it names
+    chore(release): ...     dropped
+    test(...): ...          dropped
+    Merge ...               dropped
+    anything else           Changed
+
+A revert only cancels its target when both are being rendered together. When the
+reverted feature shipped in a release that is already published, the revert is
+reported as a Changed line instead, because that release's entry is history a
+reader has already seen.
+
+Release notes written by hand for a specific version live in `scripts/changelog-notes/<version>.md`
+and are emitted as that section's opening paragraph. Everything else in a section
+is derived from git.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_URL = "https://github.com/ChristopherKahler/base"
+
+HEADER = """# Changelog
+
+Every released version of base, newest first. Each entry is generated from the commits
+between that release's tag and the one before it, by `scripts/changelog.py`.
+`scripts/release.sh` writes the top section when it cuts a release, and `cargo test`
+fails when the version in `Cargo.toml` has no entry here.
+
+Releases before 0.13.3 are tagged in the repository but are not written up.
+"""
+
+SECTIONS = ("Added", "Fixed", "Changed")
+
+# `Closes #11, closes #12, closes #13.` and `Closes #11, #12, #13.` both yield
+# 11, 12, 13. A line like `Also closes a latent bug: ...` carries no `#N` and so
+# contributes nothing, which is the point of reading numbers rather than verbs.
+CLOSES_LINE = re.compile(r"\b(?:close[sd]?|fixe[sd]?|resolve[sd]?)\b", re.I)
+ISSUE = re.compile(r"#(\d+)")
+CONVENTIONAL = re.compile(r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]*)\))?!?:\s*(?P<rest>.+)$")
+REVERT = re.compile(r'^Revert "(?P<subject>.+)"\s*$')
+
+
+def git(*args):
+    """Run git with an explicit environment: inheriting the caller's leaves the
+    output at the mercy of whatever locale or pager the parent happened to set,
+    and this script parses that output."""
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", ""),
+        "GIT_DIR": os.environ["GIT_DIR"] if "GIT_DIR" in os.environ else "",
+        "LC_ALL": "C",
+        "GIT_PAGER": "cat",
+        "TZ": "UTC",
+    }
+    env = {k: v for k, v in env.items() if v}
+    out = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        timeout=120,
+    )
+    if out.returncode != 0:
+        sys.exit(f"git {' '.join(args)} failed:\n{out.stderr.strip()}")
+    return out.stdout
+
+
+def commits(from_ref, to_ref):
+    """Every commit in (from_ref, to_ref], oldest last, as dicts."""
+    raw = git("log", "--format=%H%x1f%s%x1f%b%x1e", f"{from_ref}..{to_ref}")
+    out = []
+    for record in raw.split("\x1e"):
+        record = record.strip("\n")
+        if not record:
+            continue
+        sha, subject, body = record.split("\x1f")
+        out.append({"sha": sha, "subject": subject.strip(), "body": body})
+    return out
+
+
+def closed_issues(body):
+    """Issue numbers this commit says it closes, in the order written, deduplicated."""
+    found = []
+    for line in body.splitlines():
+        if not CLOSES_LINE.search(line):
+            continue
+        for n in ISSUE.findall(line):
+            if n not in found:
+                found.append(n)
+    return found
+
+
+def classify(subject):
+    """(bucket, text) for one subject, or (None, None) when it is not written up."""
+    m = CONVENTIONAL.match(subject)
+    if m:
+        kind, scope, rest = m.group("type"), m.group("scope"), m.group("rest")
+        if kind == "test":
+            return None, None
+        if kind == "chore" and scope == "release":
+            return None, None
+        text = f"**{scope}**: {rest}" if scope else rest
+        if kind == "feat":
+            return "Added", text
+        if kind == "fix":
+            return "Fixed", text
+        return "Changed", text
+    if subject.startswith("Merge "):
+        return None, None
+    return "Changed", subject
+
+
+def entry(commit, cancelled_subjects):
+    """One rendered bullet, or None when this commit is not written up."""
+    subject = commit["subject"]
+
+    revert = REVERT.match(subject)
+    if revert:
+        target = revert.group("subject")
+        if target in cancelled_subjects:
+            return None, None
+        bucket, text = classify(target)
+        if bucket is None:
+            return None, None
+        return "Changed", f"reverted: {text}"
+
+    # The other half of a cancelled pair. A feature that was reverted inside the
+    # set being rendered never reaches a reader, so writing it up as shipped and
+    # then not mentioning its removal would be worse than saying nothing.
+    if subject in cancelled_subjects:
+        return None, None
+
+    bucket, text = classify(subject)
+    if bucket is None or text is None:
+        return None, None
+
+    # An issue the subject already names becomes a link in place; the rest are
+    # appended. Either way every issue number in the entry is clickable, and no
+    # number is printed twice.
+    named = set(ISSUE.findall(text))
+    text = ISSUE.sub(lambda m: f"[#{m.group(1)}]({REPO_URL}/issues/{m.group(1)})", text)
+    links = [
+        f"[#{n}]({REPO_URL}/issues/{n})" for n in closed_issues(commit["body"]) if n not in named
+    ]
+    if links:
+        text = f"{text} ({', '.join(links)})"
+    return bucket, text
+
+
+def reverted_subjects(all_commits):
+    """Subjects named by a `Revert "..."` commit anywhere in the rendered set."""
+    named = set()
+    present = {c["subject"] for c in all_commits}
+    for c in all_commits:
+        m = REVERT.match(c["subject"])
+        if m and m.group("subject") in present:
+            named.add(m.group("subject"))
+    return named
+
+
+def tag_date(ref):
+    out = git("for-each-ref", "--format=%(creatordate:short)", f"refs/tags/{ref}").strip()
+    return out or git("log", "-1", "--format=%cd", "--date=short", ref).strip()
+
+
+def notes_for(version, notes_dir):
+    if not notes_dir:
+        return ""
+    path = Path(notes_dir) / f"{version}.md"
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8").strip()
+
+
+def render(version, date, commit_list, cancelled, notes):
+    buckets = {name: [] for name in SECTIONS}
+    for c in commit_list:
+        bucket, text = entry(c, cancelled)
+        if bucket:
+            buckets[bucket].append(text)
+
+    out = [f"## {version} ({date})", ""]
+    if notes:
+        out += [notes, ""]
+    wrote = False
+    for name in SECTIONS:
+        if not buckets[name]:
+            continue
+        wrote = True
+        out.append(f"### {name}")
+        out.append("")
+        out += [f"- {t}" for t in buckets[name]]
+        out.append("")
+    if not wrote and not notes:
+        out += ["*No user-visible changes.*", ""]
+    return "\n".join(out)
+
+
+def cmd_section(args):
+    commit_list = commits(args.from_ref, args.to_ref)
+    date = args.date or tag_date(args.to_ref)
+    block = render(
+        args.version,
+        date,
+        commit_list,
+        reverted_subjects(commit_list),
+        notes_for(args.version, args.notes_dir),
+    )
+    if not args.prepend:
+        print(block)
+        return
+    path = Path(args.prepend)
+    existing = path.read_text(encoding="utf-8") if path.exists() else HEADER
+    head, sep, rest = existing.partition("\n## ")
+    body = f"{head.rstrip()}\n\n{block.rstrip()}\n{sep}{rest}" if sep else f"{head.rstrip()}\n\n{block.rstrip()}"
+    path.write_text(body.rstrip() + "\n", encoding="utf-8")
+    print(f"{path}: wrote the {args.version} section", file=sys.stderr)
+
+
+def cmd_file(args):
+    tags = args.tags
+    if len(tags) < 2:
+        sys.exit("file needs at least two tags: the one before the first entry, then each release")
+
+    ranges = list(zip(tags, tags[1:]))
+    every = [c for a, b in ranges for c in commits(a, b)]
+    cancelled = reverted_subjects(every)
+
+    blocks = []
+    for from_ref, to_ref in ranges:
+        version = to_ref.lstrip("v")
+        blocks.append(
+            render(
+                version,
+                args.date or tag_date(to_ref),
+                commits(from_ref, to_ref),
+                cancelled,
+                notes_for(version, args.notes_dir),
+            )
+        )
+    print(HEADER.rstrip() + "\n\n" + "\n".join(reversed(blocks)).rstrip() + "\n", end="")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--notes-dir", default=str(Path(__file__).parent / "changelog-notes"))
+    p.add_argument("--date", help="override the release date (default: the tag's own date)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("section", help="one release's block")
+    s.add_argument("from_ref")
+    s.add_argument("to_ref")
+    s.add_argument("version")
+    s.add_argument("--prepend", metavar="FILE", help="insert into FILE under its header")
+    s.set_defaults(func=cmd_section)
+
+    f = sub.add_parser("file", help="the whole file, from a list of consecutive tags")
+    f.add_argument("tags", nargs="+")
+    f.set_defaults(func=cmd_file)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What and why

The changelog on the docs site is stuck at 0.13.2 while thirteen releases have shipped, and every GitHub release body except 0.13.3-0.13.5 is the same 154-character install template. This adds `CHANGELOG.md` and the generator that will keep it current.

`scripts/changelog.py` sorts the commits between two release tags by their conventional subject: `feat` is Added, `fix` is Fixed with every issue its body closes linked, `chore(release)`, `test` and merges are dropped, everything else is Changed. A `Revert "..."` cancels the commit it names when both are rendered together, which is why 0.13.12 and 0.13.13 carry no entry -- the slack commands shipped and were withdrawn before anyone could rely on them.

The backfill is not hand-written. `changelog.py file <tags...>` produced all thirteen sections, and `changelog.py section <from> <to> <version> --prepend CHANGELOG.md` -- the exact call the release script will make next -- was verified to reproduce this file byte for byte. That is the point of doing it this way: a hand-typed backfill would have made the first generated entry look nothing like the entries above it, and nobody would have caught it until it shipped.

The release notes written for 0.13.3, 0.13.4 and 0.13.5 are recovered verbatim from their GitHub releases into `scripts/changelog-notes/` and lead those three sections.

First of four PRs for the docs auto-sync fork. Next: the release script writes the top section and `cargo test` refuses a release without one.

## Checklist

- [x] `cargo test` -- no Rust changed in this PR; CI runs the suite
- [x] The CLI did not change, so the coach needs no regeneration
- [ ] Not a bug fix, so no issue to close
