### PR TITLE
test(release): run the command lines the release assembles, with the argv it assembles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
       - name: cargo test
         run: cargo test
 
+  # Every changelog.py command line the release assembles, run with the argv it
+  # assembles. 0.13.16 nearly died on one that every other test had missed.
+  release-invocations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: ./scripts/test-release-invocations.sh
+
   # Advisory until the three pre-existing never_loop denies in src/crud are
   # cleared; then drop continue-on-error and it becomes a required check.
   clippy:

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -285,19 +285,30 @@ def cmd_extract(args):
 
 
 def main():
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--notes-dir", default=str(Path(__file__).parent / "changelog-notes"))
-    p.add_argument("--date", help="override the release date (default: the tag's own date)")
+    # `--notes-dir` and `--date` belong to the subcommands that render a section,
+    # not to the program. Declared on the parent parser alone, argparse only
+    # accepts them *before* the subcommand, which is not where anyone writes
+    # them: `release.sh` put `--date` at the end of its line and the release
+    # aborted on an unrecognized argument.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--notes-dir", default=str(Path(__file__).parent / "changelog-notes"))
+    common.add_argument("--date", help="override the release date (default: the tag's own date)")
+
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        parents=[common],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    s = sub.add_parser("section", help="one release's block")
+    s = sub.add_parser("section", parents=[common], help="one release's block")
     s.add_argument("from_ref")
     s.add_argument("to_ref")
     s.add_argument("version")
     s.add_argument("--prepend", metavar="FILE", help="insert into FILE under its header")
     s.set_defaults(func=cmd_section)
 
-    f = sub.add_parser("file", help="the whole file, from a list of consecutive tags")
+    f = sub.add_parser("file", parents=[common], help="the whole file, from a list of consecutive tags")
     f.add_argument("tags", nargs="+")
     f.set_defaults(func=cmd_file)
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,6 +39,15 @@ if git rev-parse -q --verify "refs/tags/v$NEW" >/dev/null; then
   echo "tag v$NEW already exists"; exit 2
 fi
 
+# Cheap, and it runs the exact line below against a scratch copy first. A broken
+# invocation then stops the release before the version bump instead of after it.
+echo "==> check the release's own command lines"
+./scripts/test-release-invocations.sh > /dev/null || {
+  echo "a command line this script assembles does not run; details:"
+  ./scripts/test-release-invocations.sh
+  exit 1
+}
+
 echo "==> $OLD -> $NEW"
 # The [package] version is the first `version = ` line in Cargo.toml.
 sed -i "0,/^version = \"$OLD\"/s//version = \"$NEW\"/" Cargo.toml

