### PR TITLE
fix(changelog): accept --date and --notes-dir after the subcommand

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -285,19 +285,30 @@ def cmd_extract(args):
 
 
 def main():
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--notes-dir", default=str(Path(__file__).parent / "changelog-notes"))
-    p.add_argument("--date", help="override the release date (default: the tag's own date)")
+    # `--notes-dir` and `--date` belong to the subcommands that render a section,
+    # not to the program. Declared on the parent parser alone, argparse only
+    # accepts them *before* the subcommand, which is not where anyone writes
+    # them: `release.sh` put `--date` at the end of its line and the release
+    # aborted on an unrecognized argument.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--notes-dir", default=str(Path(__file__).parent / "changelog-notes"))
+    common.add_argument("--date", help="override the release date (default: the tag's own date)")
+
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        parents=[common],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    s = sub.add_parser("section", help="one release's block")
+    s = sub.add_parser("section", parents=[common], help="one release's block")
     s.add_argument("from_ref")
     s.add_argument("to_ref")
     s.add_argument("version")
     s.add_argument("--prepend", metavar="FILE", help="insert into FILE under its header")
     s.set_defaults(func=cmd_section)
 
-    f = sub.add_parser("file", help="the whole file, from a list of consecutive tags")
+    f = sub.add_parser("file", parents=[common], help="the whole file, from a list of consecutive tags")
     f.add_argument("tags", nargs="+")
     f.set_defaults(func=cmd_file)
 


### PR DESCRIPTION
## What and why

`scripts/release.sh` ends its changelog line with `--date "$(date +%F)"`, but `--date` and `--notes-dir` were declared on the parent parser only. argparse then accepts them exclusively *before* the subcommand, and the real invocation answered:

```
changelog.py: error: unrecognized arguments: --date 2026-09-03
```

Under `set -euo pipefail` that aborts the release at the changelog step -- after the version bump, after the coach regeneration, before the tag. The first release cut with #23 in place would have died there.

Both flags now sit on a shared parent parser that the `section` and `file` subparsers inherit, so either position works.

## How it was found, and the gap it exposes

By running the exact line `release.sh` runs, before cutting a release rather than after. #23's proofs covered the section content, `--prepend`, and byte-for-byte reproducibility, but never the specific argv `release.sh` assembles -- and that was the one part with the bug.

Swept the other argparse scripts across both repositories for the same shape. `changelog.py` is the only one with subparsers, so the only one that could have it.

## Proof

- `changelog.py section v0.13.15 HEAD 0.13.16 --date 2026-09-03` -- the exact release.sh form, now renders the section.
- `changelog.py --date 2026-01-01 section ...` -- the old position still works.
- `changelog.py file <13 tags>` still reproduces the committed `CHANGELOG.md` byte for byte.
