### PR TITLE
fix(rule): compare rule numbers as integers, not text

### DIFF
--- a/src/crud/rule.rs
+++ b/src/crud/rule.rs
@@ -145,7 +145,8 @@ pub fn remove(cwd: &Path, ns: &NamespaceConfig, domain_name: &str, index: u32) -
 fn next_rule_index(cwd: &Path, ns: &NamespaceConfig, domain_iri: &str) -> Result<u32> {
     let p = &ns.prefix;
     let sparql = format!(
-        "SELECT (MAX(?idx) AS ?max_idx) WHERE {{\n\
+        "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n\
+         SELECT (MAX(xsd:integer(?idx)) AS ?max_idx) WHERE {{\n\
            GRAPH ?g {{\n\
              <{domain_iri}> {p}:hasRule ?rule .\n\
              ?rule {p}:index ?idx .\n\

--- a/src/domain/query.rs
+++ b/src/domain/query.rs
@@ -31,7 +31,7 @@ pub fn query_domain_from_graph(
              OPTIONAL {{ ?rule {p}:rationale ?rationale }}\n\
            }}\n\
          }}\n\
-         ORDER BY ?pri"
+         ORDER BY xsd:integer(?pri)"
     );
 
     let rules_text = match crate::store::query(store, &rules_sparql) {


### PR DESCRIPTION
Closes #29.

**What changes for a user.** A domain can hold more than ten rules. Before this, every rule added after the tenth was given number 10, landed on the same IRI `rule/<domain>/cli-10`, and the hook injection rendered the cross-product of their texts and rationales (a 25-rule domain injected ~200 lines). Rules also now sort numerically in the injection (10 after 9, not after 1).

**Why.** `next_rule_index` took `MAX(?idx)` over `:index` literals stored as plain strings, so once `"0"`..`"9"` existed the maximum was `"9"` and the next index stayed 10 forever. Casting to `xsd:integer` in that query, and in the injection's `ORDER BY`, fixes both.

**Verified.** 12 rules added to a fresh domain get 12 distinct numbers; the injection lists 12 lines. Full `cargo test` passes except the two `doorbell_test` cases, which fail identically on `main` at b1a067f on this macOS machine (unix-socket accept timing), so they are unrelated.

**Existing collided graphs** are not migrated by this change; deleting the domain's `rule/<domain>/cli-*` quads and re-adding the rules repairs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pujoWN6FPbRgQhujseTwC
