### PR TITLE
feat(triage): vet bug reports and label the release that fixed them

### DIFF
--- a/.github/workflows/notify-docs-issues.yml
+++ b/.github/workflows/notify-docs-issues.yml
@@ -1,0 +1,31 @@
+name: Tell the docs site an issue changed
+
+# The Known issues page is rendered from this tracker, so anything that changes
+# which issues are `bug` + `confirmed`, or which carry a `fixed-in:` label, has
+# to reach the docs repository. It polls daily as well, so a missed dispatch
+# costs a day rather than a stale page.
+
+on:
+  issues:
+    types: [opened, closed, reopened, labeled, unlabeled, edited, deleted]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to basemode-docs
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "DOCS_DISPATCH_TOKEN is not set; the docs site will pick this up on its"
+            echo "daily render instead. Skipping."
+            exit 0
+          fi
+          curl -sS --fail-with-body -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/ChristopherKahler/basemode-docs/dispatches \
+            -d '{"event_type":"base-issues"}'

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -1,0 +1,43 @@
+name: Triage a bug report
+
+# A bug report gets a reasoned comment and exactly one of `confirmed`,
+# `needs-info` or `not-a-bug`. The label is what matters: the docs site renders
+# its Known issues page from `bug` + `confirmed` issues, so this is what puts a
+# real bug in front of readers and keeps a misfiled one off the page.
+#
+# It never closes an issue, and it stops on `human-verdict`, which is how a
+# person freezes automation on a report.
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install --quiet anthropic
+
+      - name: Read the report against this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: python3 scripts/triage-issue.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,5 +117,3 @@ Windows installs older than 0.13.4: see the v0.13.4 notes for the one-time boots
 - **tier**: resolve --global directly instead of walking up into the workspace tier
 - **sync**: let a first pull create graph.nq instead of refusing
 - **plugin**: resolve manifest paths to one shape on Windows and unix
-- **tests**: stop workspace resolution walking out of the sandbox
-- **tests**: isolate cargo test from the real global graph

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -18,7 +18,7 @@ subjects:
     fix(scope): ...         Fixed, with every issue its body closes linked
     Revert "<subject>"      dropped, together with the commit it names
     chore(release): ...     dropped
-    test(...): ...          dropped
+    test(...), fix(tests)   dropped -- nothing a reader can act on
     Merge ...               dropped
     anything else           Changed
 
@@ -119,7 +119,10 @@ def classify(subject):
     m = CONVENTIONAL.match(subject)
     if m:
         kind, scope, rest = m.group("type"), m.group("scope"), m.group("rest")
-        if kind == "test":
+        # Test work is dropped by type and by scope. `fix(tests): isolate cargo
+        # test from the real global graph` is a real fix and belongs in the
+        # history, but there is nothing a reader of a changelog can do with it.
+        if kind == "test" or scope in ("test", "tests"):
             return None, None
         if kind == "chore" and scope == "release":
             return None, None

