### PR TITLE
feat(release): write the changelog entry at release time, and refuse a release without one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,31 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
+
+      # Every release body but three was this install template and nothing else,
+      # so the tag was the only record of what changed. CHANGELOG.md now carries
+      # that record, and `cargo test` refuses a version that has no section, so
+      # this step cannot find nothing.
+      - name: Release notes for this tag
+        run: |
+          python3 scripts/changelog.py extract "${GITHUB_REF_NAME#v}" > release-notes.md
+          cat >> release-notes.md <<'FOOTER'
+
+          ---
+          ## Install
+
+          ```bash
+          npx chrisai
+          ```
+
+          Or download the binary for your platform below.
+
+          **Chris AI Systems** · https://www.skool.com/claude-code-titans-9203
+          FOOTER
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -101,13 +124,30 @@ jobs:
             base-windows-x86_64.zip/base-windows-x86_64.zip
             base-darwin-aarch64.tar.gz/base-darwin-aarch64.tar.gz
             base-darwin-x86_64.tar.gz/base-darwin-x86_64.tar.gz
-          body: |
-            ## Install
+          body_path: release-notes.md
 
-            ```bash
-            npx chrisai
-            ```
-
-            Or download the binary for your platform below.
-
-            **Chris AI Systems** · https://www.skool.com/claude-code-titans-9203
+  # Tell the docs site a release happened. It fetches the coach's reference files
+  # and this changelog at the tag and opens its own pull request; nothing is
+  # pushed from here. Skipped rather than failed when the token is absent, so a
+  # release never fails on the docs half.
+  notify-docs:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to basemode-docs
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+        run: |
+          # Tested in the shell rather than in an `if:` expression: the secrets
+          # context is not available to step conditions, and a skip that says why
+          # in the log beats one that silently evaluates to false.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "DOCS_DISPATCH_TOKEN is not set on this repository; the docs site will"
+            echo "pick this release up on its hourly poll instead. Skipping."
+            exit 0
+          fi
+          curl -sS --fail-with-body -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/ChristopherKahler/basemode-docs/dispatches \
+            -d "{\"event_type\":\"base-release\",\"client_payload\":{\"tag\":\"${GITHUB_REF_NAME}\",\"sha\":\"${GITHUB_SHA}\"}}"

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -9,6 +9,7 @@ it and nobody would have noticed until it shipped.
 
     scripts/changelog.py section v0.13.15 HEAD 0.13.16 [--date D] [--prepend F]
     scripts/changelog.py file v0.13.2 v0.13.3 ... v0.13.15 > CHANGELOG.md
+    scripts/changelog.py extract 0.13.16 > release-notes.md
 
 Classification of each commit subject, which is why the repo writes conventional
 subjects:
@@ -264,6 +265,22 @@ def cmd_file(args):
     print(HEADER.rstrip() + "\n\n" + "\n".join(reversed(blocks)).rstrip() + "\n", end="")
 
 
+def cmd_extract(args):
+    """The one section for a version, verbatim, for the GitHub release body."""
+    text = Path(args.file).read_text(encoding="utf-8")
+    want = f"## {args.version} "
+    lines = text.splitlines()
+    start = next((i for i, l in enumerate(lines) if l.startswith(want)), None)
+    if start is None:
+        sys.exit(
+            f"{args.file} has no section for {args.version}. "
+            "`cargo test` gates this on every release, so a tag that reaches here without one "
+            "was not cut by scripts/release.sh."
+        )
+    end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
+    print("\n".join(lines[start:end]).rstrip())
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--notes-dir", default=str(Path(__file__).parent / "changelog-notes"))
@@ -280,6 +297,11 @@ def main():
     f = sub.add_parser("file", help="the whole file, from a list of consecutive tags")
     f.add_argument("tags", nargs="+")
     f.set_defaults(func=cmd_file)
+
+    e = sub.add_parser("extract", help="print one version's existing section")
+    e.add_argument("version")
+    e.add_argument("--file", default="CHANGELOG.md")
+    e.set_defaults(func=cmd_extract)
 
     args = p.parse_args()
     args.func(args)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 # Cut a base release: bump, regenerate the base-help coach, test, commit, tag.
 #
-#   scripts/release.sh 0.13.15            bump + regen + full test suite + commit + tag
+#   scripts/release.sh 0.13.15            bump + regen + changelog + full suite + commit + tag
 #   scripts/release.sh 0.13.15 --push     ...then push main and the tag (CI builds the binaries)
 #   scripts/release.sh 0.13.15 --quick    gate on the help_docs tests only, skip the full suite
 #
 # Why a script: 0.13.13 shipped a Cargo.lock that cargo could not parse (a hand
-# bump), and twelve releases shipped a base-help coach stamped v0.13.2 because
-# nothing regenerated it. Every step here is one that was skipped at least once.
+# bump), twelve releases shipped a base-help coach stamped v0.13.2 because
+# nothing regenerated it, and thirteen shipped with no changelog entry at all.
+# Every step here is one that was skipped at least once.
 set -euo pipefail
 
