### PR TITLE
fix(clippy): the 26 lints rustc 1.98.1 raises, so the CI clippy job is green again

### DIFF
--- a/src/apply_ops.rs
+++ b/src/apply_ops.rs
@@ -685,7 +685,7 @@ mod tests {
         assert_eq!(
             crate::store::query_union(&store, any_sync)
                 .ok()
-                .and_then(|r| first_count(r)),
+                .and_then(first_count),
             Some(0),
             "no ledger predicate reaches a union read"
         );

--- a/src/ast_repo.rs
+++ b/src/ast_repo.rs
@@ -36,10 +36,10 @@ fn install_hook(app_root: &Path, name: &str, branch_switch_only: bool) {
         return;
     }
     let path = hooks_dir.join(name);
-    if let Ok(existing) = std::fs::read_to_string(&path) {
-        if !existing.contains(MARKER) {
-            return; // respect a pre-existing user hook
-        }
+    if let Ok(existing) = std::fs::read_to_string(&path)
+        && !existing.contains(MARKER)
+    {
+        return; // respect a pre-existing user hook
     }
     // post-checkout args: <old-ref> <new-ref> <branch-flag>; 1 == branch switch.
     let guard = if branch_switch_only {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2033,14 +2033,14 @@ pub fn run() {
                         // it's discoverable outside a dev session. Foreground syncs
                         // only — the Stop hook sets BASE_AST_SKIP_REGISTER to keep
                         // frequent background refreshes off graph.nq.
-                        if std::env::var("BASE_AST_SKIP_REGISTER").is_err() {
-                            if let Some(app_root) = ast_ttl.parent().and_then(|p| p.parent()) {
-                                base::ast_repo::ensure_repo_wiring(app_root);
-                                if let Err(e) = crud::ast_map::register(
-                                    &cwd, &config.namespace, app_root, &ast_ttl,
-                                ) {
-                                    eprintln!("(ast map registration skipped: {e})");
-                                }
+                        if std::env::var("BASE_AST_SKIP_REGISTER").is_err()
+                            && let Some(app_root) = ast_ttl.parent().and_then(|p| p.parent())
+                        {
+                            base::ast_repo::ensure_repo_wiring(app_root);
+                            if let Err(e) = crud::ast_map::register(
+                                &cwd, &config.namespace, app_root, &ast_ttl,
+                            ) {
+                                eprintln!("(ast map registration skipped: {e})");
                             }
                         }
                     }

--- a/src/crud/decision.rs
+++ b/src/crud/decision.rs
@@ -177,7 +177,6 @@ pub fn update(
     if let Some(v) = rationale { field("rationale", v); }
     if let Some(v) = recall { field("recall", v); }
     if let Some(v) = status { field("status", v); }
-    drop(field);
 
     updates.push(crud::field_update(&graph, &iri, &format!("{p}:updatedAt"), &format!("\"{now}\"^^xsd:dateTime")));
     updates.push(crud::field_update(&graph, &iri, &format!("{p}:lastActive"), &format!("\"{now}\"^^xsd:dateTime")));

--- a/src/crud/milestone.rs
+++ b/src/crud/milestone.rs
@@ -157,21 +157,21 @@ pub fn get_data(cwd: &Path, ns: &NamespaceConfig, slug: &str) -> Result<Option<M
     );
 
     let results = crud::load_and_query(cwd, ns, &sparql)?;
-    if let QueryResults::Solutions(solutions) = results {
-        for row in solutions.filter_map(|r| r.ok()) {
-            let lit = |k: &str| row.get(k).map(|t| crud::term_display(t.into()));
-            let iri_s = |k: &str| row.get(k).map(|t| crud::slug_of(&crud::term_display(t.into())));
-            return Ok(Some(MilestoneRecord {
-                id: slug.to_string(),
-                name: lit("name").unwrap_or_default(),
-                status: lit("status").unwrap_or_default(),
-                description: lit("description"),
-                project: iri_s("proj"),
-                created: lit("created"),
-                updated: lit("updated"),
-                last_active: lit("lastActive"),
-            }));
-        }
+    if let QueryResults::Solutions(solutions) = results
+        && let Some(row) = solutions.filter_map(|r| r.ok()).next()
+    {
+        let lit = |k: &str| row.get(k).map(|t| crud::term_display(t.into()));
+        let iri_s = |k: &str| row.get(k).map(|t| crud::slug_of(&crud::term_display(t.into())));
+        return Ok(Some(MilestoneRecord {
+            id: slug.to_string(),
+            name: lit("name").unwrap_or_default(),
+            status: lit("status").unwrap_or_default(),
+            description: lit("description"),
+            project: iri_s("proj"),
+            created: lit("created"),
+            updated: lit("updated"),
+            last_active: lit("lastActive"),
+        }));
     }
     Ok(None)
 }

--- a/src/crud/project.rs
+++ b/src/crud/project.rs
@@ -350,23 +350,23 @@ pub fn get_data(cwd: &Path, ns: &NamespaceConfig, slug: &str) -> Result<Option<P
     );
 
     let results = crud::load_and_query(cwd, ns, &sparql)?;
-    if let QueryResults::Solutions(solutions) = results {
-        for row in solutions.filter_map(|r| r.ok()) {
-            let cell = |k: &str| row.get(k).map(|t| crud::term_display(t.into()));
-            return Ok(Some(ProjectRecord {
-                id: slug.to_string(),
-                name: cell("name").unwrap_or_default(),
-                status: cell("status").unwrap_or_default(),
-                priority: cell("priority"),
-                path: cell("path"),
-                stage: cell("stage"),
-                blocked_by: cell("blockedBy"),
-                next_action: cell("nextAction"),
-                created: cell("created"),
-                updated: cell("updated"),
-                last_active: cell("lastActive"),
-            }));
-        }
+    if let QueryResults::Solutions(solutions) = results
+        && let Some(row) = solutions.filter_map(|r| r.ok()).next()
+    {
+        let cell = |k: &str| row.get(k).map(|t| crud::term_display(t.into()));
+        return Ok(Some(ProjectRecord {
+            id: slug.to_string(),
+            name: cell("name").unwrap_or_default(),
+            status: cell("status").unwrap_or_default(),
+            priority: cell("priority"),
+            path: cell("path"),
+            stage: cell("stage"),
+            blocked_by: cell("blockedBy"),
+            next_action: cell("nextAction"),
+            created: cell("created"),
+            updated: cell("updated"),
+            last_active: cell("lastActive"),
+        }));
     }
     Ok(None)
 }

--- a/src/crud/task.rs
+++ b/src/crud/task.rs
@@ -282,26 +282,26 @@ pub fn get_data(cwd: &Path, ns: &NamespaceConfig, slug: &str) -> Result<Option<T
     );
 
     let results = crud::load_and_query(cwd, ns, &sparql)?;
-    if let QueryResults::Solutions(solutions) = results {
-        for row in solutions.filter_map(|r| r.ok()) {
-            let lit = |k: &str| row.get(k).map(|t| crud::term_display(t.into()));
-            let iri_s = |k: &str| row.get(k).map(|t| crud::slug_of(&crud::term_display(t.into())));
-            return Ok(Some(TaskRecord {
-                id: slug.to_string(),
-                name: lit("name").unwrap_or_default(),
-                status: lit("status").unwrap_or_default(),
-                priority: lit("priority"),
-                project: iri_s("proj"),
-                milestone: iri_s("ms"),
-                description: lit("description"),
-                assignee: lit("assignee"),
-                due: lit("due"),
-                created: lit("created"),
-                updated: lit("updated"),
-                last_active: lit("lastActive"),
-                labels: labels_of(cwd, ns, slug)?,
-            }));
-        }
+    if let QueryResults::Solutions(solutions) = results
+        && let Some(row) = solutions.filter_map(|r| r.ok()).next()
+    {
+        let lit = |k: &str| row.get(k).map(|t| crud::term_display(t.into()));
+        let iri_s = |k: &str| row.get(k).map(|t| crud::slug_of(&crud::term_display(t.into())));
+        return Ok(Some(TaskRecord {
+            id: slug.to_string(),
+            name: lit("name").unwrap_or_default(),
+            status: lit("status").unwrap_or_default(),
+            priority: lit("priority"),
+            project: iri_s("proj"),
+            milestone: iri_s("ms"),
+            description: lit("description"),
+            assignee: lit("assignee"),
+            due: lit("due"),
+            created: lit("created"),
+            updated: lit("updated"),
+            last_active: lit("lastActive"),
+            labels: labels_of(cwd, ns, slug)?,
+        }));
     }
     Ok(None)
 }

--- a/src/domain/session.rs
+++ b/src/domain/session.rs
@@ -324,18 +324,18 @@ impl SessionState {
             return Bracket::Moderate; // default when brackets disabled
         }
 
-        if config.is_percent_mode() {
-            if let Some(pct) = context_pct {
-                return if pct <= config.fresh_until_pct {
-                    Bracket::Fresh
-                } else if pct <= config.moderate_until_pct {
-                    Bracket::Moderate
-                } else if pct <= config.depleted_until_pct {
-                    Bracket::Depleted
-                } else {
-                    Bracket::Critical
-                };
-            }
+        if config.is_percent_mode()
+            && let Some(pct) = context_pct
+        {
+            return if pct <= config.fresh_until_pct {
+                Bracket::Fresh
+            } else if pct <= config.moderate_until_pct {
+                Bracket::Moderate
+            } else if pct <= config.depleted_until_pct {
+                Bracket::Depleted
+            } else {
+                Bracket::Critical
+            };
         }
 
         let count = self.prompt_count_for(session_id);
@@ -571,8 +571,7 @@ mod tests {
 
     #[test]
     fn percent_mode_overrides_turn_count() {
-        let mut config = BracketConfig::default();
-        config.mode = Some("percent".into());
+        let config = BracketConfig { mode: Some("percent".into()), ..Default::default() };
         let mut state = SessionState::default();
         // 40 prompts would be CRITICAL on turns; 10% context says FRESH.
         state.prompt_counts.insert("s1".into(), 40);
@@ -622,10 +621,12 @@ mod tests {
         alpha.mark_standard_injected("std-1", 7);
         alpha.mark_ast_injected("src/main.rs", 3);
 
-        let mut beta = SessionState::default();
-        beta.injected = std::mem::take(&mut alpha.injected);
-        beta.standards_injected = std::mem::take(&mut alpha.standards_injected);
-        beta.ast_injected = std::mem::take(&mut alpha.ast_injected);
+        let mut beta = SessionState {
+            injected: std::mem::take(&mut alpha.injected),
+            standards_injected: std::mem::take(&mut alpha.standards_injected),
+            ast_injected: std::mem::take(&mut alpha.ast_injected),
+            ..Default::default()
+        };
         beta.set_active(Some("beta"));
 
         assert!(!beta.is_standard_injected("std-1", 7));
@@ -638,8 +639,7 @@ mod tests {
         alpha.mark_injected("shared-domain", 1);
         let stash = std::mem::take(&mut alpha.injected);
 
-        let mut beta = SessionState::default();
-        beta.injected = stash;
+        let mut beta = SessionState { injected: stash, ..Default::default() };
         beta.set_active(Some("beta"));
         beta.mark_injected("shared-domain", 1);
         beta.clear_dedup();
@@ -659,8 +659,7 @@ mod tests {
         alpha.mark_dirty_app("/repo/app-a");
         let stash = std::mem::take(&mut alpha.dirty_apps);
 
-        let mut beta = SessionState::default();
-        beta.dirty_apps = stash;
+        let mut beta = SessionState { dirty_apps: stash, ..Default::default() };
         beta.set_active(Some("beta"));
         beta.mark_dirty_app("/repo/app-b");
 

--- a/src/graph_analyze.rs
+++ b/src/graph_analyze.rs
@@ -39,7 +39,7 @@ pub fn run(cwd: &Path, ns: &NamespaceConfig, top_n: usize) -> Result<()> {
         groups.entry(*c).or_default().push(id);
     }
     let mut group_vec: Vec<(usize, Vec<&String>)> = groups.into_iter().collect();
-    group_vec.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    group_vec.sort_by_key(|g| std::cmp::Reverse(g.1.len()));
 
     // ── Surprising connections: edges that bridge two communities ──
     let mut bridges: Vec<(String, String)> = Vec::new();
@@ -123,11 +123,11 @@ fn label_propagation(
             // Most frequent label; ties broken by smallest label id (determinism).
             let mut ranked: Vec<(usize, usize)> = counts.into_iter().collect();
             ranked.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
-            if let Some((best, _)) = ranked.first() {
-                if label.get(*k) != Some(best) {
-                    label.insert((*k).clone(), *best);
-                    changed = true;
-                }
+            if let Some((best, _)) = ranked.first()
+                && label.get(*k) != Some(best)
+            {
+                label.insert((*k).clone(), *best);
+                changed = true;
             }
         }
         if !changed {

--- a/src/graph_query.rs
+++ b/src/graph_query.rs
@@ -80,6 +80,9 @@ pub fn run(cwd: &Path, ns: &NamespaceConfig, question: &str, opts: &Options) -> 
     Ok(())
 }
 
+/// The concept map and its undirected adjacency list, as `load_graph` returns them.
+pub type GraphMaps = (HashMap<String, Node>, HashMap<String, Vec<(String, String)>>);
+
 /// Pull labelled nodes and the concept edge-set from graph.nq into memory.
 /// Edges come from reified semantic edges (ops:from/ops:to); traversal is
 /// undirected so BFS reaches both callers and callees of a concept.
@@ -87,7 +90,7 @@ pub fn load_graph(
     cwd: &Path,
     ns: &NamespaceConfig,
     include_ast: bool,
-) -> Result<(HashMap<String, Node>, HashMap<String, Vec<(String, String)>>)> {
+) -> Result<GraphMaps> {
     let p = &ns.prefix;
 
     let node_q = format!(

--- a/src/home.rs
+++ b/src/home.rs
@@ -32,18 +32,17 @@ pub fn home_root() -> Option<PathBuf> {
     {
         return Some(PathBuf::from(over));
     }
+    // Test builds never fall through to the real home. `cfg(test)` cannot
+    // do this job: `tests/*.rs` link the library compiled WITHOUT
+    // `cfg(test)`, so an integration test that forgot to isolate would read
+    // the real home with nothing to stop it. The feature is enabled by the
+    // self-dev-dependency in Cargo.toml, so it covers both test binaries
+    // and is off for every `cargo build` / `cargo run`.
     #[cfg(feature = "isolation-guard")]
-    {
-        // Test builds never fall through to the real home. `cfg(test)` cannot
-        // do this job: `tests/*.rs` link the library compiled WITHOUT
-        // `cfg(test)`, so an integration test that forgot to isolate would read
-        // the real home with nothing to stop it. The feature is enabled by the
-        // self-dev-dependency in Cargo.toml, so it covers both test binaries
-        // and is off for every `cargo build` / `cargo run`.
-        return Some(test_root());
-    }
+    let home = Some(test_root());
     #[cfg(not(feature = "isolation-guard"))]
-    real_home()
+    let home = real_home();
+    home
 }
 
 /// The OS home directory with no override applied.

--- a/src/hook/automap.rs
+++ b/src/hook/automap.rs
@@ -376,8 +376,8 @@ pub fn bash_paths(command: &str, cwd: &Path, home: Option<&Path>) -> Vec<PathBuf
     let mut out: Vec<PathBuf> = Vec::new();
     let mut base = cwd.to_path_buf();
     let mut seen = 0usize;
-    for segment in command.split(|c| c == ';' || c == '\n' || c == '|' || c == '&') {
-        let mut tokens = segment.split_whitespace().map(|t| t.trim_matches(|c| c == '"' || c == '\'' || c == '(' || c == ')'));
+    for segment in command.split([';', '\n', '|', '&']) {
+        let mut tokens = segment.split_whitespace().map(|t| t.trim_matches(['"', '\'', '(', ')']));
         let mut first = tokens.next();
         // skip leading env assignments: FOO=bar cmd …
         while first.is_some_and(|t| t.contains('=') && !t.starts_with('-') && !t.contains('/')) {
@@ -414,7 +414,7 @@ fn push_unique(out: &mut Vec<PathBuf>, p: PathBuf) {
 /// A token that reads as a path, resolved; flags, globs, variables and URLs
 /// are not paths.
 fn resolve_token(tok: &str, base: &Path, home: Option<&Path>) -> Option<PathBuf> {
-    let t = tok.trim_end_matches(|c| c == ',' || c == ':');
+    let t = tok.trim_end_matches([',', ':']);
     if t.is_empty() || t.starts_with('-') || t.contains("://") || t.contains(['*', '$', '{', '`']) {
         return None;
     }
@@ -447,7 +447,7 @@ pub fn linux_paths(command: &str) -> Vec<String> {
         return out;
     }
     for raw in command.split(|c: char| c.is_whitespace() || c == ';' || c == '|' || c == '&' || c == '(' || c == ')' || c == '"' || c == '\'') {
-        let t = raw.trim_end_matches(|c| c == ',' || c == ':');
+        let t = raw.trim_end_matches([',', ':']);
         if (t.starts_with("~/") || t.starts_with("/home/") || t.starts_with("/mnt/")) && !t.contains(['*', '$', '{', '`']) {
             let s = t.to_string();
             if !out.contains(&s) {

--- a/src/multimodal.rs
+++ b/src/multimodal.rs
@@ -52,8 +52,8 @@ pub fn classify(path: &Path) -> Option<Modality> {
 
 // ─── Dependency bootstrap (NO sudo) ──────────────────────────
 
-/// An external tool a modality needs. Install hierarchy is in-process > user-space
-/// > system — so every dep here installs WITHOUT sudo (pip --user / pipx). PDF is
+/// An external tool a modality needs. Install hierarchy is in-process, then
+/// user-space, then system — so every dep here installs WITHOUT sudo (pip --user / pipx). PDF is
 /// not a Dep at all: it's handled in-process by the `pdf-extract` crate.
 struct Dep {
     bin: &'static str,

--- a/src/plugin/dist.rs
+++ b/src/plugin/dist.rs
@@ -71,17 +71,17 @@ fn token_from_env_file() -> Option<String> {
             continue;
         }
         let line = line.strip_prefix("export ").unwrap_or(line);
-        if let Some((k, v)) = line.split_once('=') {
-            if k.trim() == "GITHUB_TOKEN" || k.trim() == "GH_TOKEN" {
-                let mut val = v.trim();
-                if val.len() >= 2
-                    && ((val.starts_with('"') && val.ends_with('"')) || (val.starts_with('\'') && val.ends_with('\'')))
-                {
-                    val = &val[1..val.len() - 1];
-                }
-                if !val.is_empty() {
-                    return Some(val.to_string());
-                }
+        if let Some((k, v)) = line.split_once('=')
+            && (k.trim() == "GITHUB_TOKEN" || k.trim() == "GH_TOKEN")
+        {
+            let mut val = v.trim();
+            if val.len() >= 2
+                && ((val.starts_with('"') && val.ends_with('"')) || (val.starts_with('\'') && val.ends_with('\'')))
+            {
+                val = &val[1..val.len() - 1];
+            }
+            if !val.is_empty() {
+                return Some(val.to_string());
             }
         }
     }
@@ -105,10 +105,10 @@ fn token_from_gh_cli() -> Option<String> {
 /// the unauthenticated public-download path.
 fn github_token() -> Option<String> {
     for var in ["GITHUB_TOKEN", "GH_TOKEN"] {
-        if let Ok(v) = std::env::var(var) {
-            if !v.is_empty() {
-                return Some(v);
-            }
+        if let Ok(v) = std::env::var(var)
+            && !v.is_empty()
+        {
+            return Some(v);
         }
     }
     token_from_env_file().or_else(token_from_gh_cli)

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -346,7 +346,7 @@ impl RelayStore {
                     from.is_none_or(|f| m.from == f) && mtype.is_none_or(|t| m.mtype == t)
                 });
             if let Some(m) = hit {
-                let _ = self.mark_seen(title, &[m.id.clone()]);
+                let _ = self.mark_seen(title, std::slice::from_ref(&m.id));
                 return Some(m);
             }
             if std::time::Instant::now() >= deadline {
@@ -647,6 +647,30 @@ fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Option<T> {
     serde_json::from_str(&content).ok()
 }
 
+/// Clear the two shell variables that contaminate relay tests — once for the
+/// whole test process, and never restored.
+///
+/// `BASE_RELAY_AS` pins a session's codename and `WT_SESSION` drives tab
+/// continuity, so a suite run from a wrapper-launched shell (`cc work` exports
+/// both) hands every fake session the same title and the uniqueness assertions
+/// fail. Two modules used to scrub-and-restore these behind two *different*
+/// mutexes, which do not serialize against each other: `deliver`'s guard
+/// restored the shell's value while `task_inbox`'s tests were mid-run, putting
+/// the contamination back. Nothing in the suite wants the shell's value back,
+/// so the fix is to stop restoring it.
+#[cfg(test)]
+pub(crate) fn scrub_shell_env() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: runs exactly once, and no test sets these except under its
+        // own lock, after this has already run.
+        unsafe {
+            std::env::remove_var("BASE_RELAY_AS");
+            std::env::remove_var("WT_SESSION");
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -857,28 +881,4 @@ mod tests {
         let root = relay_root(&wt).expect("worktree should resolve main relay root");
         assert_eq!(root, main.join(".base").join("relay"));
     }
-}
-
-/// Clear the two shell variables that contaminate relay tests — once for the
-/// whole test process, and never restored.
-///
-/// `BASE_RELAY_AS` pins a session's codename and `WT_SESSION` drives tab
-/// continuity, so a suite run from a wrapper-launched shell (`cc work` exports
-/// both) hands every fake session the same title and the uniqueness assertions
-/// fail. Two modules used to scrub-and-restore these behind two *different*
-/// mutexes, which do not serialize against each other: `deliver`'s guard
-/// restored the shell's value while `task_inbox`'s tests were mid-run, putting
-/// the contamination back. Nothing in the suite wants the shell's value back,
-/// so the fix is to stop restoring it.
-#[cfg(test)]
-pub(crate) fn scrub_shell_env() {
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    ONCE.call_once(|| {
-        // SAFETY: runs exactly once, and no test sets these except under its
-        // own lock, after this has already run.
-        unsafe {
-            std::env::remove_var("BASE_RELAY_AS");
-            std::env::remove_var("WT_SESSION");
-        }
-    });
 }

--- a/src/standards/sync.rs
+++ b/src/standards/sync.rs
@@ -530,7 +530,6 @@ pub fn seed_file() -> StandardsFile {
                 content: svec(&["env(", "environ.get", "getenv"]),
                 semantic: svec(&["config"]),
                 paths: svec(&["config/", "settings.py"]),
-                ..Default::default()
             },
             &[
                 ("laravel", "env('X') ?: $default — never env('X', $default); an empty string is 'set' and defeats the second arg."),
@@ -682,7 +681,7 @@ pub fn test_standard_match(config: &BaseConfig, cwd: &Path, file: &str, content:
         .iter()
         .filter_map(|s| super::matcher::score(s, &ctx).map(|sc| (s, sc)))
         .collect();
-    scored.sort_by(|a, b| b.1.cmp(&a.1));
+    scored.sort_by_key(|s| std::cmp::Reverse(s.1));
 
     if scored.is_empty() {
         println!("No standards scored above zero.");


### PR DESCRIPTION
**What changes for a user.** Nothing at runtime. CI's `clippy` job has failed on every pull request since GitHub's runners moved `stable` to rustc 1.98.1 (2026-09-01), including #28, so a red check no longer meant anything. This clears the 26 lints that toolchain raises (19 in the library, 7 more in the binary and test targets that CI never reached because the library stopped it first) and keeps behaviour identical: the three crud getters still return the first row, `home_root` resolves the same way under both features, `load_graph`'s return tuple is now the named `GraphMaps`.

**Verified.** `cargo +1.98.1 clippy --all-targets -- -D warnings` clean; full suite green (392 lib + every integration target).

**Why now.** #28 (the release step-order fix) and the 0.13.16 integration branch both need a green clippy check to mean something before the release pipeline is exercised end to end.

https://claude.ai/code/session_01VMzLN9woGG8xxbQcVX2fj8