### PR TITLE
fix: the write path stops eating the CPU, and the auto-mapper never adopts temp again

### DIFF
--- a/scripts/ast/detect.py
+++ b/scripts/ast/detect.py
@@ -21,7 +21,7 @@ _NOISE_DIRS = frozenset({
 
 def _is_noise_dir(name: str) -> bool:
     """Check if a directory name is noise that should be skipped."""
-    return name in _NOISE_DIRS or name.startswith(".")
+    return name.lower() in _NOISE_DIRS or name.startswith(".")
 
 
 def _load_baseignore(root: Path) -> list[str]:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1438,6 +1438,7 @@ pub fn run() {
                     Some(MapPlan::Debounced) => println!("{}: a build is already in flight", abs.display()),
                     Some(MapPlan::SkipHome) => println!("{}: the home directory is never mapped", abs.display()),
                     Some(MapPlan::SkipHub) => println!("{}: a workspace of apps — each app maps itself", abs.display()),
+                    Some(MapPlan::SkipNeverMap(why)) => println!("{}: never mapped — {why}", abs.display()),
                     Some(MapPlan::Refresh) => println!("{}: refreshing", abs.display()),
                 }
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1439,6 +1439,13 @@ pub fn run() {
                     Some(MapPlan::SkipHome) => println!("{}: the home directory is never mapped", abs.display()),
                     Some(MapPlan::SkipHub) => println!("{}: a workspace of apps — each app maps itself", abs.display()),
                     Some(MapPlan::SkipNeverMap(why)) => println!("{}: never mapped — {why}", abs.display()),
+                    Some(MapPlan::NeedsConfirm) => println!(
+                        "{}: {}",
+                        abs.display(),
+                        std::fs::read_to_string(abs.join(".base-ast").join(".needs-confirm"))
+                            .unwrap_or_else(|_| "too large to build unattended".into())
+                            .trim()
+                    ),
                     Some(MapPlan::Refresh) => println!("{}: refreshing", abs.display()),
                 }
             }

--- a/src/hook/automap.rs
+++ b/src/hook/automap.rs
@@ -433,6 +433,24 @@ pub fn first_contact(path: &Path) -> Option<MapPlan> {
     ensure_first_map(&root)
 }
 
+/// First contact from a path a Bash command merely NAMED. Same decisions as
+/// [`first_contact`], except the resolved root must already be marked: a
+/// command's `cd` is transient, a session's cwd is a choice. Booting a session
+/// in an unmarked folder of source still adopts it (Chris, 2026-09-01) — but
+/// passing through one on the way to somewhere else does not.
+///
+/// `config::ast_app_root` happens to require a marker today, so the check here
+/// is belt and braces. That is deliberate: the rule now lives somewhere it can
+/// be tested, instead of being an accident of resolution that a later change to
+/// `ast_app_root` could quietly undo.
+pub fn bash_first_contact(path: &Path) -> Option<MapPlan> {
+    let root = crate::config::ast_app_root(path)?;
+    if !is_marked(&root) {
+        return None;
+    }
+    ensure_first_map(&root)
+}
+
 /// First contact that builds in the FOREGROUND and returns when the map has
 /// landed. For a caller whose process must outlive the build: a `wsl -e sh`
 /// invocation from Windows ends the moment its shell exits and takes every

--- a/src/hook/automap.rs
+++ b/src/hook/automap.rs
@@ -728,13 +728,6 @@ pub fn is_noise_dir(name: &str) -> bool {
 /// changes. An explicit `base sync --ast --target <path>` from a human still
 /// runs, with the extractor's own prompt.
 pub fn never_map_reason(root: &Path) -> Option<&'static str> {
-    never_map_reason_with(root, crate::home::isolation_active())
-}
-
-/// [`never_map_reason`] with the sandbox exemption as an explicit input, so
-/// both halves are testable from a test binary — which is itself isolated, and
-/// could otherwise never observe the temp rule it depends on.
-pub fn never_map_reason_with(root: &Path, isolated: bool) -> Option<&'static str> {
     let parts = lower_components(root);
 
     // Always armed, in tests too.
@@ -754,17 +747,33 @@ pub fn never_map_reason_with(root: &Path, isolated: bool) -> Option<&'static str
     }
 
     // The system temp directory is also where every test builds its fixture
-    // workspaces, and `home::within_sandbox` already defines it as this
-    // process's sandbox. Disarm this half — and only this half — while
-    // isolated. `isolation_active` is off for every `cargo build` and
-    // `cargo run`, so production keeps the guard.
-    if isolated {
+    // workspaces, so this half — and only this half — stands down inside a
+    // sandbox: a process whose HOME has itself been redirected under temp.
+    //
+    // Deliberately NOT keyed on `home::isolation_active()`, which was the first
+    // attempt. `isolation-guard` reaches the ordinary binary through the
+    // self-dev-dependency, so that version disarmed the temp rule in a plain
+    // `base` too — measured 2026-09-03 on `target/debug/base`, which skipped a
+    // `node_modules` path correctly while happily mapping a marked directory
+    // under `/tmp`. A production guard never keys on a compile-time feature.
+    if in_sandbox_home(root) {
         return None;
     }
     if parts.iter().any(|p| TEMP_SEGMENTS.contains(&p.as_str())) {
         return Some("a temp directory");
     }
     under_any(root, &temp_roots())
+}
+
+/// True when `root` sits inside a home that has itself been redirected under a
+/// temp root — a test's fixture workspace rather than a real tree. In
+/// production `home_root()` is the operator's home and is never under temp, so
+/// this is false however the crate's features happen to resolve.
+fn in_sandbox_home(root: &Path) -> bool {
+    let Some(home) = crate::home::home_root() else {
+        return false;
+    };
+    under_any(&home, &temp_roots()).is_some() && is_under(root, &home)
 }
 
 /// `/mnt/c/Users/<name>` — a Windows home seen from a WSL hook, which its own

--- a/src/hook/automap.rs
+++ b/src/hook/automap.rs
@@ -21,8 +21,10 @@
 //!   * `base scaffold` and `base project add --path` — the folder they just
 //!     registered.
 //!
-//! What a hook never maps: the home directory, a filesystem root, the
-//! well-known user folders (Desktop, Documents, Downloads, a cloud-drive root),
+//! What a hook never maps: the OS temp directory, the caches, `AppData`,
+//! `node_modules`, `~/.claude`, `~/.base-gbl`, the home directory — this OS's
+//! or, across a WSL boundary, the other's — a filesystem root, the well-known
+//! user folders (Desktop, Documents, Downloads, a cloud-drive root),
 //! and a folder that only HOLDS apps — a `.base` workspace whose repos sit one
 //! or two levels down (`~/ops-sys/toolbox` keeps fifty under `frameworks/`,
 //! `apps/`, …). Mapping one of those walks every project on the machine into
@@ -30,10 +32,18 @@
 //! app that contains other marked apps maps only its own tree: the extractor
 //! skips any subfolder carrying `.git`, `.paul` or `.base-ast`.
 //!
-//! Every build is detached and debounced; a hook never waits. An unattended
-//! build never stops to ask about the file-count threshold (`base sync --ast
-//! --yes`), and a failed one leaves `.base-ast/.last-error` behind so the next
-//! session start can say why instead of promising a map that never lands.
+//! Every build is detached and debounced; a hook never waits. A failed build
+//! leaves `.base-ast/.last-error` behind so the next session start can say why
+//! instead of promising a map that never lands.
+//!
+//! An unattended build passes `--yes`, so it never stops at the extractor's own
+//! file-count prompt — which is why the size fuse decides BEFORE the spawn
+//! rather than relying on it. A first build measures the tree, and a root over
+//! `FUSE_SOURCE_FILES` / `FUSE_ENTRIES` is not built at all: the counts and the
+//! exact by-hand command go into `.base-ast/.needs-confirm` and the next
+//! session start prints them. Chris, 2026-09-03, after a hook spent thirty
+//! minutes extracting `%TEMP%`: "Base is set to automatically make graphs, this
+//! will blow up people's computers."
 
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -93,6 +103,17 @@ const TEMP_SEGMENTS: &[&str] = &["tmp", "temp"];
 /// so a project folder merely called `Local` is not caught.
 const APPDATA_CHILDREN: &[&str] = &["local", "locallow", "roaming"];
 
+/// A hook builds no tree larger than this without being asked first. Measured
+/// 2026-09-03 against the largest real app on the machine this fork came from
+/// (`~/ops-sys/toolbox/frameworks/05-exp-cadre`: 209 source files, 10,853
+/// entries), so both fuses sit several times above anything real here.
+/// Tripping one costs a prompt, never a map, so erring low is cheap.
+const FUSE_SOURCE_FILES: usize = 5_000;
+const FUSE_ENTRIES: usize = 50_000;
+
+/// How long a tripped fuse is believed before the tree is measured again.
+const NEEDS_CONFIRM_SECS: u64 = 24 * 60 * 60;
+
 /// How deep and how far the "does this folder hold code" probe looks.
 const PROBE_DEPTH: usize = 3;
 const PROBE_ENTRIES: usize = 2000;
@@ -111,6 +132,10 @@ pub enum MapPlan {
     SkipNeverMap(&'static str),
     /// A sync ran within the debounce window; the caller may requeue.
     Debounced,
+    /// The tree is too large to extract unattended. Nothing was spawned;
+    /// `.base-ast/.needs-confirm` holds the counts and the exact command to
+    /// run by hand, and the session-start notice prints it.
+    NeedsConfirm,
     /// No `.base-ast/ast.ttl` yet: build the first map, registered.
     Build,
     /// A map exists: refresh it in the background, unregistered.
@@ -167,6 +192,12 @@ pub fn ensure_app_map(root: &Path) -> MapPlan {
     // is a crashed build and no longer counts.
     let building = recently(&base_ast.join(".building"), BUILD_LOCK_SECS);
     let plan = plan_map(root, home.as_deref(), never, mapped, building || recently_synced(&marker));
+    // The fuse, on a FIRST build only. An existing map means the extractor
+    // already got through this tree once; re-measuring up to 50,000 entries on
+    // every Stop-hook refresh would cost more than the bug it guards against.
+    if plan == MapPlan::Build && fuse_blocks(root, &base_ast) {
+        return MapPlan::NeedsConfirm;
+    }
     match plan {
         MapPlan::Build | MapPlan::Refresh => {
             let _ = std::fs::create_dir_all(&base_ast);
@@ -174,7 +205,11 @@ pub fn ensure_app_map(root: &Path) -> MapPlan {
             let _ = std::fs::write(base_ast.join(".building"), b"");
             spawn_sync(root, plan == MapPlan::Build);
         }
-        MapPlan::SkipHome | MapPlan::SkipHub | MapPlan::SkipNeverMap(_) | MapPlan::Debounced => {}
+        MapPlan::SkipHome
+        | MapPlan::SkipHub
+        | MapPlan::SkipNeverMap(_)
+        | MapPlan::NeedsConfirm
+        | MapPlan::Debounced => {}
     }
     plan
 }
@@ -320,6 +355,14 @@ pub fn session_start_notice(cwd: &Path) -> Option<String> {
             root.display(),
             base_ast.display()
         )),
+        (MapPlan::NeedsConfirm, _) => Some(format!(
+            "[AST] no code map for {}: {}",
+            root.display(),
+            std::fs::read_to_string(base_ast.join(".needs-confirm"))
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        )),
         (MapPlan::Build, false) => Some(format!(
             "[AST] no code map for {} yet — building one now in the background \
              (base sync --ast); `base ast query` and the file-map injection answer once it lands.",
@@ -410,6 +453,9 @@ pub fn first_contact_wait(path: &Path) -> Option<MapPlan> {
     let home = crate::home::real_home();
     if recently(&base_ast.join(".building"), BUILD_LOCK_SECS) {
         return Some(MapPlan::Debounced);
+    }
+    if fuse_blocks(&root, &base_ast) {
+        return Some(MapPlan::NeedsConfirm);
     }
     let plan = plan_map(&root, home.as_deref(), None, false, false);
     if plan != MapPlan::Build {
@@ -833,6 +879,100 @@ pub fn has_code_files(dir: &Path) -> bool {
         }
     }
     false
+}
+
+/// What a bounded walk of a candidate root found. Counting stops the instant a
+/// fuse trips, so both numbers are lower bounds once [`TreeSize::over_fuse`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TreeSize {
+    pub sources: usize,
+    pub entries: usize,
+}
+
+impl TreeSize {
+    pub fn over_fuse(&self) -> bool {
+        self.sources > FUSE_SOURCE_FILES || self.entries > FUSE_ENTRIES
+    }
+}
+
+/// Measure `root` the way the extractor will read it: noise directories and
+/// dot-directories skipped, nested marked apps left to their own maps.
+///
+/// Unlike the `PROBE_ENTRIES` probes this walk is not capped at 2,000 — it has
+/// to be able to count as far as [`FUSE_ENTRIES`] — but it stops the moment a
+/// fuse trips, so the worst case is ~50,000 stats, and it is paid once, on a
+/// first build, never on a refresh.
+pub fn measure_tree(root: &Path) -> TreeSize {
+    let mut size = TreeSize { sources: 0, entries: 0 };
+    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            size.entries += 1;
+            if size.over_fuse() {
+                return size;
+            }
+            let Ok(ft) = entry.file_type() else {
+                continue;
+            };
+            let path = entry.path();
+            if ft.is_dir() {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with('.') || is_noise_dir(&name) || has_strong_marker(&path) {
+                    continue;
+                }
+                stack.push(path);
+            } else if ft.is_file()
+                && path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| CODE_EXTS.contains(&e.to_ascii_lowercase().as_str()))
+            {
+                size.sources += 1;
+                if size.over_fuse() {
+                    return size;
+                }
+            }
+        }
+    }
+    size
+}
+
+/// True when `root` is too large to extract unattended. Records the counts and
+/// the exact command in `.base-ast/.needs-confirm` on the way out, and believes
+/// a fresh one rather than re-measuring the same tree every turn.
+///
+/// `base sync --ast --yes` from a hook cannot get past this: the fuse decides
+/// before anything is spawned, so `--yes` never reaches the extractor's own
+/// file-count prompt. A human running `base sync --ast` by hand is unaffected
+/// and still gets that prompt.
+fn fuse_blocks(root: &Path, base_ast: &Path) -> bool {
+    if recently(&base_ast.join(".needs-confirm"), NEEDS_CONFIRM_SECS) {
+        return true;
+    }
+    let size = measure_tree(root);
+    if !size.over_fuse() {
+        return false;
+    }
+    let _ = std::fs::create_dir_all(base_ast);
+    let _ = std::fs::write(base_ast.join(".needs-confirm"), needs_confirm_text(root, &size));
+    true
+}
+
+/// The one line `.needs-confirm` holds, and the session-start notice reads back.
+pub fn needs_confirm_text(root: &Path, size: &TreeSize) -> String {
+    format!(
+        "at least {} source files across {} entries, over the {}/{} a hook will build unattended. \
+         Run `base sync --ast --target {}` to build it by hand.",
+        size.sources,
+        size.entries,
+        FUSE_SOURCE_FILES,
+        FUSE_ENTRIES,
+        root.display()
+    )
 }
 
 /// The last line the failed extractor wrote, for a one-line notice.