--- a/scripts/test-release-invocations.sh
+++ b/scripts/test-release-invocations.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Run every `changelog.py` command line the release pipeline assembles, with the
+# argv it actually assembles, against a scratch copy of CHANGELOG.md.
+#
+# This exists because 0.13.16 nearly died on one: `release.sh` ends its line with
+# `--date "$(date +%F)"`, and `--date` was declared on the parent parser only, so
+# argparse rejected it after the subcommand. Every part of the generator had been
+# proven -- the section content, `--prepend`, byte-for-byte reproducibility --
+# except the one thing the release would actually type. Under `set -e` that
+# aborts a release after the version bump and before the tag.
+#
+# The lines are read out of `scripts/release.sh` and `.github/workflows/release.yml`
+# rather than copied here, so editing either one is covered by this.
+#
+#   ./scripts/test-release-invocations.sh
+#
+# Exit 0 = every invocation the release makes runs. Exit 1 = one of them does not.
+
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+TMP="$(mktemp -d)"
+cp CHANGELOG.md "$TMP/CHANGELOG.orig"
+# Restore on any exit: these invocations write to the real CHANGELOG.md, because
+# writing to the real path is the point of the test.
+trap 'cp "$TMP/CHANGELOG.orig" CHANGELOG.md; rm -rf "$TMP"' EXIT
+
+fail=0
+say() { printf '%s\n' "$*"; }
+bad() { printf '  FAIL  %s\n' "$*"; fail=$((fail + 1)); }
+ok()  { printf '  ok    %s\n' "$*"; }
+
+# The values release.sh has in scope when it runs its line.
+OLD="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+NEW="99.99.99"
+export OLD NEW
+
+say "Release invocations, against base $OLD"
+say ""
+
+# ── scripts/release.sh ──────────────────────────────────────────────────────
+say "scripts/release.sh"
+found=0
+while IFS= read -r line; do
+  case "$(printf '%s' "$line" | sed 's/^[[:space:]]*//')" in \#*) continue ;; esac
+  found=$((found + 1))
+  say "  \$ $line"
+  if eval "$line" >/dev/null 2>"$TMP/err"; then
+    ok "ran"
+  else
+    bad "$(head -3 "$TMP/err")"
+  fi
+done < <(grep 'scripts/changelog\.py' scripts/release.sh)
+[ "$found" -gt 0 ] || bad "no changelog.py invocation found in scripts/release.sh -- did it move?"
+
+# The point of release.sh's call is that the new version's section lands.
+if grep -q "^## $NEW " CHANGELOG.md; then
+  ok "the $NEW section was written into CHANGELOG.md"
+else
+  bad "no '## $NEW' section in CHANGELOG.md after release.sh's line ran"
+fi
+cp "$TMP/CHANGELOG.orig" CHANGELOG.md
+say ""
+
+# ── .github/workflows/release.yml ───────────────────────────────────────────
+# The release body is extracted from CHANGELOG.md by tag name; GITHUB_REF_NAME
+# is what the workflow has, so that is what this gives it.
+say ".github/workflows/release.yml"
+GITHUB_REF_NAME="v$OLD"
+export GITHUB_REF_NAME
+found=0
+while IFS= read -r line; do
+  line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//; s/ > release-notes\.md$//')"
+  case "$line" in \#*) continue ;; esac
+  found=$((found + 1))
+  say "  \$ $line"
+  if eval "$line" >/dev/null 2>"$TMP/err"; then
+    ok "ran"
+  else
+    bad "$(head -3 "$TMP/err")"
+  fi
+done < <(grep 'scripts/changelog\.py' .github/workflows/release.yml)
+[ "$found" -gt 0 ] || bad "no changelog.py invocation found in release.yml -- did it move?"
+
+say ""
+if [ "$fail" -eq 0 ]; then
+  say "PASS -- every command line the release assembles runs."
+  exit 0
+fi
+say "FAIL -- $fail invocation(s) above. A release would abort on these."
+exit 1


### PR DESCRIPTION
## What and why

#25 fixed a flag placement bug that would have aborted the first real release. This makes that class of bug impossible to ship again.

Every part of the changelog generator had a proof -- the section content, `--prepend`, byte-for-byte reproducibility between the backfill and the release path -- and **none of them ran the argv `release.sh` actually types**. That line ends in `--date "$(date +%F)"`, argparse rejected the flag after the subcommand, and under `set -e` a release would have aborted after the version bump and before the tag.

`scripts/test-release-invocations.sh` reads the `changelog.py` lines out of `scripts/release.sh` and `.github/workflows/release.yml`, runs each with the values those files have in scope, and asserts both that they run and that release.sh's line actually writes the new version's section. The lines are **read, not copied**, so editing either file stays covered.

Two places it runs:

- Its own CI job, so a failure names itself in the checks list rather than hiding inside `test`.
- `release.sh`, before the version bump -- so a broken invocation stops a release instead of half-finishing one and leaving `Cargo.toml` bumped.

## Proof

Reintroduced the bug (moved `--date` back to the parent parser only) and re-ran:

```
scripts/release.sh
  $ python3 scripts/changelog.py section "v$OLD" HEAD "$NEW" --date "$(date +%F)" --prepend CHANGELOG.md
  FAIL  changelog.py: error: unrecognized arguments: --date 2026-09-03
  FAIL  no '## 99.99.99' section in CHANGELOG.md after release.sh's line ran

FAIL -- 2 invocation(s) above. A release would abort on these.
```

Restored the fix and it passes. The working tree is left clean either way -- the test writes the real `CHANGELOG.md`, because writing to the real path is the point, and restores it from a copy in a trap on any exit.

## Checklist

- [x] `cargo test` -- no Rust changed; CI runs the suite
- [x] The CLI did not change, so the coach needs no regeneration
- [ ] Not a bug fix in the shipped binary, so no issue to close
