### PR TITLE
fix(rule): the listing counts up too, and a test that fails on the old code

### DIFF
--- a/src/crud/rule.rs
+++ b/src/crud/rule.rs
@@ -69,7 +69,13 @@ pub fn add(
 }
 
 /// List rules for a domain from the graph.
-pub fn list(cwd: &Path, ns: &NamespaceConfig, domain_name: &str) -> Result<()> {
+/// A domain's CLI rules, lowest number first.
+///
+/// Ordered by the number rather than by its text: `ORDER BY ?pri` compares
+/// `"10"` against `"2"` as strings and puts the eleventh rule second. Same
+/// comparison that gave every rule past the tenth the index 10 (#29), one query
+/// further on, so it outlived that fix and is pinned by `rule_index_test`.
+pub fn fetch(cwd: &Path, ns: &NamespaceConfig, domain_name: &str) -> Result<Vec<(u32, String)>> {
     let p = &ns.prefix;
     let domain_slug = crud::slugify(domain_name);
     let domain_iri = crud::build_iri(ns, "domain", &domain_slug);
@@ -82,29 +88,36 @@ pub fn list(cwd: &Path, ns: &NamespaceConfig, domain_name: &str) -> Result<()> {
              OPTIONAL {{ ?rule {p}:priority ?pri }}\n\
            }}\n\
          }}\n\
-         ORDER BY ?pri"
+         ORDER BY xsd:integer(?pri)"
     );
 
-    let results = crud::load_and_query(cwd, ns, &sparql)?;
-    if let QueryResults::Solutions(solutions) = results {
-        let rules: Vec<(String, String)> = solutions
-            .filter_map(|r| r.ok())
-            .filter_map(|row| {
-                let text = row.get("text").map(|t| crud::term_display(t.into()))?;
-                let pri = row.get("pri").map(|t| crud::term_display(t.into())).unwrap_or_default();
-                Some((pri, text))
-            })
-            .collect();
+    let QueryResults::Solutions(solutions) = crud::load_and_query(cwd, ns, &sparql)? else {
+        return Ok(Vec::new());
+    };
+    Ok(solutions
+        .filter_map(|r| r.ok())
+        .filter_map(|row| {
+            let text = row.get("text").map(|t| crud::term_display(t.into()))?;
+            let pri = row
+                .get("pri")
+                .map(|t| crud::term_display(t.into()))
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            Some((pri, text))
+        })
+        .collect())
+}
 
-        if rules.is_empty() {
-            println!("No rules for domain '{domain_name}'.");
-            return Ok(());
-        }
+pub fn list(cwd: &Path, ns: &NamespaceConfig, domain_name: &str) -> Result<()> {
+    let rules = fetch(cwd, ns, domain_name)?;
+    if rules.is_empty() {
+        println!("No rules for domain '{domain_name}'.");
+        return Ok(());
+    }
 
-        println!("[{domain_name}] {} rules:", rules.len());
-        for (pri, text) in &rules {
-            println!("  {pri}. {text}");
-        }
+    println!("[{domain_name}] {} rules:", rules.len());
+    for (pri, text) in &rules {
+        println!("  {pri}. {text}");
     }
     Ok(())
 }