--- a/src/hook/automap.rs
+++ b/src/hook/automap.rs
@@ -361,7 +361,6 @@ pub fn session_start_notice(cwd: &Path) -> Option<String> {
             std::fs::read_to_string(base_ast.join(".needs-confirm"))
                 .unwrap_or_default()
                 .trim()
-                .to_string()
         )),
         (MapPlan::Build, false) => Some(format!(
             "[AST] no code map for {} yet — building one now in the background \
@@ -730,19 +729,38 @@ pub fn is_noise_dir(name: &str) -> bool {
 pub fn never_map_reason(root: &Path) -> Option<&'static str> {
     let parts = lower_components(root);
 
-    // Always armed, in tests too.
-    for (i, name) in parts.iter().enumerate() {
+    // Inside a sandbox (see `sandbox_home`) the segment rules read only the
+    // part of the path BELOW the redirected home. The sandbox's own path is
+    // `%TEMP%`, which on Windows sits under `AppData\Local`: read whole, every
+    // fixture carried the `appdata`/`local` pair and was refused before the
+    // exemption below could stand the temp half down. Measured 2026-09-03 on
+    // the Windows mirror at b72703a: 5 of 13 automap tests failed for exactly
+    // this, while Linux passed because `/tmp` has no such segment.
+    let sandbox = sandbox_home(root);
+    let own_parts = match &sandbox {
+        Some(home) => fixture_components(root, home),
+        None => parts.clone(),
+    };
+
+    // Always armed, in tests too — on the fixture's own segments in a sandbox.
+    for (i, name) in own_parts.iter().enumerate() {
         if let Some(&(_, why)) = NEVER_MAP_SEGMENTS.iter().find(|(n, _)| n == name) {
             return Some(why);
         }
-        if i > 0 && parts[i - 1] == "appdata" && APPDATA_CHILDREN.contains(&name.as_str()) {
+        if i > 0 && own_parts[i - 1] == "appdata" && APPDATA_CHILDREN.contains(&name.as_str()) {
             return Some("a Windows AppData directory");
         }
     }
     if is_foreign_home(&parts) {
         return Some("the other OS's home directory");
     }
-    if let Some(why) = under_any(root, &state_roots()) {
+    // A state root the sandbox itself sits under (on Windows `%LOCALAPPDATA%`
+    // holds `%TEMP%`) is the sandbox's location, not the fixture's.
+    let state: Vec<(PathBuf, &'static str)> = state_roots()
+        .into_iter()
+        .filter(|(anc, _)| sandbox.as_ref().is_none_or(|home| !is_under(home, anc)))
+        .collect();
+    if let Some(why) = under_any(root, &state) {
         return Some(why);
     }
 
@@ -756,7 +774,7 @@ pub fn never_map_reason(root: &Path) -> Option<&'static str> {
     // `base` too — measured 2026-09-03 on `target/debug/base`, which skipped a
     // `node_modules` path correctly while happily mapping a marked directory
     // under `/tmp`. A production guard never keys on a compile-time feature.
-    if in_sandbox_home(root) {
+    if sandbox.is_some() {
         return None;
     }
     if parts.iter().any(|p| TEMP_SEGMENTS.contains(&p.as_str())) {
@@ -765,15 +783,29 @@ pub fn never_map_reason(root: &Path) -> Option<&'static str> {
     under_any(root, &temp_roots())
 }
 
-/// True when `root` sits inside a home that has itself been redirected under a
-/// temp root — a test's fixture workspace rather than a real tree. In
-/// production `home_root()` is the operator's home and is never under temp, so
-/// this is false however the crate's features happen to resolve.
-fn in_sandbox_home(root: &Path) -> bool {
-    let Some(home) = crate::home::home_root() else {
-        return false;
-    };
-    under_any(&home, &temp_roots()).is_some() && is_under(root, &home)
+/// The redirected home `root` sits inside, when this process's home has itself
+/// been redirected under a temp root — a test's fixture workspace rather than a
+/// real tree. In production `home_root()` is the operator's home and is never
+/// under temp, so this is `None` however the crate's features happen to resolve.
+fn sandbox_home(root: &Path) -> Option<PathBuf> {
+    let home = crate::home::home_root()?;
+    (under_any(&home, &temp_roots()).is_some() && is_under(root, &home)).then_some(home)
+}
+
+/// The components of `root` below the sandbox `home`, lower-cased. Tried raw
+/// first, then with both sides canonicalised (an 8.3 `%TEMP%` against its long
+/// spelling); when neither strips, the whole path stands so the rules refuse
+/// more rather than less.
+fn fixture_components(root: &Path, home: &Path) -> Vec<String> {
+    if let Ok(rest) = root.strip_prefix(home) {
+        return lower_components(rest);
+    }
+    if let (Ok(r), Ok(h)) = (std::fs::canonicalize(root), std::fs::canonicalize(home))
+        && let Ok(rest) = r.strip_prefix(&h)
+    {
+        return lower_components(rest);
+    }
+    lower_components(root)
 }
 
 /// `/mnt/c/Users/<name>` — a Windows home seen from a WSL hook, which its own
@@ -848,6 +880,15 @@ fn is_under(root: &Path, anc: &Path) -> bool {
     let norm = |p: &Path| {
         let real = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
         let s = real.to_string_lossy().replace('\\', "/");
+        // On Windows `canonicalize` answers in verbatim form (`\\?\C:\...`,
+        // `\\?\UNC\host\share\...`) and a path that does not exist yet stays
+        // raw, so a fixture's parent canonicalised against its own not-yet-
+        // created child never matched: measured 2026-09-04 on the Windows
+        // mirror, where every sandbox test compared `//?/c:/...` with `c:/...`.
+        let s = match s.strip_prefix("//?/UNC/") {
+            Some(rest) => format!("//{rest}"),
+            None => s.strip_prefix("//?/").unwrap_or(&s).to_string(),
+        };
         let s = s.trim_end_matches('/').to_string();
         if cfg!(windows) { s.to_lowercase() } else { s }
     };

--- a/src/hook/automap.rs
+++ b/src/hook/automap.rs
@@ -35,7 +35,7 @@
 //! --yes`), and a failed one leaves `.base-ast/.last-error` behind so the next
 //! session start can say why instead of promising a map that never lands.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -72,6 +72,27 @@ const CLOUD_ROOTS: &[&str] = &[
     "OneDrive", "Dropbox", "Google Drive", "GoogleDrive", "iCloud Drive", "iCloudDrive", "Nextcloud", "Box",
 ];
 
+/// Path components that make a folder unmappable wherever one appears, matched
+/// case-insensitively on every platform. This half of the rule is what works
+/// across the WSL boundary: a Windows `%TEMP%` reaches a WSL hook as
+/// `/mnt/c/Users/<name>/AppData/Local/Temp`, where not one of the environment
+/// variables in [`temp_roots`] is set.
+const NEVER_MAP_SEGMENTS: &[(&str, &str)] = &[
+    ("node_modules", "a node_modules tree"),
+    (".cache", "a cache directory"),
+    (".claude", "the Claude Code state directory"),
+    (".base-gbl", "base's own global tier"),
+];
+
+/// `tmp` / `temp` as a path component. Held apart from [`NEVER_MAP_SEGMENTS`]
+/// because every test fixture workspace is built under the system temp dir —
+/// see [`never_map_reason`].
+const TEMP_SEGMENTS: &[&str] = &["tmp", "temp"];
+
+/// The children of `AppData` that are never mapped. Matched as an ordered pair
+/// so a project folder merely called `Local` is not caught.
+const APPDATA_CHILDREN: &[&str] = &["local", "locallow", "roaming"];
+
 /// How deep and how far the "does this folder hold code" probe looks.
 const PROBE_DEPTH: usize = 3;
 const PROBE_ENTRIES: usize = 2000;
@@ -83,6 +104,11 @@ pub enum MapPlan {
     SkipHome,
     /// The root is a workspace that only holds other apps: never mapped.
     SkipHub,
+    /// The root is, or sits under, a location a hook never maps — the OS temp
+    /// directory, a cache, `AppData`, `node_modules`, the other OS's home.
+    /// Never built AND never refreshed: a single bad adoption plants
+    /// `.base-ast/`, and without this the marker would make itself permanent.
+    SkipNeverMap(&'static str),
     /// A sync ran within the debounce window; the caller may requeue.
     Debounced,
     /// No `.base-ast/ast.ttl` yet: build the first map, registered.
@@ -92,11 +118,23 @@ pub enum MapPlan {
 }
 
 /// The build/refresh decision, with every input explicit so it can be tested
-/// without a filesystem: `home` is the operator's home, `mapped` whether
+/// without a filesystem: `home` is the operator's home, `never` the reason
+/// this root is off limits (see [`never_map_reason`]), `mapped` whether
 /// `ast.ttl` exists, `debounced` whether `.last-sync` is fresher than the window.
-pub fn plan_map(root: &Path, home: Option<&Path>, mapped: bool, debounced: bool) -> MapPlan {
+pub fn plan_map(
+    root: &Path,
+    home: Option<&Path>,
+    never: Option<&'static str>,
+    mapped: bool,
+    debounced: bool,
+) -> MapPlan {
     if home.is_some_and(|h| h == root) {
         return MapPlan::SkipHome;
+    }
+    // Before `mapped` and before `debounced`, deliberately: an `ast.ttl` that
+    // already sits inside a never-mapped root must not license a refresh.
+    if let Some(why) = never {
+        return MapPlan::SkipNeverMap(why);
     }
     if debounced {
         return MapPlan::Debounced;
@@ -109,6 +147,12 @@ pub fn plan_map(root: &Path, home: Option<&Path>, mapped: bool, debounced: bool)
 /// a workspace hub. Returns what was decided; `Build` and `Refresh` mean a
 /// detached sync is now running.
 pub fn ensure_app_map(root: &Path) -> MapPlan {
+    // First, and before any filesystem probing: a never-mapped root must not
+    // even be walked, and must never have `.base-ast/` written into it.
+    let never = never_map_reason(root);
+    if never.is_some() {
+        return plan_map(root, crate::home::real_home().as_deref(), never, false, false);
+    }
     if is_workspace_hub(root) {
         return MapPlan::SkipHub;
     }
@@ -122,7 +166,7 @@ pub fn ensure_app_map(root: &Path) -> MapPlan {
     // when it finishes, success or failure; a lock older than BUILD_LOCK_SECS
     // is a crashed build and no longer counts.
     let building = recently(&base_ast.join(".building"), BUILD_LOCK_SECS);
-    let plan = plan_map(root, home.as_deref(), mapped, building || recently_synced(&marker));
+    let plan = plan_map(root, home.as_deref(), never, mapped, building || recently_synced(&marker));
     match plan {
         MapPlan::Build | MapPlan::Refresh => {
             let _ = std::fs::create_dir_all(&base_ast);
@@ -130,7 +174,7 @@ pub fn ensure_app_map(root: &Path) -> MapPlan {
             let _ = std::fs::write(base_ast.join(".building"), b"");
             spawn_sync(root, plan == MapPlan::Build);
         }
-        MapPlan::SkipHome | MapPlan::SkipHub | MapPlan::Debounced => {}
+        MapPlan::SkipHome | MapPlan::SkipHub | MapPlan::SkipNeverMap(_) | MapPlan::Debounced => {}
     }
     plan
 }
@@ -158,6 +202,8 @@ pub enum RootPlan {
     Home,
     /// A user folder, a filesystem root, or a folder that holds other apps.
     Hub,
+    /// The cwd is, or sits under, a location a hook never maps.
+    NeverMap(&'static str),
     /// No source files under it yet. The Stop hook looks again every turn.
     Empty,
 }
@@ -175,6 +221,9 @@ pub struct RootFacts<'a> {
     /// That `.base` root directly contains other marked folders — a workspace
     /// of apps rather than an app.
     pub weak_is_hub: bool,
+    /// Why the cwd is off limits entirely (temp, a cache, `AppData`,
+    /// `node_modules`, the other OS's home), or `None`.
+    pub never: Option<&'static str>,
     /// cwd is home, a filesystem root, Desktop / Documents / Downloads /
     /// Pictures / Music / Videos / Public, or a cloud drive's root.
     pub user_folder: bool,
@@ -188,6 +237,10 @@ pub struct RootFacts<'a> {
 pub fn plan_root(f: &RootFacts<'_>) -> RootPlan {
     if f.home.is_some_and(|h| h == f.cwd) {
         return RootPlan::Home;
+    }
+    // Before the markers: a `.git` inside the temp dir is still the temp dir.
+    if let Some(why) = f.never {
+        return RootPlan::NeverMap(why);
     }
     if let Some(s) = f.strong {
         return RootPlan::Marked(s.to_path_buf());
@@ -224,6 +277,7 @@ pub fn session_root(cwd: &Path) -> RootPlan {
         strong: strong.as_deref(),
         weak: weak.as_deref(),
         weak_is_hub: weak.as_deref().is_some_and(has_child_apps),
+        never: never_map_reason(cwd),
         user_folder: is_user_folder(cwd, home),
         child_apps: has_child_apps(cwd),
         sources: has_code_files(cwd),
@@ -238,6 +292,13 @@ pub fn session_start_notice(cwd: &Path) -> Option<String> {
     let (root, adopted) = match session_root(cwd) {
         RootPlan::Marked(r) => (r, false),
         RootPlan::Adopt(r) => (r, true),
+        RootPlan::NeverMap(why) => {
+            return Some(format!(
+                "[AST] {} is never mapped ({why}) — no code map is built here. \
+                 Run `base sync --ast --target <path>` by hand if you really want one.",
+                cwd.display()
+            ));
+        }
         RootPlan::Home | RootPlan::Hub | RootPlan::Empty => return None,
     };
     let outcome = ensure_app_map(&root);
@@ -314,7 +375,7 @@ fn holds_apps(dir: &Path, depth: usize) -> bool {
             }
             let name = entry.file_name();
             let name = name.to_string_lossy();
-            if lvl + 1 < depth && !name.starts_with('.') && !NOISE_DIRS.contains(&name.as_ref()) {
+            if lvl + 1 < depth && !name.starts_with('.') && !is_noise_dir(&name) {
                 stack.push((path, lvl + 1));
             }
         }
@@ -336,6 +397,9 @@ pub fn first_contact(path: &Path) -> Option<MapPlan> {
 /// Same decisions as [`first_contact`]; only the spawn differs.
 pub fn first_contact_wait(path: &Path) -> Option<MapPlan> {
     let root = crate::config::ast_app_root(path)?;
+    if let Some(why) = never_map_reason(&root) {
+        return Some(MapPlan::SkipNeverMap(why));
+    }
     let base_ast = root.join(".base-ast");
     if base_ast.join("ast.ttl").is_file() {
         return None;
@@ -347,7 +411,7 @@ pub fn first_contact_wait(path: &Path) -> Option<MapPlan> {
     if recently(&base_ast.join(".building"), BUILD_LOCK_SECS) {
         return Some(MapPlan::Debounced);
     }
-    let plan = plan_map(&root, home.as_deref(), false, false);
+    let plan = plan_map(&root, home.as_deref(), None, false, false);
     if plan != MapPlan::Build {
         return Some(plan);
     }
@@ -474,6 +538,11 @@ pub fn delegate_wsl_contact(paths: &[String]) {
     };
     let _ = std::fs::create_dir_all(&dir);
     for p in paths {
+        // A Linux path the WSL base would refuse anyway: do not pay for a
+        // `wsl` process to be told no.
+        if never_map_reason(Path::new(p)).is_some() {
+            continue;
+        }
         let marker = dir.join(fingerprint(p));
         if recently(&marker, WSL_CONTACT_SECS) {
             continue;
@@ -575,6 +644,159 @@ fn same_dir(a: &Path, b: &Path) -> bool {
     norm(a) == norm(b)
 }
 
+/// A directory name that is never walked. Case-insensitive: Windows spells
+/// the same folder `Temp` and `temp`, `Build` and `build`, and "has code" here
+/// has to agree with "has files to extract" in `scripts/ast/detect.py`.
+pub fn is_noise_dir(name: &str) -> bool {
+    NOISE_DIRS.iter().any(|d| d.eq_ignore_ascii_case(name))
+}
+
+/// Why a hook never maps `root`, or `None` when it may.
+///
+/// Chris, 2026-09-03, after a hook spent thirty minutes extracting `%TEMP%`:
+/// "just make it not ast parse shit it obviously shouldn't." A root that IS or
+/// sits UNDER one of these is never built and never refreshed — an `ast.ttl`
+/// already inside one buys nothing, because a single bad adoption plants
+/// `.base-ast/` and would otherwise make itself permanent.
+///
+/// Deliberately NOT wired into [`crate::config::ast_app_root`]: resolution
+/// stays honest about which folder owns a path, and only the decision to build
+/// changes. An explicit `base sync --ast --target <path>` from a human still
+/// runs, with the extractor's own prompt.
+pub fn never_map_reason(root: &Path) -> Option<&'static str> {
+    never_map_reason_with(root, crate::home::isolation_active())
+}
+
+/// [`never_map_reason`] with the sandbox exemption as an explicit input, so
+/// both halves are testable from a test binary — which is itself isolated, and
+/// could otherwise never observe the temp rule it depends on.
+pub fn never_map_reason_with(root: &Path, isolated: bool) -> Option<&'static str> {
+    let parts = lower_components(root);
+
+    // Always armed, in tests too.
+    for (i, name) in parts.iter().enumerate() {
+        if let Some(&(_, why)) = NEVER_MAP_SEGMENTS.iter().find(|(n, _)| n == name) {
+            return Some(why);
+        }
+        if i > 0 && parts[i - 1] == "appdata" && APPDATA_CHILDREN.contains(&name.as_str()) {
+            return Some("a Windows AppData directory");
+        }
+    }
+    if is_foreign_home(&parts) {
+        return Some("the other OS's home directory");
+    }
+    if let Some(why) = under_any(root, &state_roots()) {
+        return Some(why);
+    }
+
+    // The system temp directory is also where every test builds its fixture
+    // workspaces, and `home::within_sandbox` already defines it as this
+    // process's sandbox. Disarm this half — and only this half — while
+    // isolated. `isolation_active` is off for every `cargo build` and
+    // `cargo run`, so production keeps the guard.
+    if isolated {
+        return None;
+    }
+    if parts.iter().any(|p| TEMP_SEGMENTS.contains(&p.as_str())) {
+        return Some("a temp directory");
+    }
+    under_any(root, &temp_roots())
+}
+
+/// `/mnt/c/Users/<name>` — a Windows home seen from a WSL hook, which its own
+/// `real_home()` (`/home/<user>`) cannot recognise, so `SkipHome` never fires.
+/// Matched EXACTLY, never as a prefix: real projects live under that home and
+/// must keep mapping normally.
+fn is_foreign_home(parts: &[String]) -> bool {
+    matches!(
+        parts,
+        [mnt, drive, users, _name]
+            if mnt == "mnt"
+                && users == "users"
+                && drive.len() == 1
+                && drive.chars().all(|c| c.is_ascii_alphabetic())
+    )
+}
+
+/// Caches and per-user state that hold no project of anyone's: never mapped,
+/// isolated process or not.
+fn state_roots() -> Vec<(PathBuf, &'static str)> {
+    let mut v: Vec<(PathBuf, &'static str)> = Vec::new();
+    if let Some(p) = dirs::cache_dir() {
+        v.push((p, "a cache directory"));
+    }
+    // Only on Windows: `dirs` maps these to `~/.config` and `~/.local/share`
+    // on Linux, which are not what `%APPDATA%` means and not on the list.
+    if cfg!(windows) {
+        for p in [dirs::config_dir(), dirs::data_dir(), dirs::data_local_dir()].into_iter().flatten() {
+            v.push((p, "a Windows AppData directory"));
+        }
+        for key in ["LOCALAPPDATA", "APPDATA"] {
+            if let Some(val) = std::env::var_os(key)
+                && !val.is_empty()
+            {
+                v.push((PathBuf::from(val), "a Windows AppData directory"));
+            }
+        }
+    }
+    if let Some(h) = crate::home::real_home() {
+        v.push((h.join(".cache"), "a cache directory"));
+        v.push((h.join(".claude"), "the Claude Code state directory"));
+        v.push((h.join(".base-gbl"), "base's own global tier"));
+    }
+    v
+}
+
+/// Every spelling of "the temp directory" this process can see.
+fn temp_roots() -> Vec<(PathBuf, &'static str)> {
+    let mut v: Vec<(PathBuf, &'static str)> = vec![(std::env::temp_dir(), "the OS temp directory")];
+    for key in ["TMPDIR", "TEMP", "TMP"] {
+        if let Some(val) = std::env::var_os(key)
+            && !val.is_empty()
+        {
+            v.push((PathBuf::from(val), "the OS temp directory"));
+        }
+    }
+    v.push((PathBuf::from("/tmp"), "the OS temp directory"));
+    v.push((PathBuf::from("/var/tmp"), "the OS temp directory"));
+    v
+}
+
+fn under_any(root: &Path, roots: &[(PathBuf, &'static str)]) -> Option<&'static str> {
+    roots.iter().find(|(anc, _)| is_under(root, anc)).map(|(_, why)| *why)
+}
+
+/// `root` is `anc` or sits inside it, compared at a component boundary so
+/// `/tmpfoo` is not under `/tmp`. Both sides are canonicalised when that
+/// succeeds — which is what makes `%TEMP%`'s 8.3 short form
+/// `C:\Users\CHRIS~1\AppData\Local\Temp` match the long spelling — and
+/// compared raw when it does not, since a candidate root need not exist yet.
+fn is_under(root: &Path, anc: &Path) -> bool {
+    let norm = |p: &Path| {
+        let real = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+        let s = real.to_string_lossy().replace('\\', "/");
+        let s = s.trim_end_matches('/').to_string();
+        if cfg!(windows) { s.to_lowercase() } else { s }
+    };
+    let (r, a) = (norm(root), norm(anc));
+    if a.is_empty() {
+        return false;
+    }
+    r == a || r.starts_with(&format!("{a}/"))
+}
+
+/// A path's normal components, lowercased. Case folding is unconditional: every
+/// name matched against them is either a canonical lowercase dot-directory or a
+/// Windows name, and no project is legitimately called `node_modules`.
+fn lower_components(p: &Path) -> Vec<String> {
+    p.components()
+        .filter_map(|c| match c {
+            Component::Normal(n) => Some(n.to_string_lossy().to_ascii_lowercase()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// At least one code file under `dir`, looking `PROBE_DEPTH` deep and at most
 /// `PROBE_ENTRIES` entries, skipping the noise directories. Bounded so a huge
 /// folder costs a few milliseconds, not a walk.
@@ -597,7 +819,7 @@ pub fn has_code_files(dir: &Path) -> bool {
             if ft.is_dir() {
                 let name = entry.file_name();
                 let name = name.to_string_lossy();
-                if depth + 1 < PROBE_DEPTH && !name.starts_with('.') && !NOISE_DIRS.contains(&name.as_ref()) {
+                if depth + 1 < PROBE_DEPTH && !name.starts_with('.') && !is_noise_dir(&name) {
                     stack.push((path, depth + 1));
                 }
             } else if ft.is_file()

--- a/src/hook/pre_tool_use.rs
+++ b/src/hook/pre_tool_use.rs
@@ -64,7 +64,9 @@ pub fn handle(
         let home = crate::home::home_root();
         for p in crate::hook::automap::bash_paths(cmd, cwd, home.as_deref()) {
             if p.exists() {
-                crate::hook::automap::first_contact(&p);
+                // Marked roots only — a `cd` through a folder is not the same
+                // choice as booting a session in it. See `bash_first_contact`.
+                crate::hook::automap::bash_first_contact(&p);
             }
         }
         crate::hook::automap::delegate_wsl_contact(&crate::hook::automap::linux_paths(cmd));

--- a/src/hook/user_prompt_submit.rs
+++ b/src/hook/user_prompt_submit.rs
@@ -439,7 +439,7 @@ fn ensure_domain_sync(config: &BaseConfig, cwd: &Path) {
                 let needs_sync = needs_sync_check(&domains_toml, &marker);
                 if needs_sync
                     && domain::sync::sync_domains_to_graph(config, &global_dir, None).is_ok() {
-                        let _ = std::fs::write(&marker, "");
+                        let _ = touch_sync_marker(&marker);
                     }
             }
         }
@@ -461,8 +461,20 @@ fn ensure_domain_sync(config: &BaseConfig, cwd: &Path) {
     let needs_sync = needs_sync_check(&domains_toml, &marker);
     if needs_sync
         && domain::sync::sync_domains_to_graph(config, cwd, None).is_ok() {
-            let _ = std::fs::write(&marker, "");
+            let _ = touch_sync_marker(&marker);
         }
+}
+
+/// Close the guard: the marker must land NEWER than `domains.toml` on every
+/// filesystem, and an empty write does not do that. On NTFS, `fs::write(path, "")`
+/// onto an existing empty file leaves LastWriteTime exactly where it was (measured
+/// 2026-09-03 with a compiled probe on a copy of a real marker; the guard had been
+/// open on that machine since June, costing two full graph rewrites per prompt).
+/// A non-empty write moves it everywhere. The content is the sync time, so the
+/// file also says when the last good sync ran.
+fn touch_sync_marker(marker: &Path) -> std::io::Result<()> {
+    let stamp = chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+    std::fs::write(marker, format!("{stamp}\n"))
 }
 
 /// Check if a domains.toml is newer than its sync marker. Pure and path-scoped

--- a/src/hook/user_prompt_submit.rs
+++ b/src/hook/user_prompt_submit.rs
@@ -465,8 +465,9 @@ fn ensure_domain_sync(config: &BaseConfig, cwd: &Path) {
         }
 }
 
-/// Check if a domains.toml is newer than its sync marker.
-fn needs_sync_check(domains_toml: &Path, marker: &Path) -> bool {
+/// Check if a domains.toml is newer than its sync marker. Pure and path-scoped
+/// (the test seam): `true` when the marker is missing or unreadable.
+pub fn needs_sync_check(domains_toml: &Path, marker: &Path) -> bool {
     if marker.exists() {
         match (
             std::fs::metadata(domains_toml).and_then(|m| m.modified()),

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -127,6 +127,9 @@ pub fn run(target: &Path) -> Result<()> {
             match crate::hook::automap::ensure_first_map(&root) {
                 Some(crate::hook::automap::MapPlan::Build) => println!("✓ building in the background → {}/.base-ast/", root.display()),
                 Some(crate::hook::automap::MapPlan::Debounced) => println!("✓ (build already in flight)"),
+                Some(crate::hook::automap::MapPlan::NeedsConfirm) => {
+                    println!("⊘ (too large to build unattended — see {}/.base-ast/.needs-confirm)", root.display())
+                }
                 None => println!("✓ (already mapped)"),
                 Some(_) => println!("⊘ (not an app folder)"),
             }

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -133,6 +133,7 @@ pub fn run(target: &Path) -> Result<()> {
         }
         crate::hook::automap::RootPlan::Hub => println!("⊘ (a workspace of apps — each app maps itself)"),
         crate::hook::automap::RootPlan::Home => println!("⊘ (home is never mapped)"),
+        crate::hook::automap::RootPlan::NeverMap(why) => println!("⊘ ({why} — never mapped)"),
         crate::hook::automap::RootPlan::Empty => println!("⊘ (no source files yet — the first session here maps it)"),
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -570,6 +570,40 @@ pub fn query_union(store: &Store, sparql: &str) -> Result<QueryResults> {
 /// that forgets to log is indistinguishable, to the reader, from no write at all;
 /// requiring it makes that a compile error instead of a silent gap.
 pub fn write_back(store: &Store, path: &Path, change: Change<'_>) -> Result<()> {
+    write_back_inner(store, path, change, |file| file, None)
+}
+
+/// `write_back` with its two failure paths exposed for tests: `wrap` sees the
+/// freshly created temp file before the serializer writes a byte (a sink that
+/// fails after K bytes is how a flush failure is provoked), and `validation_len`
+/// stands in for the validation store's quad count. Compiled only with the
+/// `isolation-guard` feature, which the self dev-dependency turns on for every
+/// test build and nothing turns on for `cargo build`. One implementation serves
+/// both entries; production passes the identity wrapper and `None`.
+#[cfg(feature = "isolation-guard")]
+pub fn write_back_seamed<W: Write>(
+    store: &Store,
+    path: &Path,
+    change: Change<'_>,
+    wrap: impl FnOnce(fs::File) -> W,
+    validation_len: Option<usize>,
+) -> Result<()> {
+    write_back_inner(store, path, change, wrap, validation_len)
+}
+
+/// Bytes the dump is buffered in before each write syscall. oxrdfio's serializer
+/// writes unbuffered — one syscall per term — and Windows charged ~9 s of kernel
+/// time per dump of a 13 MB graph for it. 1 MiB is thirteen syscalls for that
+/// file; the store it came from is already in memory many times over.
+const DUMP_BUFFER_BYTES: usize = 1 << 20;
+
+fn write_back_inner<W: Write>(
+    store: &Store,
+    path: &Path,
+    change: Change<'_>,
+    wrap: impl FnOnce(fs::File) -> W,
+    validation_len: Option<usize>,
+) -> Result<()> {
     crate::home::assert_isolated_write(path);
     let parent = path
         .parent()
@@ -610,29 +644,15 @@ pub fn write_back(store: &Store, path: &Path, change: Change<'_>) -> Result<()> 
         }
     }
 
-    let mut tmp_file = fs::File::create(&tmp_path)
+    let tmp_file = fs::File::create(&tmp_path)
         .with_context(|| format!("Failed to create temp file {}", tmp_path.display()))?;
 
-    store
-        .dump_to_writer(RdfSerializer::from_format(GRAPH_FORMAT), &mut tmp_file)
-        .context("Failed to serialize store to NQuads")?;
-
-    // Flush and close the file handle before validation.
-    drop(tmp_file);
-
-    // Validate: re-parse the written file to catch serializer corruption.
-    {
-        let check_file = fs::File::open(&tmp_path)
-            .with_context(|| format!("Failed to re-open {} for validation", tmp_path.display()))?;
-        let check_reader = BufReader::new(check_file);
-        let check_store = Store::new().context("Failed to create validation store")?;
-        if let Err(e) = check_store.load_from_reader(GRAPH_FORMAT, check_reader) {
-            let _ = fs::remove_file(&tmp_path);
-            anyhow::bail!(
-                "write_back validation failed — serializer produced invalid output, \
-                 original file preserved. Parse error: {e}"
-            );
-        }
+    // From here on the temp file exists, so every failure removes it before it
+    // surfaces: a temp cut short at a line boundary parses clean, and a stale one
+    // is a trap for the next reader. The original graph is never touched.
+    if let Err(e) = dump_and_validate(store, &tmp_path, wrap(tmp_file), validation_len) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
     }
 
     // Atomic rename
@@ -652,6 +672,60 @@ pub fn write_back(store: &Store, path: &Path, change: Change<'_>) -> Result<()> 
     // the log append: best-effort, after the write landed, never fatal.
     crate::doorbell::ring(path);
 
+    Ok(())
+}
+
+/// Dump the store into `sink` through a buffer, close it, and prove the file
+/// holds every quad. Any `Err` here means the temp file must not be trusted.
+fn dump_and_validate<W: Write>(
+    store: &Store,
+    tmp_path: &Path,
+    sink: W,
+    validation_len: Option<usize>,
+) -> Result<()> {
+    let mut writer = BufWriter::with_capacity(DUMP_BUFFER_BYTES, sink);
+    store
+        .dump_to_writer(RdfSerializer::from_format(GRAPH_FORMAT), &mut writer)
+        .context("Failed to serialize store to NQuads")?;
+    // An explicit flush, propagated: `BufWriter`'s Drop flushes too but swallows
+    // the error, and a swallowed flush error is the one way a short file gets past
+    // the parse below. `into_inner` cannot fail after a successful flush; it is
+    // here because it is the only way to get the file back without a Drop.
+    writer
+        .flush()
+        .with_context(|| format!("Failed to flush {}", tmp_path.display()))?;
+    let sink = writer
+        .into_inner()
+        .map_err(|e| e.into_error())
+        .with_context(|| format!("Failed to flush {}", tmp_path.display()))?;
+    // Close the file handle before validation.
+    drop(sink);
+
+    // Validate: re-parse the written file to catch serializer corruption.
+    let check_file = fs::File::open(tmp_path)
+        .with_context(|| format!("Failed to re-open {} for validation", tmp_path.display()))?;
+    let check_reader = BufReader::new(check_file);
+    let check_store = Store::new().context("Failed to create validation store")?;
+    if let Err(e) = check_store.load_from_reader(GRAPH_FORMAT, check_reader) {
+        anyhow::bail!(
+            "write_back validation failed — serializer produced invalid output, \
+             original file preserved. Parse error: {e}"
+        );
+    }
+
+    // And that it holds every quad: a file that parses clean but stops early is
+    // exactly what a lost flush error would leave behind.
+    let want = store.len().context("Failed to count the store's quads")?;
+    let got = match validation_len {
+        Some(n) => n,
+        None => check_store.len().context("Failed to count the written file's quads")?,
+    };
+    if got != want {
+        anyhow::bail!(
+            "write_back validation failed — the written file holds {got} quads but the \
+             store holds {want}, original file preserved"
+        );
+    }
     Ok(())
 }
 

--- a/tests/ast_automap_test.rs
+++ b/tests/ast_automap_test.rs
@@ -11,8 +11,8 @@
 use std::path::{Path, PathBuf};
 
 use base::hook::automap::{
-    bash_paths, ensure_first_map, is_noise_dir, linux_paths, never_map_reason_with, plan_root,
-    session_root, wsl_script, RootFacts, RootPlan,
+    bash_paths, ensure_first_map, is_noise_dir, linux_paths, measure_tree, never_map_reason_with,
+    plan_root, session_root, wsl_script, RootFacts, RootPlan,
 };
 use base::hook::stop::{plan_map, MapPlan};
 
@@ -336,4 +336,82 @@ fn noise_directories_match_whatever_the_case() {
     for name in ["src", "lib", "tests", "buildscripts", "tempo"] {
         assert!(!is_noise_dir(name), "{name} is not noise");
     }
+}
+
+
+/// The backstop for whatever the never-map list misses. Chris, 2026-09-03:
+/// "Base is set to automatically make graphs, this will blow up people's
+/// computers." A tree too big to extract unattended is not extracted at all —
+/// `--yes` from a hook cannot get past this, because the fuse decides before
+/// anything is spawned.
+#[test]
+fn a_tree_too_big_to_build_unattended_is_not_built() {
+    // SAFETY: single-process test env; every test in this crate tolerates it set.
+    unsafe { std::env::set_var("BASE_AST_NO_SPAWN", "1") };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let huge = home.join("dev").join("huge");
+    std::fs::create_dir_all(&huge).unwrap();
+    for i in 0..6_000 {
+        std::fs::write(huge.join(format!("m{i}.py")), "x = 1\n").unwrap();
+    }
+
+    base::home::with_thread_home(&home, || {
+        assert_eq!(ensure_first_map(&huge), Some(MapPlan::NeedsConfirm), "6,000 source files: ask first");
+
+        let note = std::fs::read_to_string(huge.join(".base-ast").join(".needs-confirm"))
+            .expect("the fuse records why");
+        assert!(note.contains("5000"), "the limit is named: {note}");
+        assert!(note.contains("source files"), "the counts are named: {note}");
+        assert!(
+            note.contains(&format!("base sync --ast --target {}", huge.display())),
+            "the exact command to run by hand is spelled out: {note}"
+        );
+
+        // Nothing was spawned and no build was recorded — the fuse decides
+        // ahead of every write `ensure_app_map` would otherwise make.
+        assert!(!huge.join(".base-ast").join(".last-sync").exists(), "no build was recorded");
+        assert!(!huge.join(".base-ast").join(".building").exists(), "no build lock was taken");
+
+        // A tripped fuse is believed rather than re-walked every turn.
+        assert_eq!(ensure_first_map(&huge), Some(MapPlan::NeedsConfirm));
+    });
+}
+
+/// The fuse measures what the extractor will actually read: noise directories
+/// and dot-directories skipped, nested marked apps left to their own maps.
+/// Otherwise a repo with a vendored `node_modules` would be fused off its map.
+#[test]
+fn the_fuse_measures_what_the_extractor_will_read() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = tmp.path().join("app");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    for i in 0..5 {
+        std::fs::write(app.join("src").join(format!("s{i}.rs")), "fn f() {}\n").unwrap();
+    }
+
+    let bare = measure_tree(&app);
+    assert_eq!(bare.sources, 5);
+    assert!(!bare.over_fuse());
+
+    // A vendored dependency tree does not count — the extractor never walks it.
+    std::fs::create_dir_all(app.join("node_modules").join("react")).unwrap();
+    for i in 0..50 {
+        std::fs::write(app.join("node_modules").join("react").join(format!("r{i}.js")), "1\n").unwrap();
+    }
+    // Nor does a nested repo, which keeps its own map.
+    let nested = app.join("vendored-repo");
+    std::fs::create_dir_all(nested.join(".git")).unwrap();
+    for i in 0..50 {
+        std::fs::write(nested.join(format!("n{i}.rs")), "fn g() {}\n").unwrap();
+    }
+    // Nor does a build directory, whatever its case.
+    std::fs::create_dir_all(app.join("Target")).unwrap();
+    for i in 0..50 {
+        std::fs::write(app.join("Target").join(format!("t{i}.rs")), "fn h() {}\n").unwrap();
+    }
+
+    let after = measure_tree(&app);
+    assert_eq!(after.sources, 5, "150 skipped files stayed out of the count");
 }

--- a/tests/ast_automap_test.rs
+++ b/tests/ast_automap_test.rs
@@ -11,8 +11,8 @@
 use std::path::{Path, PathBuf};
 
 use base::hook::automap::{
-    bash_paths, ensure_first_map, is_noise_dir, linux_paths, measure_tree, never_map_reason_with,
-    plan_root, session_root, wsl_script, RootFacts, RootPlan,
+    bash_first_contact, bash_paths, ensure_first_map, is_noise_dir, linux_paths, measure_tree,
+    never_map_reason_with, plan_root, session_root, wsl_script, RootFacts, RootPlan,
 };
 use base::hook::stop::{plan_map, MapPlan};
 
@@ -414,4 +414,46 @@ fn the_fuse_measures_what_the_extractor_will_read() {
 
     let after = measure_tree(&app);
     assert_eq!(after.sources, 5, "150 skipped files stayed out of the count");
+}
+
+
+/// A command's `cd` is transient; a session's cwd is a choice. Walking through
+/// an unmarked folder never adopts it — but booting a session in that same
+/// folder still does, because Chris's 2026-09-01 rule outranks this one.
+#[test]
+fn a_cd_never_adopts_an_unmarked_folder_but_a_session_cwd_still_does() {
+    // SAFETY: single-process test env; every test in this crate tolerates it set.
+    unsafe { std::env::set_var("BASE_AST_NO_SPAWN", "1") };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let loose = home.join("dev").join("passing-through");
+    std::fs::create_dir_all(&loose).unwrap();
+    std::fs::write(loose.join("main.py"), "x = 1\n").unwrap();
+
+    base::home::with_thread_home(&home, || {
+        // The path a `cd` names, exactly as pre-tool-use derives it.
+        let named = bash_paths(
+            &format!("cd {} && python main.py", loose.display()),
+            &home,
+            Some(&home),
+        );
+        assert_eq!(named, vec![loose.clone()], "the cd target is what gets contacted");
+
+        assert_eq!(bash_first_contact(&loose), None, "walking through it adopts nothing");
+        assert!(!loose.join(".base-ast").exists(), "…and leaves no marker behind");
+
+        // THE NEGATIVE CONTROL. The same folder, as the session's own cwd, is
+        // still adopted — this rule must not narrow session-start adoption.
+        assert_eq!(session_root(&loose), RootPlan::Adopt(loose.clone()));
+        assert_eq!(ensure_first_map(&loose), Some(MapPlan::Build));
+    });
+
+    // Once something marks it, a `cd` reaches it like any other app.
+    let marked = home.join("dev").join("real-repo");
+    std::fs::create_dir_all(marked.join(".git")).unwrap();
+    std::fs::write(marked.join("main.py"), "x = 1\n").unwrap();
+    base::home::with_thread_home(&home, || {
+        assert_eq!(bash_first_contact(&marked), Some(MapPlan::Build), "a marked repo is contacted normally");
+    });
 }

--- a/tests/ast_automap_test.rs
+++ b/tests/ast_automap_test.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 
 use base::hook::automap::{
     bash_first_contact, bash_paths, ensure_first_map, is_noise_dir, linux_paths, measure_tree,
-    never_map_reason_with, plan_root, session_root, wsl_script, RootFacts, RootPlan,
+    never_map_reason, plan_root, session_root, wsl_script, RootFacts, RootPlan,
 };
 use base::hook::stop::{plan_map, MapPlan};
 
@@ -215,13 +215,15 @@ fn wsl_commands_hand_their_linux_paths_over() {
 /// the other OS's home are never mapped — from any hook, marked or not.
 #[test]
 fn the_places_a_hook_never_maps() {
-    let why = |p: &str| never_map_reason_with(Path::new(p), false);
+    // Called with this process's REAL home, which is not under temp, so both
+    // halves are armed exactly as they are in production.
+    let why = |p: &str| never_map_reason(Path::new(p));
 
     // 1. The OS temp directory itself, and a path three levels under it.
     let tmp = std::env::temp_dir();
     assert!(why(&tmp.to_string_lossy()).is_some(), "the temp dir itself: {}", tmp.display());
     let deep = tmp.join("claude").join("sess").join("scratchpad");
-    assert!(never_map_reason_with(&deep, false).is_some(), "three levels under temp");
+    assert!(never_map_reason(&deep).is_some(), "three levels under temp");
     // The exact shape the 11:43 run walked, seen from a WSL hook — where not
     // one of %TEMP% / %TMP% / TMPDIR is set, so only the segment rule fires.
     assert_eq!(why("/mnt/c/Users/Chris/AppData/Local/Temp"), Some("a Windows AppData directory"));
@@ -257,23 +259,38 @@ fn the_places_a_hook_never_maps() {
     assert_eq!(why("/home/u/dev/Local/app"), None, "Local without AppData above it is a project");
 }
 
-/// The sandbox exemption, both directions. Every test in this suite builds its
-/// fixture workspace under the system temp dir, and `home::within_sandbox`
-/// already defines that dir as the sandbox — so the temp half, and only the
-/// temp half, stands down while isolated.
+/// The sandbox exemption, both directions. Every test here builds its fixture
+/// under the system temp dir, so the temp half has to stand down somewhere —
+/// but ONLY for a process whose home is itself redirected under temp. Keying it
+/// on the `isolation-guard` feature instead was the first attempt and was
+/// wrong: that feature reaches the ordinary binary through the crate's
+/// self-dev-dependency, and disarmed the guard in a plain `base` too.
 #[test]
-fn the_temp_rule_stands_down_inside_the_test_sandbox() {
+fn the_temp_rule_stands_down_only_inside_a_redirected_home() {
     let tmp = tempfile::tempdir().unwrap();
-    let app = tmp.path().join("home").join("dev").join("app");
+    let home = tmp.path().join("home");
+    let app = home.join("dev").join("app");
 
-    assert_eq!(never_map_reason_with(&app, true), None, "a fixture workspace is mappable while isolated");
-    assert!(never_map_reason_with(&app, false).is_some(), "…and never mappable in production");
+    // Outside any redirected home this process's home is the real one, so the
+    // guard is armed exactly as it is in a shipped binary.
+    assert!(never_map_reason(&app).is_some(), "a temp path is never mappable in production");
 
-    // The segment rules stay armed even in the sandbox: a node_modules inside
-    // a fixture is still a node_modules.
-    let vendored = app.join("node_modules").join("react");
-    assert_eq!(never_map_reason_with(&vendored, true), Some("a node_modules tree"));
-    assert_eq!(never_map_reason_with(&app.join(".claude"), true), Some("the Claude Code state directory"));
+    // Inside a home that has itself been redirected under temp, the temp half
+    // stands down so fixtures can be adopted — and nothing else does.
+    base::home::with_thread_home(&home, || {
+        assert_eq!(never_map_reason(&app), None, "a fixture inside the sandbox home is mappable");
+        assert_eq!(
+            never_map_reason(&app.join("node_modules").join("react")),
+            Some("a node_modules tree"),
+            "the segment rules stay armed in the sandbox too"
+        );
+        assert_eq!(never_map_reason(&app.join(".claude")), Some("the Claude Code state directory"));
+
+        // A temp path OUTSIDE the sandbox home is still refused, even from an
+        // isolated process: the exemption is this sandbox, not the temp dir.
+        let elsewhere = std::env::temp_dir().join("some-other-tree");
+        assert!(never_map_reason(&elsewhere).is_some(), "only this sandbox is exempt");
+    });
 }
 
 /// A map that already exists inside a never-mapped root buys nothing. This is
@@ -284,7 +301,7 @@ fn the_temp_rule_stands_down_inside_the_test_sandbox() {
 fn an_existing_map_inside_a_never_mapped_root_is_not_refreshed() {
     let home = Path::new("/home/u");
     let temp_app = Path::new("/mnt/c/Users/Chris/AppData/Local/Temp");
-    let never = never_map_reason_with(temp_app, false);
+    let never = never_map_reason(temp_app);
     assert!(never.is_some());
 
     assert_eq!(plan_map(temp_app, Some(home), never, false, false), MapPlan::SkipNeverMap("a Windows AppData directory"));

--- a/tests/ast_automap_test.rs
+++ b/tests/ast_automap_test.rs
@@ -293,6 +293,33 @@ fn the_temp_rule_stands_down_only_inside_a_redirected_home() {
     });
 }
 
+/// The Windows shape of the sandbox, on every platform: `%TEMP%` sits under
+/// `AppData\Local`, so a fixture's full path carries the `appdata`/`local`
+/// pair. That pair belongs to the sandbox, not the fixture, and must not refuse
+/// it — while the same pair, or any never-mapped segment, INSIDE the fixture
+/// still does. 5 of 13 tests in this file failed on the Windows mirror at
+/// b72703a for exactly this reason (2026-09-03); Linux never saw it.
+#[test]
+fn the_sandbox_exemption_covers_the_segments_the_sandbox_itself_sits_under() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("AppData").join("Local").join("Temp").join("sandbox-home");
+    let app = home.join("dev").join("app");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::write(app.join("src").join("main.py"), "def f():\n    pass\n").unwrap();
+
+    assert!(never_map_reason(&app).is_some(), "outside any sandbox the AppData segments refuse it");
+    base::home::with_thread_home(&home, || {
+        assert_eq!(never_map_reason(&app), None, "the sandbox's own AppData/Local/Temp segments do not count");
+        assert_eq!(
+            never_map_reason(&app.join("AppData").join("Local").join("x")),
+            Some("a Windows AppData directory"),
+            "the same pair inside the fixture still refuses"
+        );
+        assert_eq!(never_map_reason(&app.join("node_modules").join("react")), Some("a node_modules tree"));
+        assert_eq!(session_root(&app), RootPlan::Adopt(app.clone()), "and the fixture is adopted");
+    });
+}
+
 /// A map that already exists inside a never-mapped root buys nothing. This is
 /// the loop measured on this machine: the 11:43 run planted `.base-ast/` in
 /// `%TEMP%`, which made `ast_app_root` resolve every later temp path to Temp,

--- a/tests/ast_automap_test.rs
+++ b/tests/ast_automap_test.rs
@@ -10,7 +10,10 @@
 
 use std::path::{Path, PathBuf};
 
-use base::hook::automap::{bash_paths, ensure_first_map, linux_paths, plan_root, session_root, wsl_script, RootFacts, RootPlan};
+use base::hook::automap::{
+    bash_paths, ensure_first_map, is_noise_dir, linux_paths, never_map_reason_with, plan_root,
+    session_root, wsl_script, RootFacts, RootPlan,
+};
 use base::hook::stop::{plan_map, MapPlan};
 
 #[test]
@@ -18,18 +21,18 @@ fn first_contact_builds_then_refreshes_never_the_home_dir() {
     let home = Path::new("C:/Users/someone");
     let app = Path::new("C:/Users/someone/dev/app");
 
-    assert_eq!(plan_map(app, Some(home), false, false), MapPlan::Build, "no map yet → build it");
-    assert_eq!(plan_map(app, Some(home), true, false), MapPlan::Refresh, "map exists → refresh it");
-    assert_eq!(plan_map(app, Some(home), false, true), MapPlan::Debounced, "a sync just ran → wait");
-    assert_eq!(plan_map(app, Some(home), true, true), MapPlan::Debounced);
+    assert_eq!(plan_map(app, Some(home), None, false, false), MapPlan::Build, "no map yet → build it");
+    assert_eq!(plan_map(app, Some(home), None, true, false), MapPlan::Refresh, "map exists → refresh it");
+    assert_eq!(plan_map(app, Some(home), None, false, true), MapPlan::Debounced, "a sync just ran → wait");
+    assert_eq!(plan_map(app, Some(home), None, true, true), MapPlan::Debounced);
 
     // The home directory is an app root on this machine (it holds .base), and
     // mapping it would walk every project at once. Never, mapped or not.
-    assert_eq!(plan_map(home, Some(home), false, false), MapPlan::SkipHome);
-    assert_eq!(plan_map(home, Some(home), true, false), MapPlan::SkipHome);
+    assert_eq!(plan_map(home, Some(home), None, false, false), MapPlan::SkipHome);
+    assert_eq!(plan_map(home, Some(home), None, true, false), MapPlan::SkipHome);
 
     // No known home: nothing is special.
-    assert_eq!(plan_map(app, None, false, false), MapPlan::Build);
+    assert_eq!(plan_map(app, None, None, false, false), MapPlan::Build);
 }
 
 /// Which folder a session maps, one rule, every input explicit.
@@ -38,7 +41,7 @@ fn which_folder_is_the_app() {
     let home = Path::new("/home/u");
     let cwd = Path::new("/home/u/dev/app");
     let facts = |strong: Option<&Path>, weak: Option<&Path>, weak_is_hub, user_folder, child_apps, sources| {
-        plan_root(&RootFacts { cwd, home: Some(home), strong, weak, weak_is_hub, user_folder, child_apps, sources })
+        plan_root(&RootFacts { cwd, home: Some(home), strong, weak, weak_is_hub, never: None, user_folder, child_apps, sources })
     };
 
     // A repo maps at its root.
@@ -48,27 +51,27 @@ fn which_folder_is_the_app() {
     let repo = Path::new("/home/u/dev/mono");
     let pkg = Path::new("/home/u/dev/mono/packages/x");
     assert_eq!(
-        plan_root(&RootFacts { cwd: pkg, home: Some(home), strong: Some(repo), weak: None, weak_is_hub: false, user_folder: false, child_apps: false, sources: true }),
+        plan_root(&RootFacts { cwd: pkg, home: Some(home), strong: Some(repo), weak: None, weak_is_hub: false, never: None, user_folder: false, child_apps: false, sources: true }),
         RootPlan::Marked(repo.into())
     );
 
     // A `.base` workspace that is itself the app.
     let ws = Path::new("/home/u/dev/ws");
     assert_eq!(
-        plan_root(&RootFacts { cwd: ws, home: Some(home), strong: None, weak: Some(ws), weak_is_hub: false, user_folder: false, child_apps: false, sources: true }),
+        plan_root(&RootFacts { cwd: ws, home: Some(home), strong: None, weak: Some(ws), weak_is_hub: false, never: None, user_folder: false, child_apps: false, sources: true }),
         RootPlan::Marked(ws.into())
     );
 
     // A `.base` workspace that only holds repos: a hub, never mapped as one app.
     assert_eq!(
-        plan_root(&RootFacts { cwd: ws, home: Some(home), strong: None, weak: Some(ws), weak_is_hub: true, user_folder: false, child_apps: true, sources: true }),
+        plan_root(&RootFacts { cwd: ws, home: Some(home), strong: None, weak: Some(ws), weak_is_hub: true, never: None, user_folder: false, child_apps: true, sources: true }),
         RootPlan::Hub
     );
 
     // A bare folder inside that hub, with its own code: adopted on its own.
     let fresh = Path::new("/home/u/dev/ws/newapp");
     assert_eq!(
-        plan_root(&RootFacts { cwd: fresh, home: Some(home), strong: None, weak: Some(ws), weak_is_hub: true, user_folder: false, child_apps: false, sources: true }),
+        plan_root(&RootFacts { cwd: fresh, home: Some(home), strong: None, weak: Some(ws), weak_is_hub: true, never: None, user_folder: false, child_apps: false, sources: true }),
         RootPlan::Adopt(fresh.into())
     );
 
@@ -81,7 +84,7 @@ fn which_folder_is_the_app() {
 
     // Home, Documents, a folder of repos: never.
     assert_eq!(
-        plan_root(&RootFacts { cwd: home, home: Some(home), strong: None, weak: None, weak_is_hub: false, user_folder: true, child_apps: true, sources: true }),
+        plan_root(&RootFacts { cwd: home, home: Some(home), strong: None, weak: None, weak_is_hub: false, never: None, user_folder: true, child_apps: true, sources: true }),
         RootPlan::Home
     );
     assert_eq!(facts(None, None, false, true, false, true), RootPlan::Hub, "a user folder");
@@ -89,7 +92,7 @@ fn which_folder_is_the_app() {
 
     // Home is never an app even when nothing else is known about it.
     assert_eq!(
-        plan_root(&RootFacts { cwd: home, home: Some(home), strong: None, weak: None, weak_is_hub: false, user_folder: false, child_apps: false, sources: true }),
+        plan_root(&RootFacts { cwd: home, home: Some(home), strong: None, weak: None, weak_is_hub: false, never: None, user_folder: false, child_apps: false, sources: true }),
         RootPlan::Home
     );
 }
@@ -203,4 +206,134 @@ fn wsl_commands_hand_their_linux_paths_over() {
     // A tilde path reaches the WSL shell as "$HOME/…", where it expands; an absolute one is quoted as-is.
     assert!(wsl_script("~/ops-sys/toolbox/frameworks/kit").contains("ast ensure --wait \"$HOME/ops-sys/toolbox/frameworks/kit\""));
     assert!(wsl_script("/home/u/x.rs").contains("ast ensure --wait '/home/u/x.rs'"));
+}
+
+
+/// Chris, 2026-09-03, after a hook spent thirty minutes extracting `%TEMP%` at
+/// a third of a 16-core CPU: "just make it not ast parse shit it obviously
+/// shouldn't." The temp directory, the caches, `AppData`, `node_modules` and
+/// the other OS's home are never mapped — from any hook, marked or not.
+#[test]
+fn the_places_a_hook_never_maps() {
+    let why = |p: &str| never_map_reason_with(Path::new(p), false);
+
+    // 1. The OS temp directory itself, and a path three levels under it.
+    let tmp = std::env::temp_dir();
+    assert!(why(&tmp.to_string_lossy()).is_some(), "the temp dir itself: {}", tmp.display());
+    let deep = tmp.join("claude").join("sess").join("scratchpad");
+    assert!(never_map_reason_with(&deep, false).is_some(), "three levels under temp");
+    // The exact shape the 11:43 run walked, seen from a WSL hook — where not
+    // one of %TEMP% / %TMP% / TMPDIR is set, so only the segment rule fires.
+    assert_eq!(why("/mnt/c/Users/Chris/AppData/Local/Temp"), Some("a Windows AppData directory"));
+    assert_eq!(why("/mnt/c/Users/Chris/AppData/Local/Temp/claude/x"), Some("a Windows AppData directory"));
+
+    // 2. Caches, the Claude state dir, base's own global tier, node_modules.
+    //    Segment-matched, so these hold on Linux and Windows alike.
+    assert_eq!(why("/home/u/.cache/uv/wheels"), Some("a cache directory"));
+    assert_eq!(why("/home/u/.claude/skills/humanizer"), Some("the Claude Code state directory"));
+    assert_eq!(why("/home/u/.base-gbl/forks"), Some("base's own global tier"));
+    assert_eq!(why("/home/u/dev/app/node_modules/react"), Some("a node_modules tree"));
+    assert_eq!(why("C:/Users/Chris/AppData/Roaming/npm"), Some("a Windows AppData directory"));
+
+    // Case-insensitively, because Windows spells the same folder both ways.
+    assert!(why("/mnt/c/Users/Chris/appdata/local/temp").is_some());
+    assert!(why("/home/u/dev/app/NODE_MODULES/react").is_some());
+
+    // 1(b). The other OS's home: `/mnt/c/Users/<name>` is a Windows home seen
+    // from WSL, whose own real_home() is /home/<user>, so SkipHome never fires
+    // for it. Measured 2026-09-03: C:/Users/Chris/.base-ast/ast.ttl, 23.6 MB.
+    assert_eq!(why("/mnt/c/Users/Chris"), Some("the other OS's home directory"));
+    assert_eq!(why("/mnt/d/Users/someone"), Some("the other OS's home directory"));
+
+    // …matched EXACTLY. Real projects live under that home and still map.
+    assert_eq!(why("/mnt/c/Users/Chris/dev/app"), None, "a project under the Windows home still maps");
+    // …and the shape is not over-eager: /mnt/wsl and /mnt/c/Users are not homes.
+    assert_eq!(why("/mnt/wsl/Users/x"), None, "wsl is not a drive letter");
+    assert_eq!(why("/mnt/c/Users"), None, "the Users folder is not a home");
+
+    // Component boundaries: a folder whose name merely starts with a banned one.
+    assert_eq!(why("/home/u/dev/tmpfoo"), None, "/tmpfoo is not under /tmp");
+    assert_eq!(why("/home/u/dev/cache-server"), None);
+    assert_eq!(why("/home/u/dev/Local/app"), None, "Local without AppData above it is a project");
+}
+
+/// The sandbox exemption, both directions. Every test in this suite builds its
+/// fixture workspace under the system temp dir, and `home::within_sandbox`
+/// already defines that dir as the sandbox — so the temp half, and only the
+/// temp half, stands down while isolated.
+#[test]
+fn the_temp_rule_stands_down_inside_the_test_sandbox() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = tmp.path().join("home").join("dev").join("app");
+
+    assert_eq!(never_map_reason_with(&app, true), None, "a fixture workspace is mappable while isolated");
+    assert!(never_map_reason_with(&app, false).is_some(), "…and never mappable in production");
+
+    // The segment rules stay armed even in the sandbox: a node_modules inside
+    // a fixture is still a node_modules.
+    let vendored = app.join("node_modules").join("react");
+    assert_eq!(never_map_reason_with(&vendored, true), Some("a node_modules tree"));
+    assert_eq!(never_map_reason_with(&app.join(".claude"), true), Some("the Claude Code state directory"));
+}
+
+/// A map that already exists inside a never-mapped root buys nothing. This is
+/// the loop measured on this machine: the 11:43 run planted `.base-ast/` in
+/// `%TEMP%`, which made `ast_app_root` resolve every later temp path to Temp,
+/// which made every later hook refresh a thirty-minute extraction for ever.
+#[test]
+fn an_existing_map_inside_a_never_mapped_root_is_not_refreshed() {
+    let home = Path::new("/home/u");
+    let temp_app = Path::new("/mnt/c/Users/Chris/AppData/Local/Temp");
+    let never = never_map_reason_with(temp_app, false);
+    assert!(never.is_some());
+
+    assert_eq!(plan_map(temp_app, Some(home), never, false, false), MapPlan::SkipNeverMap("a Windows AppData directory"));
+    assert_eq!(
+        plan_map(temp_app, Some(home), never, true, false),
+        MapPlan::SkipNeverMap("a Windows AppData directory"),
+        "a landed ast.ttl does not license a refresh"
+    );
+
+    // The guard sits ahead of the debounce, so it cannot be raced open either.
+    assert_eq!(plan_map(temp_app, Some(home), never, true, true), MapPlan::SkipNeverMap("a Windows AppData directory"));
+
+    // …and an ordinary app is untouched by any of it.
+    let app = Path::new("/home/u/dev/app");
+    assert_eq!(plan_map(app, Some(home), None, false, false), MapPlan::Build);
+    assert_eq!(plan_map(app, Some(home), None, true, false), MapPlan::Refresh);
+}
+
+/// The negative control for the whole fork: an unmarked folder of source is
+/// still adopted. Chris's 2026-09-01 rule ("do not lock it to only scaffolded
+/// workspaces") outranks every guard added here.
+#[test]
+fn an_unmarked_folder_of_code_is_still_adopted() {
+    // SAFETY: single-process test env; every test in this crate tolerates it set.
+    unsafe { std::env::set_var("BASE_AST_NO_SPAWN", "1") };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let app = home.join("dev").join("scratch-app");
+    std::fs::create_dir_all(&app).unwrap();
+    for i in 0..40 {
+        std::fs::write(app.join(format!("m{i}.py")), "x = 1\n").unwrap();
+    }
+
+    base::home::with_thread_home(&home, || {
+        assert_eq!(session_root(&app), RootPlan::Adopt(app.clone()), "no .git, no .base: still an app");
+        assert_eq!(ensure_first_map(&app), Some(MapPlan::Build), "40 files, well under any fuse");
+    });
+}
+
+/// Windows spells the same folder `Temp` and `temp`, `Build` and `build`. "Has
+/// code" here has to agree with "has files to extract" in detect.py, which
+/// lowercases the name before its own lookup.
+#[test]
+fn noise_directories_match_whatever_the_case() {
+    for name in ["node_modules", "NODE_MODULES", "Node_Modules", "temp", "Temp", "TEMP", "build", "Build", "target", "Target", ".Cache"] {
+        assert!(is_noise_dir(name), "{name} is noise");
+    }
+    for name in ["src", "lib", "tests", "buildscripts", "tempo"] {
+        assert!(!is_noise_dir(name), "{name} is not noise");
+    }
 }

--- a/tests/domain_sync_marker_test.rs
+++ b/tests/domain_sync_marker_test.rs
@@ -1,0 +1,203 @@
+//! The domain-sync guard: `domains.toml` is synced into the graph only when it
+//! is newer than `.domain-sync-ts`, and a good sync must leave the marker NEWER
+//! than the toml — on every filesystem.
+//!
+//! The regression this file exists for: the marker used to be "touched" with an
+//! empty write. On NTFS, `fs::write(path, "")` onto an existing empty file does
+//! not move LastWriteTime at all (measured 2026-09-03 with a compiled probe on a
+//! copy of a real marker), so once a `domains.toml` edit opened the guard it
+//! never closed again, and every prompt paid a full rewrite of both graphs. ext4
+//! bumps mtime on that call, which is why the Linux suite never saw it — the
+//! `existing_empty_marker` test below is the one that fails on Windows with the
+//! old code and passes with the new.
+//!
+//! Every tier is built inside the test's tempdir under `with_thread_home`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use base::config::BaseConfig;
+use base::hook::user_prompt_submit::{self, needs_sync_check};
+
+const NEW_RULE: &str = "NEW-RULE-7f3a reached the graph";
+
+fn domains_toml(extra_rule: Option<&str>) -> String {
+    let mut rules = vec!["\"Markertest rule one\"".to_string()];
+    if let Some(r) = extra_rule {
+        rules.push(format!("\"{r}\""));
+    }
+    format!(
+        "[[domain]]\nname = \"markertest\"\nmode = \"triggered\"\nkeywords = [\"markertest\"]\nrules = [{}]\n",
+        rules.join(", ")
+    )
+}
+
+/// Both tiers, the shape `ensure_domain_sync` walks: `<home>/.base-gbl/{domains.toml,.base/}`
+/// and `<home>/proj/.base/domains.toml`. Returns (global .base dir, workspace root).
+fn tiers(home: &Path) -> (PathBuf, PathBuf) {
+    let global = home.join(".base-gbl");
+    fs::create_dir_all(global.join(".base")).unwrap();
+    fs::write(global.join("domains.toml"), domains_toml(None)).unwrap();
+    let ws = home.join("proj");
+    fs::create_dir_all(ws.join(".base")).unwrap();
+    fs::write(ws.join(".base").join("domains.toml"), domains_toml(None)).unwrap();
+    (global.join(".base"), ws)
+}
+
+fn mtime(p: &Path) -> SystemTime {
+    fs::metadata(p).unwrap().modified().unwrap()
+}
+
+fn set_mtime(p: &Path, t: SystemTime) {
+    fs::File::options().write(true).open(p).unwrap().set_modified(t).unwrap();
+}
+
+fn ago(secs: u64) -> SystemTime {
+    SystemTime::now() - Duration::from_secs(secs)
+}
+
+/// (toml, marker) for a tier's `.base` dir — global: toml sits one level up.
+fn global_pair(global_base: &Path) -> (PathBuf, PathBuf) {
+    (global_base.parent().unwrap().join("domains.toml"), global_base.join(".domain-sync-ts"))
+}
+fn ws_pair(ws: &Path) -> (PathBuf, PathBuf) {
+    (ws.join(".base").join("domains.toml"), ws.join(".base").join(".domain-sync-ts"))
+}
+
+fn graph_state(base_dir: &Path) -> (Vec<u8>, SystemTime, usize) {
+    let g = base_dir.join("graph.nq");
+    let log = base_dir.join("changes.jsonl");
+    let lines = fs::read_to_string(&log).map(|s| s.lines().filter(|l| !l.trim().is_empty()).count()).unwrap_or(0);
+    (fs::read(&g).unwrap(), mtime(&g), lines)
+}
+
+fn rule_texts(ws: &Path, config: &BaseConfig) -> Vec<String> {
+    let ns = &config.namespace;
+    let p = &ns.prefix;
+    let domain_iri = format!("{}domain/markertest", ns.uri);
+    let results = base::crud::load_and_query(
+        ws,
+        ns,
+        &format!("SELECT ?text WHERE {{ GRAPH ?g {{ <{domain_iri}> {p}:hasRule ?r . ?r {p}:ruleText ?text }} }}"),
+    )
+    .unwrap();
+    let oxigraph::sparql::QueryResults::Solutions(solutions) = results else {
+        panic!("expected solutions");
+    };
+    solutions
+        .filter_map(|r| r.ok())
+        .filter_map(|row| {
+            row.get("text").map(|t| match oxigraph::model::TermRef::from(t) {
+                oxigraph::model::TermRef::Literal(l) => l.value().to_string(),
+                _ => String::new(),
+            })
+        })
+        .collect()
+}
+
+// ─── (1) a sync closes the guard on both tiers ───────────────
+
+#[test]
+fn a_sync_closes_the_guard_on_both_tiers_and_the_marker_says_when() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let (global_base, ws) = tiers(tmp.path());
+        let config = BaseConfig::default();
+        let (gt, gm) = global_pair(&global_base);
+        let (wt, wm) = ws_pair(&ws);
+        assert!(needs_sync_check(&gt, &gm) && needs_sync_check(&wt, &wm), "precondition: no marker, guard open");
+
+        user_prompt_submit::ensure_domain_sync_pub(&config, &ws);
+
+        for (toml, marker) in [(&gt, &gm), (&wt, &wm)] {
+            assert!(marker.exists(), "sync writes {}", marker.display());
+            assert!(mtime(marker) > mtime(toml), "the marker must land newer than domains.toml: {}", marker.display());
+            assert!(!needs_sync_check(toml, marker), "the guard is closed after a good sync");
+            let content = fs::read_to_string(marker).unwrap();
+            chrono::DateTime::parse_from_rfc3339(content.trim())
+                .unwrap_or_else(|e| panic!("the marker carries the sync time as RFC 3339, got {content:?}: {e}"));
+        }
+    });
+}
+
+// ─── (2) the NTFS regression: an existing empty marker ───────
+
+#[test]
+fn an_existing_empty_marker_older_than_domains_toml_is_closed_by_the_next_sync() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let (global_base, ws) = tiers(tmp.path());
+        let config = BaseConfig::default();
+        let pairs = [global_pair(&global_base), ws_pair(&ws)];
+        // Exactly the state found on the operator's machine: a 0-byte marker from
+        // a sync months ago, and a domains.toml edited since.
+        for (toml, marker) in &pairs {
+            fs::write(marker, "").unwrap();
+            set_mtime(marker, ago(10_000));
+            set_mtime(toml, ago(5_000));
+            assert!(needs_sync_check(toml, marker), "precondition: the guard is open");
+        }
+
+        user_prompt_submit::ensure_domain_sync_pub(&config, &ws);
+
+        for (toml, marker) in &pairs {
+            assert!(
+                mtime(marker) > mtime(toml),
+                "an existing empty marker must still move past domains.toml (NTFS leaves an empty rewrite's mtime untouched): {}",
+                marker.display()
+            );
+            assert!(!needs_sync_check(toml, marker), "the guard closes: {}", marker.display());
+        }
+    });
+}
+
+// ─── (3) a closed guard writes nothing ───────────────────────
+
+#[test]
+fn a_second_call_with_the_guard_closed_writes_no_graph_and_no_record() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let (global_base, ws) = tiers(tmp.path());
+        let config = BaseConfig::default();
+        user_prompt_submit::ensure_domain_sync_pub(&config, &ws);
+        let before = [graph_state(&global_base), graph_state(&ws.join(".base"))];
+        assert!(before.iter().all(|(_, _, lines)| *lines == 1), "precondition: one sync record per tier");
+
+        user_prompt_submit::ensure_domain_sync_pub(&config, &ws);
+
+        let after = [graph_state(&global_base), graph_state(&ws.join(".base"))];
+        assert_eq!(before, after, "bytes, mtime and changelog length all unchanged on both tiers");
+    });
+}
+
+// ─── (4) an edit reopens the guard and the new rule lands ────
+
+#[test]
+fn editing_domains_toml_reopens_the_guard_and_the_new_rule_reaches_the_graph() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let (_global_base, ws) = tiers(tmp.path());
+        let config = BaseConfig::default();
+        user_prompt_submit::ensure_domain_sync_pub(&config, &ws);
+        let (wt, wm) = ws_pair(&ws);
+        assert!(!needs_sync_check(&wt, &wm), "precondition: closed");
+        assert!(!rule_texts(&ws, &config).iter().any(|t| t == NEW_RULE), "precondition: the rule is not there yet");
+
+        // The sync happened a minute ago; the operator edits domains.toml now.
+        set_mtime(&wm, ago(60));
+        fs::write(&wt, domains_toml(Some(NEW_RULE))).unwrap();
+        assert!(needs_sync_check(&wt, &wm), "an edit reopens the guard");
+
+        // The next prompt: the hook syncs before it loads the graph it injects from.
+        let event = serde_json::json!({ "prompt": "markertest please" });
+        user_prompt_submit::handle(&config, &ws, &event).unwrap();
+
+        assert!(
+            rule_texts(&ws, &config).iter().any(|t| t == NEW_RULE),
+            "the new rule is in the graph the prompt injection reads from"
+        );
+        assert!(mtime(&wm) > mtime(&wt), "and the guard is closed again");
+        assert!(!needs_sync_check(&wt, &wm));
+    });
+}

--- a/tests/write_back_test.rs
+++ b/tests/write_back_test.rs
@@ -1,0 +1,173 @@
+//! `store::write_back` is the one function every graph write funnels through.
+//! These tests pin what it must keep true while its dump is being buffered:
+//! N quads in, N quads on disk; the bytes are the serializer's bytes; the
+//! per-pid temp file is cleaned up the way it always was; one write, one
+//! changelog record.
+//!
+//! Every path lives in the test's own tempdir. The `isolation-guard` feature
+//! arms `home::assert_isolated_write`, so a write that escaped would panic.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use base::changelog::{Change, LOG_FILE};
+use base::store;
+use oxigraph::io::{RdfFormat, RdfSerializer};
+use oxigraph::model::{GraphName, Literal, NamedNode, Quad};
+use oxigraph::store::Store;
+
+/// A store holding exactly `n` distinct quads in one named graph.
+fn store_with(n: usize) -> Store {
+    let store = Store::new().unwrap();
+    let p = NamedNode::new("http://test.local/p").unwrap();
+    let g = GraphName::NamedNode(NamedNode::new("http://test.local/g").unwrap());
+    for i in 0..n {
+        let s = NamedNode::new(format!("http://test.local/s/{i}")).unwrap();
+        store
+            .insert(&Quad::new(s, p.clone(), Literal::new_simple_literal(format!("v{i}")), g.clone()))
+            .unwrap();
+    }
+    assert_eq!(store.len().unwrap(), n, "fixture must hold exactly n quads");
+    store
+}
+
+/// `<root>/ws/.base/graph.nq`, with the directory made — the shape of a real tier.
+fn graph_path(root: &Path) -> PathBuf {
+    let base = root.join("ws").join(".base");
+    fs::create_dir_all(&base).unwrap();
+    base.join("graph.nq")
+}
+
+fn tmp_files(dir: &Path) -> Vec<String> {
+    let mut out: Vec<String> = fs::read_dir(dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.contains(".nq.tmp."))
+        .collect();
+    out.sort();
+    out
+}
+
+fn log_lines(graph: &Path) -> usize {
+    let log = graph.with_file_name(LOG_FILE);
+    if !log.exists() {
+        return 0;
+    }
+    fs::read_to_string(log).unwrap().lines().filter(|l| !l.trim().is_empty()).count()
+}
+
+/// What the serializer emits with no buffering in the way: the reference bytes.
+fn raw_dump(store: &Store) -> Vec<u8> {
+    store
+        .dump_to_writer(RdfSerializer::from_format(RdfFormat::NQuads), Vec::new())
+        .unwrap()
+}
+
+// ─── N in, N out ─────────────────────────────────────────────
+
+fn round_trips(n: usize) {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    let store = store_with(n);
+
+    store::write_back(&store, &path, Change::Op("test.round-trip")).unwrap();
+
+    let reloaded = store::load_graph(&path).unwrap();
+    assert_eq!(reloaded.len().unwrap(), n, "{n} quads written must parse back as {n} quads");
+    let lines = fs::read_to_string(&path).unwrap().lines().filter(|l| !l.trim().is_empty()).count();
+    assert_eq!(lines, n, "N-Quads is one quad per line, so {n} quads is {n} non-empty lines");
+    assert!(tmp_files(path.parent().unwrap()).is_empty(), "a completed write leaves no temp file");
+}
+
+#[test]
+fn write_back_round_trips_an_empty_store() {
+    round_trips(0);
+}
+
+#[test]
+fn write_back_round_trips_one_quad() {
+    round_trips(1);
+}
+
+#[test]
+fn write_back_round_trips_a_thousand_quads() {
+    round_trips(1_000);
+}
+
+#[test]
+fn write_back_round_trips_sixty_thousand_quads() {
+    round_trips(60_000);
+}
+
+// ─── the bytes are the serializer's bytes ───────────────────
+
+#[test]
+fn the_written_file_is_byte_identical_to_the_raw_serializer_output() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    let store = store_with(60_000);
+
+    store::write_back(&store, &path, Change::Op("test.bytes")).unwrap();
+
+    let on_disk = fs::read(&path).unwrap();
+    let reference = raw_dump(&store);
+    assert!(!reference.is_empty(), "precondition: the reference dump has content");
+    assert_eq!(on_disk.len(), reference.len(), "same length before comparing content");
+    assert!(on_disk == reference, "the file on disk must be exactly what the serializer emitted");
+}
+
+// ─── the temp-file contract, pinned ──────────────────────────
+
+#[test]
+fn a_stale_temp_file_is_reaped_and_a_fresh_one_is_left_alone() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    let dir = path.parent().unwrap();
+
+    let stale = dir.join("graph.nq.tmp.999");
+    fs::write(&stale, "stale").unwrap();
+    fs::File::options()
+        .write(true)
+        .open(&stale)
+        .unwrap()
+        .set_modified(SystemTime::now() - Duration::from_secs(120))
+        .unwrap();
+    let fresh = dir.join("graph.nq.tmp.998");
+    fs::write(&fresh, "fresh").unwrap();
+
+    store::write_back(&store_with(3), &path, Change::Op("test.sweep")).unwrap();
+
+    assert_eq!(
+        tmp_files(dir),
+        vec!["graph.nq.tmp.998".to_string()],
+        "the 60 s rule: older temps are reaped, a live writer's temp is never touched"
+    );
+}
+
+#[test]
+fn a_rewrite_replaces_the_previous_file_completely() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+
+    store::write_back(&store_with(1_000), &path, Change::Op("test.first")).unwrap();
+    store::write_back(&store_with(5), &path, Change::Op("test.second")).unwrap();
+
+    assert_eq!(store::load_graph(&path).unwrap().len().unwrap(), 5, "the second write wins in full");
+    assert_eq!(fs::read(&path).unwrap(), raw_dump(&store_with(5)));
+}
+
+// ─── one write, one record ───────────────────────────────────
+
+#[test]
+fn every_write_appends_exactly_one_changelog_record() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+
+    assert_eq!(log_lines(&path), 0);
+    store::write_back(&store_with(2), &path, Change::Op("test.log-1")).unwrap();
+    assert_eq!(log_lines(&path), 1);
+    store::write_back(&store_with(2), &path, Change::Op("test.log-2")).unwrap();
+    assert_eq!(log_lines(&path), 2);
+}

--- a/tests/write_back_test.rs
+++ b/tests/write_back_test.rs
@@ -171,3 +171,122 @@ fn every_write_appends_exactly_one_changelog_record() {
     store::write_back(&store_with(2), &path, Change::Op("test.log-2")).unwrap();
     assert_eq!(log_lines(&path), 2);
 }
+
+// ─── the failure paths: an error is an error, the original survives ─────────
+
+/// A sink that accepts `limit` bytes and then fails every write — a full disk,
+/// a yanked drive, a permission that vanished mid-dump.
+struct FailAfter<W: std::io::Write> {
+    inner: W,
+    left: usize,
+}
+
+impl<W: std::io::Write> std::io::Write for FailAfter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.left == 0 {
+            return Err(std::io::Error::other("sink failed after its byte budget"));
+        }
+        let n = buf.len().min(self.left);
+        let n = self.inner.write(&buf[..n])?;
+        self.left -= n;
+        Ok(n)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// A seeded graph on disk: (path, its bytes, its mtime, its changelog length).
+fn seeded(root: &Path) -> (PathBuf, Vec<u8>, SystemTime, usize) {
+    let path = graph_path(root);
+    store::write_back(&store_with(200), &path, Change::Op("test.seed")).unwrap();
+    let bytes = fs::read(&path).unwrap();
+    let mtime = fs::metadata(&path).unwrap().modified().unwrap();
+    (path.clone(), bytes, mtime, log_lines(&path))
+}
+
+fn assert_original_survived(path: &Path, bytes: &[u8], mtime: SystemTime, log: usize, what: &str) {
+    assert_eq!(fs::read(path).unwrap(), bytes, "{what}: the original file is byte-identical");
+    assert_eq!(fs::metadata(path).unwrap().modified().unwrap(), mtime, "{what}: the original file was not rewritten");
+    assert!(tmp_files(path.parent().unwrap()).is_empty(), "{what}: no temp file is left behind");
+    assert_eq!(log_lines(path), log, "{what}: nothing was logged for a write that did not land");
+}
+
+#[test]
+fn a_sink_that_fails_mid_dump_is_an_error_and_the_original_survives() {
+    // 0: the very first write fails. 4096: inside the first buffer flush.
+    // 1 MiB + 17: the second buffer flush, past the first full chunk.
+    for limit in [0usize, 4096, (1 << 20) + 17] {
+        let root = tempfile::tempdir().unwrap();
+        let (path, bytes, mtime, log) = seeded(root.path());
+        let big = store_with(60_000); // ~3.6 MB of N-Quads, several buffer flushes
+
+        let result = store::write_back_seamed(
+            &big,
+            &path,
+            Change::Op("test.fail"),
+            |file| FailAfter { inner: file, left: limit },
+            None,
+        );
+
+        let err = result.expect_err("a failed write must surface as an error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("sink failed after its byte budget"), "the sink's own error is in the chain, got: {msg}");
+        assert_original_survived(&path, &bytes, mtime, log, &format!("limit={limit}"));
+    }
+}
+
+#[test]
+fn a_flush_failure_after_a_clean_dump_is_an_error_and_the_original_survives() {
+    // The dump fits the 1 MiB buffer entirely, so the sink sees its first byte —
+    // and fails — only at the explicit flush. This is the "tmp cut at a line
+    // boundary parses clean" case the buffer must not be allowed to hide.
+    let root = tempfile::tempdir().unwrap();
+    let (path, bytes, mtime, log) = seeded(root.path());
+
+    let result = store::write_back_seamed(
+        &store_with(1_000),
+        &path,
+        Change::Op("test.flush"),
+        |file| FailAfter { inner: file, left: 0 },
+        None,
+    );
+
+    let msg = format!("{:#}", result.expect_err("the flush error must propagate"));
+    assert!(msg.contains("Failed to flush"), "the flush step names itself, got: {msg}");
+    assert_original_survived(&path, &bytes, mtime, log, "flush");
+}
+
+#[test]
+fn a_quad_count_mismatch_is_an_error_naming_both_counts_and_the_original_survives() {
+    let root = tempfile::tempdir().unwrap();
+    let (path, bytes, mtime, log) = seeded(root.path());
+
+    let result = store::write_back_seamed(&store_with(1_000), &path, Change::Op("test.count"), |file| file, Some(999));
+
+    let msg = format!("{:#}", result.expect_err("a short file must not be renamed into place"));
+    assert!(msg.contains("999") && msg.contains("1000"), "both counts are named, got: {msg}");
+    assert_original_survived(&path, &bytes, mtime, log, "count");
+}
+
+#[test]
+fn the_seam_with_no_injection_behaves_exactly_like_write_back() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    store::write_back_seamed(&store_with(1_000), &path, Change::Op("test.identity"), |file| file, None).unwrap();
+    assert_eq!(fs::read(&path).unwrap(), raw_dump(&store_with(1_000)));
+    assert_eq!(log_lines(&path), 1);
+}
+
+// ─── Q4: what the count costs ────────────────────────────────
+
+#[test]
+#[ignore = "measurement, run with --ignored; prints Store::len() cost on 60k quads"]
+fn measure_store_len_cost_on_sixty_thousand_quads() {
+    let store = store_with(60_000);
+    let t = std::time::Instant::now();
+    let n = store.len().unwrap();
+    let elapsed = t.elapsed();
+    println!("Store::len() on {n} quads: {elapsed:?}");
+    assert_eq!(n, 60_000);
+}


### PR DESCRIPTION
Closes #31. Closes #32.

**What changes for a user.** Two things they feel on every prompt.

1. **The write path stops eating the CPU.** Every graph write serialised through an unbuffered writer, one syscall per term (6.11 s of kernel time per write on NTFS), and the domain-sync marker was "touched" with a zero-byte write that NTFS never re-stamps, so the guard never closed and every prompt re-synced both tiers (14.27 s per prompt hook). The dump now goes through a 1 MiB buffer with the flush propagated and the quad count checked, the temp file is removed on every error path, and the marker carries an RFC 3339 timestamp. Measured on copies of the real graphs: write 6.11 s → 0.06 s, prompt hook 14.27 s → 0.14 s, and a second prompt on an unchanged `domains.toml` rewrites nothing. (#31)

2. **The AST auto-mapper never adopts the temp directory again.** Temp, caches, `AppData`, `node_modules` and the other OS's home are never mapped, mapped or not; a shell `cd` never adopts an unmarked folder (a session's own cwd and a first edit still do); a tree above the size fuse asks before any unattended build; noise directories match case-insensitively. The temp exemption is keyed on a redirected home (the test sandbox), never on a compile-time feature. (#32)

Plus the Windows-only test defect that followed from 2: the sandbox exemption now reads only the path below the redirected home, so a fixture under `AppData\Local\Temp` is not refused as "a Windows AppData directory". 5 of 13 automap tests failed on Windows at b72703a for that reason; a new test reproduces the shape on every platform.

**Verified.** WSL full suite green; Windows mirror full suite green after the sandbox fix (both runs recorded in the fork docs `base-write-back-bufwriter-and-sync-marker` and `base-automap-temp-guard`). Beyond the suites, for the write path: round trips of both real graphs under an independent parser, 90 crash kills mid-write, 8×20 concurrent writers, a full-disk run under RLIMIT, and a 21-prompt dogfood, originals never touched.

**Merge as a rebase**, not a squash: `CHANGELOG.md` is generated from the commit subjects between tags, and these nine subjects are the entry.

https://claude.ai/code/session_01VMzLN9woGG8xxbQcVX2fj8