--- a/scripts/label-fixed-in.py
+++ b/scripts/label-fixed-in.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Label every issue closed since the previous release `fixed-in:<version>`.
+
+That label, not the close, is what flips an entry on the docs site's Known
+issues page from "Still live" to "Fixed in <version>". A close can mean the
+report was a duplicate, or wrong, or went stale; the label means one thing.
+
+Run by `scripts/release.sh` after the tag is pushed.
+
+    scripts/label-fixed-in.py 0.13.16
+    scripts/label-fixed-in.py 0.13.16 --dry-run
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "ChristopherKahler/base")
+
+
+def token():
+    if os.environ.get("GH_TOKEN"):
+        return os.environ["GH_TOKEN"]
+    out = subprocess.run(
+        ["git", "credential", "fill"],
+        input="protocol=https\nhost=github.com\n\n",
+        capture_output=True,
+        text=True,
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "HOME": os.environ.get("HOME", "")},
+        timeout=30,
+    ).stdout
+    for line in out.splitlines():
+        if line.startswith("password="):
+            return line[len("password=") :]
+    sys.exit("no GitHub credential: set GH_TOKEN, or configure a git credential helper")
+
+
+def gh(path, method="GET", payload=None):
+    req = urllib.request.Request(
+        "https://api.github.com" + path,
+        method=method,
+        data=json.dumps(payload).encode() if payload is not None else None,
+        headers={
+            "Authorization": f"Bearer {token()}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        if method == "POST" and e.code == 422:
+            return {}  # the label already exists
+        sys.exit(f"github said {e.code} for {method} {path}: {e.read().decode()[:300]}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("version")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    label = f"fixed-in:{args.version}"
+
+    releases = gh(f"/repos/{REPO}/releases?per_page=100")
+    published = sorted(r["published_at"] for r in releases if r.get("published_at"))
+    if not published:
+        print("no published releases to measure against; nothing to label")
+        return 0
+    since = published[-1]
+
+    closed = gh(f"/repos/{REPO}/issues?state=closed&since={since}&per_page=100")
+    targets = [
+        i
+        for i in closed
+        if "pull_request" not in i
+        and i.get("closed_at")
+        and i["closed_at"] > since
+        and not any(l["name"].startswith("fixed-in:") for l in i["labels"])
+    ]
+
+    print(f"{label}: {len(targets)} issue(s) closed since {since}")
+    for i in targets:
+        print(f"  #{i['number']} {i['title'][:60]}")
+    if not targets:
+        return 0
+    if args.dry_run:
+        print("--dry-run: nothing labelled")
+        return 0
+
+    gh(
+        f"/repos/{REPO}/labels",
+        "POST",
+        {"name": label, "color": "0E8A16", "description": f"Closed and shipped in {args.version}"},
+    )
+    for i in targets:
+        gh(f"/repos/{REPO}/issues/{i['number']}/labels", "POST", {"labels": [label]})
+    print(f"labelled {len(targets)} issue(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -72,6 +72,12 @@ echo "==> committed $(git rev-parse --short HEAD), tagged v$NEW"
 if [ "$PUSH" = 1 ]; then
   git push origin main "v$NEW"
   echo "==> pushed; the Release workflow builds the binaries and base update picks them up"
+  # `fixed-in:<version>`, not the close, is what flips an entry on the docs
+  # site's Known issues page. Never fatal: the release is already out, and this
+  # can be re-run by hand.
+  echo "==> label issues closed since the previous release"
+  python3 scripts/label-fixed-in.py "$NEW" || echo "    (labelling failed; re-run: scripts/label-fixed-in.py $NEW)"
 else
   echo "push with: git push origin main v$NEW"
+  echo "then label the issues it fixed: scripts/label-fixed-in.py $NEW"
 fi

--- a/scripts/triage-issue.py
+++ b/scripts/triage-issue.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Read a bug report, check it against this tree, and label it.
+
+Applies exactly one of `confirmed`, `needs-info` or `not-a-bug`, and posts one
+comment saying how it got there. It never closes an issue, and it stops
+immediately on an issue carrying `human-verdict`, which is how a person freezes
+automation on a report.
+
+The label is the whole point: the docs site renders its Known issues page from
+`bug` + `confirmed` issues, so this is what puts a real bug in front of readers
+and keeps a misfiled one off the page.
+
+    ISSUE_NUMBER=42 GITHUB_REPOSITORY=owner/repo scripts/triage-issue.py
+    scripts/triage-issue.py --issue 42 --dry-run
+
+Credentials, in order: ANTHROPIC_API_KEY, else CLAUDE_CODE_OAUTH_TOKEN (a
+subscription token, passed as ANTHROPIC_AUTH_TOKEN with the oauth beta header).
+With neither, it exits nonzero and says so rather than labelling nothing.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import anthropic
+
+MODEL = "claude-opus-5"
+REPO = os.environ.get("GITHUB_REPOSITORY", "ChristopherKahler/base")
+ROOT = Path(__file__).resolve().parent.parent
+BANK = ROOT / "claude" / "skills" / "base-help" / "references"
+
+VERDICTS = ("confirmed", "needs-info", "not-a-bug")
+FROZEN = "human-verdict"
+
+SYSTEM = """You triage bug reports for base, a Rust CLI that injects context into coding-agent \
+sessions from a local knowledge graph.
+
+You are given a report and the release's own command reference, which is generated from the \
+binary and is therefore exact about what commands and flags exist.
+
+Reach one of three verdicts.
+
+confirmed - the report describes real behaviour that base should not have. You could point at \
+the surface it concerns and the described behaviour is consistent with it. A design choice that \
+surprises people is still confirmed; say so in your reasoning.
+
+needs-info - you cannot tell from what was written. A missing version, no way to reproduce, or a \
+description that could be several different problems. Say exactly what would settle it.
+
+not-a-bug - the command or flag does not exist, the behaviour is documented and intended, or the \
+report is about something outside base.
+
+Judge only what the report says against what the reference shows. You cannot run anything. When \
+the reference does not settle it, that is usually needs-info rather than a guess.
+
+Write for the person who filed it. Plain sentences, no headings, no bullet lists, under 150 \
+words. Say what you checked and what you concluded. Never claim to have reproduced anything."""
+
+TOOL = {
+    "name": "record_verdict",
+    "description": "Record the triage verdict and the reasoning to post as a comment.",
+    "strict": True,
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "verdict": {"type": "string", "enum": list(VERDICTS)},
+            "reasoning": {"type": "string", "description": "The comment to post. Plain sentences."},
+        },
+        "required": ["verdict", "reasoning"],
+        "additionalProperties": False,
+    },
+}
+
+
+def gh(path, method="GET", payload=None):
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        sys.exit("no GH_TOKEN in the environment")
+    req = urllib.request.Request(
+        "https://api.github.com" + path,
+        method=method,
+        data=json.dumps(payload).encode() if payload is not None else None,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        sys.exit(f"github said {e.code} for {method} {path}: {e.read().decode()[:300]}")
+
+
+def client():
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return anthropic.Anthropic()
+    oauth = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+    if oauth:
+        # A Claude Code subscription token authenticates as a bearer token and
+        # needs the oauth beta header. Produced by `claude setup-token`.
+        os.environ["ANTHROPIC_AUTH_TOKEN"] = oauth
+        return anthropic.Anthropic(default_headers={"anthropic-beta": "oauth-2025-04-20"})
+    sys.exit(
+        "no Anthropic credential. Set ANTHROPIC_API_KEY, or CLAUDE_CODE_OAUTH_TOKEN from "
+        "`claude setup-token`, in this repository's Actions secrets. Triage does nothing until "
+        "one exists; it will not label an issue it has not read."
+    )
+
+
+def reference():
+    """The generated command reference for this tree, which is what makes a
+    verdict about whether a command exists checkable rather than recalled."""
+    cli = BANK / "cli.md"
+    if not cli.is_file():
+        sys.exit(f"no command reference at {cli}; run this from a checkout of the repository")
+    text = cli.read_text(encoding="utf-8")
+    version = subprocess.run(
+        ["sed", "-n", "s/^version = \"\\(.*\\)\"/\\1/p", str(ROOT / "Cargo.toml")],
+        capture_output=True,
+        text=True,
+    ).stdout.split("\n")[0]
+    return version, text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--issue", type=int, default=int(os.environ.get("ISSUE_NUMBER", 0)))
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    if not args.issue:
+        sys.exit("no issue number: pass --issue or set ISSUE_NUMBER")
+
+    issue = gh(f"/repos/{REPO}/issues/{args.issue}")
+    labels = {l["name"] for l in issue["labels"]}
+    if FROZEN in labels:
+        print(f"#{args.issue} carries `{FROZEN}`; a person has ruled on it. Nothing to do.")
+        return 0
+    if "bug" not in labels:
+        print(f"#{args.issue} is not labelled `bug`. Nothing to do.")
+        return 0
+
+    version, cli_md = reference()
+    prompt = (
+        f"base {version}\n\n"
+        f"## The report\n\n### {issue['title']}\n\n{issue.get('body') or '(no body)'}\n\n"
+        f"## The command reference for this release\n\n{cli_md}\n\n"
+        "Reach a verdict and record it with the record_verdict tool."
+    )
+
+    message = client().messages.create(
+        model=MODEL,
+        max_tokens=8000,
+        thinking={"type": "adaptive"},
+        system=SYSTEM,
+        tools=[TOOL],
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    call = next((b for b in message.content if b.type == "tool_use"), None)
+    if call is None:
+        said = " ".join(b.text for b in message.content if b.type == "text")
+        sys.exit(f"no verdict recorded (stop_reason={message.stop_reason}). It said: {said[:400]}")
+    verdict = call.input["verdict"]
+    reasoning = call.input["reasoning"]
+
+    print(f"#{args.issue}: {verdict}\n\n{reasoning}\n")
+    if args.dry_run:
+        print("--dry-run: nothing posted")
+        return 0
+
+    gh(
+        f"/repos/{REPO}/issues/{args.issue}/comments",
+        "POST",
+        {"body": f"{reasoning}\n\n<sub>Triaged automatically against base {version}. "
+                 f"A maintainer can overrule this by applying the `{FROZEN}` label.</sub>"},
+    )
+    # Exactly one verdict label: drop the other two before adding this one, so a
+    # re-triage after an edit does not leave two contradicting labels.
+    for stale in (v for v in VERDICTS if v != verdict and v in labels):
+        gh(f"/repos/{REPO}/issues/{args.issue}/labels/{stale}", "DELETE")
+    gh(f"/repos/{REPO}/issues/{args.issue}/labels", "POST", {"labels": [verdict]})
+    print("comment posted, label applied")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What and why

Two halves of the same loop, plus the changelog correction from review.

**Vetting.** `scripts/triage-issue.py` reads a `bug` issue against this release's generated command reference and applies exactly one of `confirmed`, `needs-info` or `not-a-bug`, with one comment saying how it got there. The label is the point: the docs site renders its Known issues page from `bug` + `confirmed` issues, so this is what puts a real bug in front of readers and keeps a misfiled one off the page. It never closes an issue, and it stops on `human-verdict`, which is how a person freezes automation on a report. A re-triage after an edit removes the other two verdict labels first, so an issue never carries two contradicting ones.

**Fix landing.** `scripts/label-fixed-in.py` labels every issue closed since the previous release `fixed-in:<version>`, and `scripts/release.sh --push` calls it after the tag. That label, not the close, is what flips a page entry to "Fixed in <version>" -- a close can mean duplicate, or wrong, or stale, and the label means one thing. It is never fatal to a release; by that point the release is already out, and the script can be re-run by hand.

`notify-docs-issues.yml` tells the docs repository an issue changed, so the page follows within a minute rather than waiting for its daily render.

**Changelog correction.** `fix(tests): ...` commits no longer reach the changelog. They are real fixes and belong in the history, but a reader cannot act on test isolation. `CHANGELOG.md` was regenerated through the generator rather than edited, so the backfill and the release path stay byte-identical -- verified by re-running `changelog.py file` and diffing.

## Credentials

`ANTHROPIC_API_KEY`, else `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`. **Neither is set on this repository yet** -- that is the one human step in this whole piece of work and it has been escalated. Until one exists, the triage workflow exits nonzero naming exactly what to set. It will not label an issue it has not read, and nothing else here depends on it.

## Proof

| | |
|---|---|
| an issue not labelled `bug` | skipped -- run against #15: "not labelled `bug`. Nothing to do." exit 0 |
| a `bug` issue with no credential | exits 1 naming the two secrets, labels nothing |
| the request shape | sent through the real `anthropic` SDK (1.3.0) at a dead port: it accepts the model, adaptive thinking, system, the `strict` tool and messages, and reaches the wire |
| `label-fixed-in.py --dry-run` | correct -- 0 issues closed since v0.13.15 |
| changelog regeneration | no `**tests**` entries remain; `changelog.py file` is byte-for-byte reproducible |
| `release.sh` | `bash -n` clean |

Last of four PRs for the docs auto-sync fork.

## Checklist

- [x] `cargo test` -- no Rust changed in this PR; CI runs the suite
- [x] The CLI did not change, so the coach needs no regeneration
- [ ] Not a bug fix, so no issue to close
