### PR TITLE
fix(release): write the changelog before regenerating the coach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        # `release.sh` reads `v$OLD..HEAD`, so the rehearsal below needs tags.
+        with:
+          fetch-depth: 0
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: cargo test
         run: cargo test
+      # Cut a whole release in a throwaway clone. It runs here rather than in a
+      # job of its own because it reuses this one's target directory and cargo
+      # registry; on its own it would pay for both again. 0.13.16's first
+      # attempt died on a step order every other test passed.
+      - name: release rehearsal
+        run: ./scripts/test-release-rehearsal.sh
 
   # Every changelog.py command line the release assembles, run with the argv it
   # assembles. 0.13.16 nearly died on one that every other test had missed.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -58,14 +58,18 @@ if ! grep -A1 '^name = "base"$' Cargo.lock | grep -q "version = \"$NEW\""; then
   echo "Cargo.lock did not pick up $NEW"; exit 1
 fi
 
-echo "==> regenerate the base-help coach for $NEW"
-BASE_REGEN_DOCS=1 cargo test --quiet --bin base help_docs
-
 # The tag does not exist yet, so the range ends at HEAD and the date is today's
-# rather than the last commit's. src/help_docs.rs fails the suite below if this
-# step did not run, which is the whole reason it sits above the tests.
+# rather than the last commit's. This has to precede the regeneration below, not
+# merely the suite: `changelog_has_a_section_for_this_version` is one of the
+# help_docs tests, and it is the single check BASE_REGEN_DOCS deliberately
+# cannot write its way out of. Regenerating first fails on it and aborts the
+# release after the version bump and before the tag, which is exactly how
+# 0.13.16's first attempt died.
 echo "==> write the $NEW section of CHANGELOG.md"
 python3 scripts/changelog.py section "v$OLD" HEAD "$NEW" --date "$(date +%F)" --prepend CHANGELOG.md
+
+echo "==> regenerate the base-help coach for $NEW"
+BASE_REGEN_DOCS=1 cargo test --quiet --bin base help_docs
 
 echo "==> test"
 if [ "$QUICK" = 1 ]; then

--- a/scripts/test-release-rehearsal.sh
+++ b/scripts/test-release-rehearsal.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Cut a whole release, for real, in a throwaway clone -- then throw it away.
+#
+# `test-release-invocations.sh` runs the command lines the release assembles.
+# This runs `release.sh` itself, in the order it runs them, and that distinction
+# is not academic. 0.13.16's first attempt died with every individual step
+# working: the coach regeneration ran before the changelog was written, and
+# `changelog_has_a_section_for_this_version` is one of the help_docs tests that
+# regeneration deliberately cannot write its way out of. Under `set -e` the
+# release aborted after the version bump and before the tag, leaving a bumped
+# working tree and no release. Nothing tested the sequence, only the steps.
+#
+#   ./scripts/test-release-rehearsal.sh
+#
+# Nothing here touches this repository or the remote: the rehearsal clones the
+# current commit into a temporary directory, runs `release.sh` there without
+# `--push`, at a version no real release will ever use, and deletes it.
+#
+# Exit 0 = a release cut from this commit reaches its commit and its tag.
+# Exit 1 = it does not, and the message says which step it died on.
+
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+VERSION="99.99.99"
+TAG="v$VERSION"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+CLONE="$TMP/base"
+
+fail=0
+say() { printf '%s\n' "$*"; }
+bad() { printf '  FAIL  %s\n' "$*"; fail=$((fail + 1)); }
+ok()  { printf '  ok    %s\n' "$*"; }
+
+HEAD_SHA="$(git rev-parse HEAD)"
+OLD="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+
+say "Release rehearsal: $OLD -> $VERSION, from $(git rev-parse --short HEAD)"
+say ""
+
+# --no-hardlinks so a rehearsal that somehow writes into .git cannot reach the
+# real object store. Tags come along, which `release.sh` needs for `v$OLD..HEAD`.
+if ! git clone --quiet --no-hardlinks "$ROOT" "$CLONE" 2>"$TMP/err"; then
+  bad "could not clone the repository: $(head -3 "$TMP/err")"
+  say ""
+  say "FAIL -- the rehearsal could not start."
+  exit 1
+fi
+
+# `release.sh` refuses to run off main, and CI checks out a detached HEAD.
+git -C "$CLONE" checkout -q -B main "$HEAD_SHA"
+
+# One compile, not two: the rehearsal shares whatever target directory the
+# caller is already using, so in CI it reuses the suite's and locally it reuses
+# this checkout's.
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/target}"
+
+# --quick gates on the help_docs tests rather than the full suite. The step that
+# broke -- the regeneration -- runs either way, and the suite has already run by
+# the time anything calls this.
+say "  \$ ./scripts/release.sh $VERSION --quick"
+if (cd "$CLONE" && ./scripts/release.sh "$VERSION" --quick) >"$TMP/out" 2>&1; then
+  ok "ran to completion"
+else
+  bad "release.sh exited $?; its last lines:"
+  sed 's/^/        /' "$TMP/out" | tail -20
+fi
+
+# Reaching the tag is the claim. A release that bumps the version and dies is
+# worse than one that never started, because the tree is left half-released.
+if [ -n "$(git -C "$CLONE" tag -l "$TAG")" ]; then
+  ok "tagged $TAG"
+else
+  bad "no $TAG tag -- the release did not reach its last step"
+fi
+
+subject="$(git -C "$CLONE" log -1 --format=%s 2>/dev/null)"
+if [ "$subject" = "chore(release): $VERSION" ]; then
+  ok "committed \"$subject\""
+else
+  bad "top commit is \"$subject\", expected \"chore(release): $VERSION\""
+fi
+
+if head -20 "$CLONE/CHANGELOG.md" 2>/dev/null | grep -q "^## $VERSION "; then
+  ok "CHANGELOG.md opens on the $VERSION section"
+else
+  bad "no '## $VERSION' section at the top of CHANGELOG.md"
+fi
+
+# `release.sh` names the paths it stages. Anything it modifies and does not name
+# is left behind uncommitted, and ships in whatever the next commit sweeps up.
+dirty="$(git -C "$CLONE" status --porcelain)"
+if [ -z "$dirty" ]; then
+  ok "the release committed everything it touched"
+else
+  bad "files modified by the release but not staged by it:"
+  printf '%s\n' "$dirty" | sed 's/^/        /'
+fi
+
+say ""
+if [ "$fail" -eq 0 ]; then
+  say "PASS -- a release cut from this commit reaches its commit and its tag."
+  exit 0
+fi
+say "FAIL -- $fail check(s) above. Cutting a real release would break the same way."
+exit 1

