### PR TITLE
fix(domain): count the rules a domain actually injects, not just the file's

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2091,8 +2091,8 @@ pub fn run() {
                     Err(e) => die("Failed", e),
                 }
             }
-            DomainAction::List => domain::list_domains(&cwd),
-            DomainAction::Get { name } => domain::get_domain(&cwd, &name),
+            DomainAction::List => domain::list_domains(&cwd, &config.namespace),
+            DomainAction::Get { name } => domain::get_domain(&cwd, &config.namespace, &name),
             DomainAction::Sync { carl } => {
                 let carl_path = carl.as_ref().map(std::path::Path::new);
                 match domain::sync::sync_domains_to_graph(&config, &cwd, carl_path) {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -389,7 +389,7 @@ pub fn remove_trigger(
 }
 
 /// List all domains (for CLI output).
-pub fn list_domains(cwd: &Path) {
+pub fn list_domains(cwd: &Path, ns: &crate::config::NamespaceConfig) {
     let domains = load_domains(cwd);
     if domains.is_empty() {
         eprintln!("No domains configured.");
@@ -405,13 +405,40 @@ pub fn list_domains(cwd: &Path) {
             d.prompt_keywords.len(),
             d.file_keywords.len(),
             d.paths.len(),
-            d.rules.len(),
+            {
+                let (declared, added) = rules_of(cwd, ns, d);
+                declared.len() + added.len()
+            },
         );
     }
 }
 
+/// Every rule a domain injects: the ones declared in `domains.toml`, and the
+/// ones added with `base rule add`.
+///
+/// The two live in different stores by design. A CLI-added rule is written to
+/// the graph at `rule/<slug>/cli-N`, in its own IRI namespace, so that a
+/// `base sync` rebuilding a domain from `domains.toml` cannot delete it. The
+/// cost of that split was this: the readers only ever looked at the file, so
+/// `base domain get` answered `Rules (0)` for a domain whose rules were being
+/// injected on every matching tool call, and the natural reading of that is
+/// that `base rule add` had failed (#38).
+///
+/// A missing or unreadable graph yields the file half alone rather than an
+/// error: these are display commands, and a domain's declared rules are still
+/// worth showing outside a workspace.
+pub fn rules_of(
+    cwd: &Path,
+    ns: &crate::config::NamespaceConfig,
+    d: &DomainDef,
+) -> (Vec<String>, Vec<(u32, String)>) {
+    let declared: Vec<String> = d.rules.iter().map(|r| r.render()).collect();
+    let added = crate::crud::rule::fetch(cwd, ns, &d.name).unwrap_or_default();
+    (declared, added)
+}
+
 /// Show a specific domain's full config (for CLI output).
-pub fn get_domain(cwd: &Path, name: &str) {
+pub fn get_domain(cwd: &Path, ns: &crate::config::NamespaceConfig, name: &str) {
     let domains = load_domains(cwd);
     match domains.iter().find(|d| d.name == name) {
         Some(d) => {
@@ -445,9 +472,15 @@ pub fn get_domain(cwd: &Path, name: &str) {
             if let Some(fmt) = &d.format {
                 println!("Format: {fmt}");
             }
-            println!("Rules ({}):", d.rules.len());
-            for (i, rule) in d.rules.iter().enumerate() {
-                println!("  {i}. {}", rule.render());
+            let (declared, added) = rules_of(cwd, ns, d);
+            println!("Rules ({}):", declared.len() + added.len());
+            for (i, rule) in declared.iter().enumerate() {
+                println!("  {i}. {rule}");
+            }
+            // Numbered by their own index, which is what `base rule remove
+            // --index` takes; the two stores number independently.
+            for (n, text) in &added {
+                println!("  [cli-{n}] {text}");
             }
         }
         None => eprintln!("Domain '{name}' not found."),

--- a/tests/domain_rules_test.rs
+++ b/tests/domain_rules_test.rs
@@ -1,0 +1,86 @@
+//! A domain's rules live in two stores, and every reader has to see both.
+//!
+//! `base rule add` writes to the graph at `rule/<slug>/cli-N`, in its own IRI
+//! namespace, so that a `base sync` rebuilding a domain from `domains.toml`
+//! cannot delete a rule someone added by hand. The readers only ever looked at
+//! the file, so `base domain get` answered `Rules (0)` for a domain whose rules
+//! were injecting on every matching tool call — and the obvious reading of that
+//! is that `base rule add` had silently failed (#38).
+
+use std::path::Path;
+
+use base::config::NamespaceConfig;
+use base::crud;
+use base::domain;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+/// A workspace with a domain declared in `domains.toml` and an empty graph.
+fn workspace(declared: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let base_dir = tmp.path().join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    std::fs::write(base_dir.join("graph.nq"), "").unwrap();
+    std::fs::write(
+        base_dir.join("domains.toml"),
+        format!(
+            "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = [\"probe\"]\nrules = [{declared}]\n"
+        ),
+    )
+    .unwrap();
+    tmp
+}
+
+fn probe(cwd: &Path) -> base::domain::DomainDef {
+    domain::load_domains(cwd)
+        .into_iter()
+        .find(|d| d.name == "probe")
+        .expect("the probe domain is declared")
+}
+
+/// The reader returns both stores, not just the file.
+#[test]
+fn a_rule_added_from_the_cli_reaches_the_domain_readers() {
+    let tmp = workspace("\"a rule from the file\"");
+    crud::rule::add(tmp.path(), &ns(), "probe", "a rule from the cli", None).unwrap();
+
+    let (declared, added) = domain::rules_of(tmp.path(), &ns(), &probe(tmp.path()));
+    assert_eq!(declared, vec!["a rule from the file".to_string()]);
+    assert_eq!(
+        added,
+        vec![(0, "a rule from the cli".to_string())],
+        "the graph half is what `domain get` used to drop"
+    );
+    assert_eq!(
+        declared.len() + added.len(),
+        2,
+        "the count `base domain get` prints — it said 1 before this fix, and 0 with no file rules"
+    );
+}
+
+/// The shape from #38: nothing in the file, everything from the CLI.
+#[test]
+fn a_domain_whose_rules_are_all_from_the_cli_does_not_read_as_empty() {
+    let tmp = workspace("");
+    for text in ["first", "second", "third"] {
+        crud::rule::add(tmp.path(), &ns(), "probe", text, None).unwrap();
+    }
+
+    let (declared, added) = domain::rules_of(tmp.path(), &ns(), &probe(tmp.path()));
+    assert!(declared.is_empty(), "the file declares none");
+    assert_eq!(added.len(), 3, "and `Rules (0)` was the bug");
+    assert_eq!(added[2].1, "third");
+}
+
+/// Outside a workspace the declared half still shows rather than erroring.
+#[test]
+fn a_missing_graph_yields_the_declared_rules_alone() {
+    let tmp = workspace("\"a rule from the file\"");
+    std::fs::remove_file(tmp.path().join(".base").join("graph.nq")).unwrap();
+
+    let (declared, added) = domain::rules_of(tmp.path(), &ns(), &probe(tmp.path()));
+    assert_eq!(declared.len(), 1, "a display command still shows what it can");
+    assert!(added.is_empty());
+}


### PR DESCRIPTION
Closes #38.

**What changes for a user.** `base domain get` and `base domain list` show the rules a domain actually injects. Before, both counted only what `domains.toml` declared, so a rule added with `base rule add` — which is written to the graph on purpose, in its own IRI namespace, so a `base sync` cannot delete it — read as missing from the one command you run to check it took.

Before and after, same domain, one CLI-added rule:

```
Rules (0):                        Rules (1):
                                    [cli-0] a rule that works
```

CLI rules print as `[cli-N]` because that is the index `base rule remove --index` takes. The two stores number independently, so merging them into one sequence would make that flag lie. A missing graph yields the declared rules alone rather than an error, since these are display commands.

**Why it mattered.** It says the rule is not there while the rule is working. The next move it invites is adding it again, or concluding `rule add` is broken and hand-editing `domains.toml`. I nearly did while writing up the workaround on #15.

**Tests.** `tests/domain_rules_test.rs`, three cases, each checked against the old reader by removing the graph half:

| | old reader | fixed |
|---|---|---|
| file rule + CLI rule | FAILED | ok |
| CLI rules only (the #38 shape) | FAILED | ok |
| no graph, declared rules alone | ok | ok |

clippy clean under rustc 1.98.1; full suite green, 37 targets.

https://claude.ai/code/session_01VMzLN9woGG8xxbQcVX2fj8