-usage() { sed -n '2,10p' "$0"; exit 2; }
+usage() { sed -n '2,6p' "$0"; exit 2; }
 [ $# -ge 1 ] || usage
 NEW="$1"; shift
 PUSH=0; QUICK=0
@@ -51,6 +52,12 @@ fi
 echo "==> regenerate the base-help coach for $NEW"
 BASE_REGEN_DOCS=1 cargo test --quiet --bin base help_docs
 
+# The tag does not exist yet, so the range ends at HEAD and the date is today's
+# rather than the last commit's. src/help_docs.rs fails the suite below if this
+# step did not run, which is the whole reason it sits above the tests.
+echo "==> write the $NEW section of CHANGELOG.md"
+python3 scripts/changelog.py section "v$OLD" HEAD "$NEW" --date "$(date +%F)" --prepend CHANGELOG.md
+
 echo "==> test"
 if [ "$QUICK" = 1 ]; then
   cargo test --quiet --bin base help_docs
@@ -58,7 +65,7 @@ else
   cargo test --quiet
 fi
 
-git add Cargo.toml Cargo.lock README.md claude/skills/base-help
+git add Cargo.toml Cargo.lock README.md CHANGELOG.md claude/skills/base-help
 git commit --quiet -m "chore(release): $NEW"
 git tag -a "v$NEW" -m "v$NEW"
 echo "==> committed $(git rev-parse --short HEAD), tagged v$NEW"

--- a/src/help_docs.rs
+++ b/src/help_docs.rs
@@ -16,6 +16,10 @@
 //! 4. Every `base ...` invocation the skill shows a reader resolves against
 //!    this binary: the subcommand path exists (aliases included) and every flag
 //!    it names is real and sits on the right command.
+//! 5. `CHANGELOG.md` has a section for the version in `Cargo.toml`. That one is
+//!    about the release rather than the coach, and it lives here because this is
+//!    the file that already refuses to let a release ship out of step with
+//!    itself: thirteen releases went out with no changelog entry at all.
 //!
 //! 1 and 2 are generated: `BASE_REGEN_DOCS=1 cargo test --bin base help_docs`
 //! rewrites them, and `scripts/release.sh` does that on every release. 3 and 4
@@ -47,6 +51,8 @@ const README_MD: &str = "README.md";
 const QA_MD: &str = "references/qa.md";
 const COMMANDS_MD: &str = "references/commands.md";
 const CLI_MD: &str = "references/cli.md";
+/// Not part of the skill; it sits at the repository root.
+const CHANGELOG_MD: &str = "CHANGELOG.md";
 
 const COMMANDS_TITLE: &str = "# base command reference (v";
 const SKILL_COUNT_PHRASE: &str = " verified Q&A pairs";
@@ -73,6 +79,19 @@ fn write(rel: &str, text: &str) {
     std::fs::write(&tmp, text).unwrap_or_else(|e| panic!("cannot write {}: {e}", tmp.display()));
     std::fs::rename(&tmp, &path)
         .unwrap_or_else(|e| panic!("cannot replace {}: {e}", path.display()));
+}
+
+fn changelog() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(CHANGELOG_MD);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+        .replace("\r\n", "\n")
+}
+
+/// The version of the newest section, i.e. the first `## ` line in the file.
+fn newest_changelog_version(text: &str) -> Option<&str> {
+    let heading = text.lines().find(|l| l.starts_with("## "))?;
+    heading[3..].split_whitespace().next()
 }
 
 fn regen_requested() -> bool {
@@ -701,6 +720,22 @@ mod tests {
              `base doctor` reports exactly this drift on every machine that installs the release.\n{HOW_TO_REGEN}\n",
             wrong.join("\n  ")
         );
+    }
+
+    #[test]
+    fn changelog_has_a_section_for_this_version() {
+        let text = changelog();
+        match newest_changelog_version(&text) {
+            Some(v) if v == VERSION => {}
+            other => panic!(
+                "\n{CHANGELOG_MD} has no entry for v{VERSION}; its newest section is {other:?}.\n\
+                 A release with no changelog entry is one nobody can read afterwards, and thirteen\n\
+                 of them shipped that way before this check existed.\n\
+                 `scripts/release.sh` writes the section as part of cutting a release. To write it\n\
+                 by hand for the version already in Cargo.toml:\n\
+                 \x20 python3 scripts/changelog.py section v<previous> HEAD {VERSION} --prepend {CHANGELOG_MD}\n"
+            ),
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod cli;
 
-/// Test-only: keeps the base-help coach in step with this binary.
+/// Test-only: keeps the base-help coach, and CHANGELOG.md, in step with this binary.
 #[cfg(test)]
 mod help_docs;
 


### PR DESCRIPTION
## What and why

Thirteen releases shipped with no changelog entry, and every GitHub release body but three was 154 characters of install template. PR #17 added `CHANGELOG.md` and the generator. This makes the release write its own entry and refuses one that does not.

`scripts/release.sh` calls `changelog.py section "v$OLD" HEAD "$NEW" --prepend CHANGELOG.md` between regenerating the coach and running the suite. The range ends at `HEAD` rather than at the tag, because the tag does not exist yet.

A fifth check in `src/help_docs.rs` is what makes it stick: the newest `## ` version in `CHANGELOG.md` must equal `CARGO_PKG_VERSION`. It lives beside the four coach checks because that file is already the one that refuses to let a release ship out of step with itself, and its panic message names the command that fixes it. It is deliberately not regenerated by `BASE_REGEN_DOCS` -- a missing entry is a release-process failure, not drift to paper over.

The release workflow now publishes the real notes: `changelog.py extract` pulls the tag's section out of the file and passes it as `body_path`, with the install block appended underneath.

A `notify-docs` job tells `basemode-docs` that a release happened so the site can open its own PR against the tag. It prints why and exits 0 when `DOCS_DISPATCH_TOKEN` is absent rather than failing the release; the docs side also polls hourly, so a missed dispatch costs an hour rather than a sync.

## Proof

`cargo test --bin base help_docs` on this branch: 13 passed, 0 failed, including the new `changelog_has_a_section_for_this_version`.

The release-notes step was run locally with `GITHUB_REF_NAME=v0.13.15` and produced the 0.13.15 section followed by the install block.

Second of four PRs for the docs auto-sync fork.

## Checklist

- [x] `cargo test` is green locally (it includes the base-help coach gate)
- [x] The CLI did not change, so no regeneration was needed
- [ ] Not a bug fix, so no issue to close