--- a/scripts/test-release-rehearsal.sh
+++ b/scripts/test-release-rehearsal.sh
@@ -54,6 +54,13 @@ fi
 # `release.sh` refuses to run off main, and CI checks out a detached HEAD.
 git -C "$CLONE" checkout -q -B main "$HEAD_SHA"
 
+# `release.sh` commits, and a CI runner has no git identity, so the commit dies
+# with "Author identity unknown" after the version bump -- the same half-released
+# shape this test exists to catch, from the environment rather than the script.
+# Set here rather than globally: it reaches only this temporary clone.
+git -C "$CLONE" config user.name "release rehearsal"
+git -C "$CLONE" config user.email "rehearsal@invalid"
+
 # One compile, not two: the rehearsal shares whatever target directory the
 # caller is already using, so in CI it reuses the suite's and locally it reuses
 # this checkout's.


### PR DESCRIPTION
Cutting 0.13.16 aborted after the version bump and before the tag. Every step worked; the sequence did not.

`release.sh` regenerated the base-help coach before writing the changelog section. `changelog_has_a_section_for_this_version` is one of the `help_docs` tests that regeneration runs, and it is the single check `BASE_REGEN_DOCS` deliberately cannot write its way out of — a missing entry is a release-process failure rather than drift to paper over. So the regeneration failed on the one thing it could not fix, and `set -e` left a bumped working tree and no release.

The changelog write has no dependency on the regeneration, so it moves above it. Both still precede the suite, which is what enforces them.

### Why the existing test could not catch it

`test-release-invocations.sh` runs the command lines the release assembles, one at a time, and each of them runs. The defect is in the order.

`scripts/test-release-rehearsal.sh` runs `release.sh` itself, in a throwaway clone at 99.99.99, and asserts it reaches its commit and its tag. It also asserts the release staged every file it modified — a file the release writes but does not `git add` is left behind for whatever the next commit sweeps up. It runs inside the existing `test` job so it reuses that job's target directory and cargo registry rather than paying for both again; the job's checkout gains `fetch-depth: 0` because `release.sh` reads `v$OLD..HEAD`.

This is the same lesson as #26, one level up: that test proved the argv a release types, this one proves the order it types them in.

### Verification

The failure was reproduced by the real thing, not a reconstruction: `scripts/release.sh 0.13.16 --push` on a fresh clone of `main` at `b1a067f`, which died exactly as described and pushed nothing. This branch is that fix. The rehearsal's first run is this PR's CI.

Closes #27