@@ -145,8 +158,7 @@ pub fn remove(cwd: &Path, ns: &NamespaceConfig, domain_name: &str, index: u32) -
 fn next_rule_index(cwd: &Path, ns: &NamespaceConfig, domain_iri: &str) -> Result<u32> {
     let p = &ns.prefix;
     let sparql = format!(
-        "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n\
-         SELECT (MAX(xsd:integer(?idx)) AS ?max_idx) WHERE {{\n\
+        "SELECT (MAX(xsd:integer(?idx)) AS ?max_idx) WHERE {{\n\
            GRAPH ?g {{\n\
              <{domain_iri}> {p}:hasRule ?rule .\n\
              ?rule {p}:index ?idx .\n\

--- a/tests/rule_index_test.rs
+++ b/tests/rule_index_test.rs
@@ -1,0 +1,92 @@
+//! Rule numbers are numbers, not text.
+//!
+//! `next_rule_index` took `MAX(?idx)` over `:index` literals stored as strings,
+//! so once `"0"`..`"9"` existed the maximum stayed `"9"` and every later rule was
+//! handed the index 10: they landed on one IRI, `rule/<domain>/cli-10`, and the
+//! hook injection rendered the cross-product of their texts. Reported as #29 by
+//! Marc Swindle, fixed in #30, measured on the released 0.13.16 binary — twelve
+//! rules produced eleven IRIs and six quads on cli-10.
+//!
+//! The same string comparison sat one query further on, in the listing's
+//! `ORDER BY`, and outlived that fix: a domain past its tenth rule printed
+//! 0, 1, 10, 11, 2. Both are pinned here, because both look right until a
+//! domain crosses ten rules.
+
+use base::config::NamespaceConfig;
+use base::crud;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+/// A workspace with an empty graph, which is what `base scaffold` leaves behind
+/// and what every read in `crud` expects to open.
+fn workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".base")).unwrap();
+    std::fs::write(tmp.path().join(".base").join("graph.nq"), "").unwrap();
+    tmp
+}
+
+/// `count` rules on one domain, in order, returning the index each was given.
+fn add_rules(root: &std::path::Path, count: u32) -> Vec<u32> {
+    (1..=count)
+        .map(|i| crud::rule::add(root, &ns(), "probe", &format!("rule number {i}"), None).unwrap())
+        .collect()
+}
+
+/// Twelve rules, twelve numbers. Fails on the old code at the eleventh.
+#[test]
+fn every_rule_past_the_tenth_gets_its_own_number() {
+    let tmp = workspace();
+    let indices = add_rules(tmp.path(), 12);
+
+    assert_eq!(
+        indices,
+        (0..12).collect::<Vec<u32>>(),
+        "each rule takes the next number; the old MAX over strings stuck at 10"
+    );
+
+    let graph = std::fs::read_to_string(tmp.path().join(".base").join("graph.nq")).unwrap();
+    let mut iris: Vec<&str> = graph
+        .match_indices("rule/probe/cli-")
+        .map(|(at, _)| {
+            let rest = &graph[at..];
+            &rest[..rest.find(['>', ' ']).unwrap_or(rest.len())]
+        })
+        .collect();
+    iris.sort_unstable();
+    iris.dedup();
+    assert_eq!(iris.len(), 12, "twelve rules, twelve IRIs — no two rules share one");
+}
+
+/// The listing counts up, not alphabetically.
+#[test]
+fn the_listing_orders_by_the_number_not_its_text() {
+    let tmp = workspace();
+    add_rules(tmp.path(), 12);
+
+    let rules = crud::rule::fetch(tmp.path(), &ns(), "probe").unwrap();
+    let numbers: Vec<u32> = rules.iter().map(|(n, _)| *n).collect();
+    assert_eq!(
+        numbers,
+        (0..12).collect::<Vec<u32>>(),
+        "10 comes after 9, not after 1 — `ORDER BY ?pri` sorted the digits as text"
+    );
+    assert_eq!(rules[10].1, "rule number 11", "and the text travels with its number");
+}
+
+/// A rule added past the tenth is still removable by its number.
+#[test]
+fn a_rule_past_the_tenth_can_still_be_removed() {
+    let tmp = workspace();
+    add_rules(tmp.path(), 12);
+    crud::rule::remove(tmp.path(), &ns(), "probe", 10).unwrap();
+
+    let left = crud::rule::fetch(tmp.path(), &ns(), "probe").unwrap();
+    assert_eq!(left.len(), 11, "one rule gone");
+    assert!(
+        !left.iter().any(|(_, t)| t == "rule number 11"),
+        "the eleventh rule is the one that went"
+    );
+}


### PR DESCRIPTION
**What changes for a user.** `base rule list` counts up. #30 fixed the number a rule is given; the same string comparison sat one query further on, in the listing's `ORDER BY ?pri`, so a domain past its tenth rule still printed 0, 1, 10, 11, 2 — the eleventh rule second.

The rows now come back from `rule::fetch`, which orders numerically and hands back parsed indices; `list` prints them. Having the rows in hand is what lets a test see the order at all, since `list` only printed.

**Tests.** `tests/rule_index_test.rs` pins both halves and the removal that addresses a rule by its number. Each fails on the code it pins, checked by reverting one line at a time:

| reverted | result |
|---|---|
| the `MAX(xsd:integer(...))` cast | all three fail |
| the listing `ORDER BY` | the ordering test alone fails |
| neither | 3 passed |

Also drops the `PREFIX xsd:` line #30 added inline: `crud::load_and_query` already prepends `crud::prefixes`, which declares xsd, and no other query in that file carries its own.

**Verified.** clippy clean under rustc 1.98.1, full suite green (36 targets).

Refs #29.

https://claude.ai/code/session_01VMzLN9woGG8xxbQcVX2fj8