### PR TITLE
fix(graph): read the edges base writes for itself, and resolve names the same way every run

### DIFF
--- a/src/graph_analyze.rs
+++ b/src/graph_analyze.rs
@@ -39,26 +39,15 @@ pub fn run(cwd: &Path, ns: &NamespaceConfig, top_n: usize) -> Result<()> {
         groups.entry(*c).or_default().push(id);
     }
     let mut group_vec: Vec<(usize, Vec<&String>)> = groups.into_iter().collect();
-    group_vec.sort_by_key(|g| std::cmp::Reverse(g.1.len()));
+    for (_, members) in group_vec.iter_mut() {
+        members.sort();
+    }
+    // Largest first; equal sizes by their first member, so `[3]` names the same
+    // community on every run instead of whichever the map iterated first.
+    group_vec.sort_by(|x, y| y.1.len().cmp(&x.1.len()).then_with(|| x.1.first().cmp(&y.1.first())));
 
     // ── Surprising connections: edges that bridge two communities ──
-    let mut bridges: Vec<(String, String)> = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for (a, neighbors) in &adj {
-        for (b, _) in neighbors {
-            if comm.get(a) != comm.get(b) {
-                let key = if a < b { (a.clone(), b.clone()) } else { (b.clone(), a.clone()) };
-                if seen.insert(key) {
-                    bridges.push((a.clone(), b.clone()));
-                }
-            }
-        }
-    }
-    bridges.sort_by(|x, y| {
-        let dx = degree.get(&x.0).unwrap_or(&0) + degree.get(&x.1).unwrap_or(&0);
-        let dy = degree.get(&y.0).unwrap_or(&0) + degree.get(&y.1).unwrap_or(&0);
-        dy.cmp(&dx)
-    });
+    let bridges = bridge_pairs(&adj, &comm, &degree);
 
     // ── Report ──
     let edge_count: usize = adj.values().map(|v| v.len()).sum::<usize>() / 2;
@@ -85,14 +74,65 @@ pub fn run(cwd: &Path, ns: &NamespaceConfig, top_n: usize) -> Result<()> {
     if !bridges.is_empty() {
         println!("\n## Surprising connections (bridges across communities)");
         for (a, b) in bridges.iter().take(top_n) {
-            println!("  {}  <->  {}", label_of(&nodes, a), label_of(&nodes, b));
+            let (la, lb) = (label_of(&nodes, a), label_of(&nodes, b));
+            if la == lb {
+                // Two records really do share this name (`domain/base` ↔ `project/base`).
+                // The edge is real; printing it twice under one name reads as a bug.
+                println!("  {}  <->  {}", typed_label(&nodes, a), typed_label(&nodes, b));
+            } else {
+                println!("  {la}  <->  {lb}");
+            }
         }
     }
     Ok(())
 }
 
+/// Edges whose ends sit in different communities, busiest pair first. Each pair is
+/// stored low id first and ties break on the ids, so the list — and which end
+/// prints on the left — is the same on every run. The edge set came out of a
+/// HashMap walk before, and the same bridge printed as `A <-> B` or `B <-> A`
+/// depending on which end the map visited first.
+fn bridge_pairs(
+    adj: &HashMap<String, Vec<(String, String)>>,
+    comm: &HashMap<String, usize>,
+    degree: &HashMap<&String, usize>,
+) -> Vec<(String, String)> {
+    let mut seen = std::collections::HashSet::new();
+    let mut bridges: Vec<(String, String)> = Vec::new();
+    for (a, neighbors) in adj {
+        for (b, _) in neighbors {
+            if comm.get(a) != comm.get(b) {
+                let pair = if a < b { (a.clone(), b.clone()) } else { (b.clone(), a.clone()) };
+                if seen.insert(pair.clone()) {
+                    bridges.push(pair);
+                }
+            }
+        }
+    }
+    let weight = |p: &(String, String)| degree.get(&p.0).unwrap_or(&0) + degree.get(&p.1).unwrap_or(&0);
+    bridges.sort_by(|x, y| weight(y).cmp(&weight(x)).then_with(|| x.cmp(y)));
+    bridges
+}
+
 fn label_of(nodes: &HashMap<String, crate::graph_query::Node>, id: &str) -> String {
     nodes.get(id).map(|n| n.label.clone()).unwrap_or_else(|| id.to_string())
+}
+
+/// `base (Domain)` — the label plus its RDF class, for the one place two records
+/// sharing a name would otherwise print as the same word twice. A store written
+/// before records carried `rdf:type` has no class to show, so the kind is read
+/// off the IRI instead (`domain/base` → `base (domain)`).
+fn typed_label(nodes: &HashMap<String, crate::graph_query::Node>, id: &str) -> String {
+    let label = label_of(nodes, id);
+    let kind = nodes
+        .get(id)
+        .map(|n| n.ntype.clone())
+        .filter(|t| !t.is_empty())
+        .or_else(|| crate::graph_query::iri_kind(id).map(str::to_string));
+    match kind {
+        Some(k) => format!("{label} ({k})"),
+        None => label,
+    }
 }
 
 /// Label propagation: each node iteratively adopts the most common label among
@@ -135,4 +175,68 @@ fn label_propagation(
         }
     }
     label
+}
+
+#[cfg(test)]
+mod order_tests {
+    use super::*;
+    use crate::graph_query::Node;
+
+    const U: &str = "http://t.local/o#";
+
+    fn node(label: &str, ntype: &str) -> Node {
+        Node { label: label.into(), ntype: ntype.into(), source: String::new(), summary: String::new() }
+    }
+
+    /// Two communities joined by one bridge, built in a varying insertion order and
+    /// with a fresh hash seed each time.
+    fn two_clusters(rotate: usize) -> crate::graph_query::GraphMaps {
+        let ids = ["domain/alpha", "project/alpha", "note/a1", "note/a2", "note/p1", "note/p2"];
+        let mut edges: Vec<(&str, &str)> = vec![
+            ("domain/alpha", "note/a1"),
+            ("domain/alpha", "note/a2"),
+            ("project/alpha", "note/p1"),
+            ("project/alpha", "note/p2"),
+            ("domain/alpha", "project/alpha"),
+        ];
+        let len = edges.len();
+        edges.rotate_left(rotate % len);
+        let mut nodes = HashMap::new();
+        for id in ids {
+            let (kind, _) = id.split_once('/').unwrap();
+            nodes.insert(format!("<{U}{id}>"), node("alpha", if kind == "note" { "Note" } else { "" }));
+        }
+        let mut adj: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for (a, b) in edges {
+            let (a, b) = (format!("<{U}{a}>"), format!("<{U}{b}>"));
+            adj.entry(a.clone()).or_default().push((b.clone(), "relatedTo".into()));
+            adj.entry(b).or_default().push((a, "relatedTo".into()));
+        }
+        (nodes, adj)
+    }
+
+    #[test]
+    fn bridge_pairs_print_the_same_way_round_every_run() {
+        let mut seen: std::collections::HashSet<Vec<(String, String)>> = std::collections::HashSet::new();
+        for i in 0..20 {
+            let (nodes, adj) = two_clusters(i);
+            let degree: HashMap<&String, usize> =
+                nodes.keys().map(|id| (id, adj.get(id).map(|v| v.len()).unwrap_or(0))).collect();
+            let comm = label_propagation(&nodes, &adj);
+            seen.insert(bridge_pairs(&adj, &comm, &degree));
+        }
+        assert_eq!(seen.len(), 1, "bridge order varied across runs: {seen:?}");
+        for (a, b) in seen.into_iter().next().unwrap() {
+            assert!(a < b, "pair stored low id first: {a} {b}");
+        }
+    }
+
+    #[test]
+    fn a_same_name_pair_on_an_untyped_store_is_still_qualified_by_iri_kind() {
+        let (nodes, _) = two_clusters(0);
+        assert_eq!(typed_label(&nodes, &format!("<{U}domain/alpha>")), "alpha (domain)");
+        assert_eq!(typed_label(&nodes, &format!("<{U}project/alpha>")), "alpha (project)");
+        // A typed record still shows its class, which is the nicer of the two.
+        assert_eq!(typed_label(&nodes, &format!("<{U}note/a1>")), "alpha (Note)");
+    }
 }

--- a/src/graph_query.rs
+++ b/src/graph_query.rs
@@ -8,7 +8,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use oxigraph::sparql::QueryResults;
 
 use crate::config::NamespaceConfig;
@@ -19,6 +19,37 @@ pub struct Node {
     pub ntype: String,
     pub source: String,
     pub summary: String,
+}
+
+/// The record a bare name denotes when several kinds answer to it, in preference
+/// order (see `crud::build_iri` for the kinds). `concept` stays first because it is
+/// the only kind 0.13.17 ever resolved: on a store where `graph extract` has run,
+/// `neighbors alpha` must keep naming `concept/alpha`, not switch to `domain/alpha`
+/// underneath the user. The hub kinds follow for the stores that never ran extract.
+/// Shared by `graph_tools::resolve` and the query seeder, so a name means the same
+/// record everywhere — and this is a preference order, never an allowlist: a kind
+/// missing here still resolves, it just ranks after these six.
+pub const RESOLVE_KINDS: [&str; 6] = ["concept", "domain", "project", "entity", "task", "decision"];
+
+/// `<http://…#domain/base>` → `domain`: the kind base addresses a record by, read
+/// off its IRI. `None` for an id with no `kind/slug` tail (a code entity, a literal).
+pub fn iri_kind(id: &str) -> Option<&str> {
+    let bare = id.strip_prefix('<').unwrap_or(id);
+    let bare = bare.strip_suffix('>').unwrap_or(bare);
+    let (head, _slug) = bare.rsplit_once('/')?;
+    let kind = head.rsplit(['#', '/']).next()?;
+    if kind.is_empty() { None } else { Some(kind) }
+}
+
+/// Where a record falls in `RESOLVE_KINDS`: by its IRI kind, else by its RDF class
+/// (a `graph extract` concept carries its `conceptType` as `ntype`, which is why the
+/// IRI is asked first). Anything outside the list ranks after it.
+pub fn kind_rank(id: &str, node: Option<&Node>) -> usize {
+    let kind = iri_kind(id)
+        .map(|k| k.to_lowercase())
+        .or_else(|| node.map(|n| n.ntype.to_lowercase()))
+        .unwrap_or_default();
+    RESOLVE_KINDS.iter().position(|k| *k == kind).unwrap_or(RESOLVE_KINDS.len())
 }
 
 const EXACT: f64 = 1000.0;
@@ -41,14 +72,14 @@ pub fn run(cwd: &Path, ns: &NamespaceConfig, question: &str, opts: &Options) -> 
     }
 
     let terms = query_terms(question);
-    let scored = score_nodes(&nodes, &terms);
+    let degree: HashMap<&String, usize> = adj.iter().map(|(k, v)| (k, v.len())).collect();
+    let scored = score_nodes(&nodes, &terms, &degree);
     let seeds = pick_seeds(&scored);
     if seeds.is_empty() {
         println!("No matching nodes found for: {question}");
         return Ok(());
     }
 
-    let degree: HashMap<&String, usize> = adj.iter().map(|(k, v)| (k, v.len())).collect();
     let hub = hub_threshold(&degree);
     let (visited, edges) = bfs(&adj, &seeds, opts.depth, hub, &degree);
     let subgraph = render(&nodes, &visited, &edges, &seeds, opts.token_budget);
@@ -83,9 +114,37 @@ pub fn run(cwd: &Path, ns: &NamespaceConfig, question: &str, opts: &Options) -> 
 /// The concept map and its undirected adjacency list, as `load_graph` returns them.
 pub type GraphMaps = (HashMap<String, Node>, HashMap<String, Vec<(String, String)>>);
 
-/// Pull labelled nodes and the concept edge-set from graph.nq into memory.
-/// Edges come from reified semantic edges (ops:from/ops:to); traversal is
-/// undirected so BFS reaches both callers and callees of a concept.
+/// Body predicates, in preference order, that stand in for a missing `ops:name`.
+/// A record written by `base learn`/`base rule add` carries its text here and no
+/// name; without this it would load as an unlabelled node or not at all.
+const BODY_PREDS: [&str; 5] = ["noteText", "ruleText", "description", "text", "summary"];
+
+/// First line of a body value, clipped, as a display label.
+fn body_label(s: &str) -> String {
+    let line = s.trim().lines().next().unwrap_or("").trim();
+    line.chars().take(90).collect()
+}
+
+/// `<http://…#entity/renda-group>` → `("entity", "renda group")`. The IRI scheme is
+/// `{ns.uri}{kind}/{slug}` (see `crud::build_iri`), so an edge endpoint that carries
+/// no triples of its own still names itself.
+fn kind_and_label_from_iri(id: &str, ns: &NamespaceConfig) -> Option<(String, String)> {
+    let bare = id.strip_prefix('<')?.strip_suffix('>')?;
+    let loc = bare.strip_prefix(ns.uri.as_str())?;
+    let (kind, slug) = loc.split_once('/')?;
+    if kind.is_empty() || slug.is_empty() {
+        return None;
+    }
+    Some((kind.to_string(), slug.replace('-', " ")))
+}
+
+/// Pull nodes and the concept edge-set from graph.nq into memory.
+///
+/// Nodes are every `ops:name`-bearing subject plus every typed subject (labelled
+/// from its body text or its IRI slug), plus any edge endpoint that appears
+/// nowhere as a subject. Edges are every ops-namespace predicate whose object is
+/// an IRI, plus the reified semantic edges written by `graph extract`
+/// (`ops:from`/`ops:to`). Traversal is undirected so BFS reaches both sides.
 pub fn load_graph(
     cwd: &Path,
     ns: &NamespaceConfig,
@@ -93,24 +152,120 @@ pub fn load_graph(
 ) -> Result<GraphMaps> {
     let p = &ns.prefix;
 
+    // One parse, four queries. `crud::load_and_query` re-reads and re-parses graph.nq
+    // on every call, so the old two-query loader paid for the 13 MB store twice and
+    // this four-query one would pay four times.
+    let base_dir = crate::config::find_workspace_base(cwd)
+        .context("no .base/ directory found. Use --global for global rules, or run `base scaffold` to create a workspace.")?;
+    let store = crate::store::load_graph(&base_dir.join("graph.nq"))?;
+    let pfx = crud::prefixes(ns);
+    let ask = |q: &str| crate::store::query(&store, &format!("{pfx}\n{q}"));
+
+    // `conceptType` is written only by `graph extract`; a store that has never run it
+    // has none, so fall back to the RDF class every record carries. Without this every
+    // node's type is blank and two records sharing a name are indistinguishable.
     let node_q = format!(
-        "SELECT ?s ?label ?type ?src ?summary WHERE {{ GRAPH ?g {{\n\
+        "SELECT ?s ?label ?type ?rdftype ?src ?summary WHERE {{ GRAPH ?g {{\n\
            ?s {p}:name ?label .\n\
            OPTIONAL {{ ?s {p}:conceptType ?type }}\n\
+           OPTIONAL {{ ?s a ?rdftype }}\n\
            OPTIONAL {{ ?s {p}:sourceDoc ?src }}\n\
            OPTIONAL {{ ?s {p}:summary ?summary }}\n\
          }} }}"
     );
     let mut nodes: HashMap<String, Node> = HashMap::new();
-    if let QueryResults::Solutions(sols) = crud::load_and_query(cwd, ns, &node_q)? {
+    if let QueryResults::Solutions(sols) = ask(&node_q)? {
         for row in sols.filter_map(|r| r.ok()) {
             let Some(s) = row.get("s").map(|t| t.to_string()) else { continue };
             nodes.entry(s).or_insert_with(|| Node {
                 label: row.get("label").map(|t| crud::term_display(t.into())).unwrap_or_default(),
-                ntype: row.get("type").map(|t| crud::term_display(t.into())).unwrap_or_default(),
+                ntype: row
+                    .get("type")
+                    .or_else(|| row.get("rdftype"))
+                    .map(|t| crud::term_display(t.into()))
+                    .unwrap_or_default(),
                 source: row.get("src").map(|t| crud::term_display(t.into())).unwrap_or_default(),
                 summary: row.get("summary").map(|t| crud::term_display(t.into())).unwrap_or_default(),
             });
+        }
+    }
+
+    // Typed subjects that carry no `ops:name`: 58% of a real store (records written
+    // by learn/rule/task/decision, plus every PAUL acceptance-criteria and
+    // file-change). They are the far end of most edges, so without them the graph
+    // loads adjacency into nodes nobody can see.
+    let body_opts: String = BODY_PREDS
+        .iter()
+        .map(|b| format!("           OPTIONAL {{ ?s {p}:{b} ?{b} }}\n"))
+        .collect();
+    let body_vars: String = BODY_PREDS.iter().map(|b| format!(" ?{b}")).collect();
+    let typed_q = format!(
+        "SELECT ?s ?type ?src{body_vars} WHERE {{ GRAPH ?g {{\n\
+           ?s a ?type .\n\
+           FILTER NOT EXISTS {{ ?s {p}:name ?any }}\n\
+           OPTIONAL {{ ?s {p}:sourceDoc ?src }}\n\
+         {body_opts}\
+         }} }}"
+    );
+    if let QueryResults::Solutions(sols) = ask(&typed_q)? {
+        for row in sols.filter_map(|r| r.ok()) {
+            let Some(s) = row.get("s").map(|t| t.to_string()) else { continue };
+            if nodes.contains_key(&s) {
+                continue;
+            }
+            let body = BODY_PREDS
+                .iter()
+                .find_map(|b| row.get(*b).map(|t| crud::term_display(t.into())))
+                .map(|v| body_label(&v))
+                .filter(|v| !v.is_empty());
+            let from_iri = kind_and_label_from_iri(&s, ns);
+            let label = body
+                .or_else(|| from_iri.as_ref().map(|(_, l)| l.clone()))
+                .unwrap_or_default();
+            if label.is_empty() {
+                continue; // nothing to show it under — leave it out rather than print an IRI
+            }
+            nodes.insert(
+                s,
+                Node {
+                    label,
+                    ntype: row
+                        .get("type")
+                        .map(|t| crud::term_display(t.into()))
+                        .or_else(|| from_iri.map(|(k, _)| k))
+                        .unwrap_or_default(),
+                    source: row.get("src").map(|t| crud::term_display(t.into())).unwrap_or_default(),
+                    summary: String::new(),
+                },
+            );
+        }
+    }
+
+    let mut adj: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    let push = |adj: &mut HashMap<String, Vec<(String, String)>>, a: String, b: String, rel: String| {
+        adj.entry(a.clone()).or_default().push((b.clone(), rel.clone()));
+        adj.entry(b).or_default().push((a, rel)); // undirected for reachability
+    };
+
+    // Direct ontology relations: `?s ops:references ?o`. Any ops-namespace predicate
+    // whose object is an IRI is a node→node edge — a literal object can never match
+    // isIRI, so this cannot pull in `hasSection`/`hasTag`-style string properties, and
+    // it does not go stale when ops.ttl gains a property. The three excluded predicates
+    // are the reification scaffolding of a SemanticEdge, loaded as one edge below.
+    let direct_q = format!(
+        "SELECT ?a ?p ?b WHERE {{ GRAPH ?g {{\n\
+           ?a ?p ?b .\n\
+           FILTER(isIRI(?a) && isIRI(?b))\n\
+           FILTER(STRSTARTS(STR(?p), \"{u}\"))\n\
+           FILTER(?p != {p}:from && ?p != {p}:to && ?p != {p}:relation)\n\
+         }} }}",
+        u = ns.uri
+    );
+    if let QueryResults::Solutions(sols) = ask(&direct_q)? {
+        for row in sols.filter_map(|r| r.ok()) {
+            let (Some(a), Some(b)) = (row.get("a").map(|t| t.to_string()), row.get("b").map(|t| t.to_string())) else { continue };
+            let Some(rel) = row.get("p").map(|t| crud::term_display(t.into())) else { continue };
+            push(&mut adj, a, b, rel);
         }
     }
 
@@ -120,14 +275,25 @@ pub fn load_graph(
            OPTIONAL {{ ?e {p}:relation ?rel }}\n\
          }} }}"
     );
-    let mut adj: HashMap<String, Vec<(String, String)>> = HashMap::new();
-    if let QueryResults::Solutions(sols) = crud::load_and_query(cwd, ns, &edge_q)? {
+    if let QueryResults::Solutions(sols) = ask(&edge_q)? {
         for row in sols.filter_map(|r| r.ok()) {
             let (Some(a), Some(b)) = (row.get("a").map(|t| t.to_string()), row.get("b").map(|t| t.to_string())) else { continue };
             let rel = row.get("rel").map(|t| crud::term_display(t.into())).unwrap_or_else(|| "relates_to".into());
-            adj.entry(a.clone()).or_default().push((b.clone(), rel.clone()));
-            adj.entry(b).or_default().push((a, rel)); // undirected for reachability
+            push(&mut adj, a, b, rel);
         }
+    }
+
+    // An endpoint that is only ever an object (`entity/…`, `document/…`) carries no
+    // triples of its own, so neither node query found it. Its IRI slug is a real name
+    // — base addresses the record by it. Without this the other end of ~44% of edges
+    // renders as a raw URL.
+    let dangling: Vec<String> = adj.keys().filter(|id| !nodes.contains_key(*id)).cloned().collect();
+    for id in dangling {
+        let Some((kind, label)) = kind_and_label_from_iri(&id, ns) else { continue };
+        nodes.insert(
+            id,
+            Node { label, ntype: kind, source: String::new(), summary: String::new() },
+        );
     }
 
     // Federate the per-app AST map so code entities (functions/structs/modules)
@@ -150,6 +316,13 @@ pub fn load_graph(
                 adj.entry(b).or_default().push((a, rel));
             }
         }
+    }
+
+    // Adjacency in id order, not store order: every reader (neighbors, get-node,
+    // path, the query BFS) prints or walks these lists, and the same store must
+    // produce the same output on every run.
+    for list in adj.values_mut() {
+        list.sort();
     }
 
     Ok((nodes, adj))
@@ -179,7 +352,19 @@ fn idf(nodes: &HashMap<String, Node>, terms: &[String]) -> HashMap<String, f64> 
     out
 }
 
-fn score_nodes(nodes: &HashMap<String, Node>, terms: &[String]) -> Vec<(f64, String)> {
+/// Text-score every node against the question, highest first, in a TOTAL order.
+///
+/// The score is text only (exact, prefix, substring, IDF-weighted). Ties are the
+/// normal case, not the edge case: eleven records on a real store are labelled
+/// exactly `basemode` (one Domain hub, one Project, nine Handoffs) and all score
+/// the same. `nodes` is a HashMap, so before ties had an order the seed set came
+/// out of hash iteration and one question returned anywhere from 3 to 323 nodes
+/// on the same store. Ties now break on structure: degree, then hub kind, then id.
+fn score_nodes(
+    nodes: &HashMap<String, Node>,
+    terms: &[String],
+    degree: &HashMap<&String, usize>,
+) -> Vec<(f64, String)> {
     let weights = idf(nodes, terms);
     let mut scored: Vec<(f64, String)> = Vec::new();
     for (id, node) in nodes {
@@ -203,7 +388,17 @@ fn score_nodes(nodes: &HashMap<String, Node>, terms: &[String]) -> Vec<(f64, Str
             scored.push((score, id.clone()));
         }
     }
-    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    scored.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                let da = degree.get(&a.1).copied().unwrap_or(0);
+                let db = degree.get(&b.1).copied().unwrap_or(0);
+                db.cmp(&da)
+            })
+            .then_with(|| kind_rank(&a.1, nodes.get(&a.1)).cmp(&kind_rank(&b.1, nodes.get(&b.1))))
+            .then_with(|| a.1.cmp(&b.1))
+    });
     scored
 }
 
@@ -246,7 +441,11 @@ fn bfs(
     let mut edges: Vec<(String, String, String)> = Vec::new();
     for _ in 0..depth {
         let mut next: HashSet<String> = HashSet::new();
-        for n in &frontier {
+        // Walk the frontier in id order so the edge list, and therefore what the
+        // budget cut keeps, is the same on every run of the same store.
+        let mut order: Vec<&String> = frontier.iter().collect();
+        order.sort();
+        for n in order {
             let deg = degree.get(n).copied().unwrap_or(0);
             if !seed_set.contains(n) && deg >= hub {
                 continue; // don't transit through hubs
@@ -282,7 +481,12 @@ fn render(
     let seed_set: HashSet<&String> = seeds.iter().collect();
     let mut ordered: Vec<&String> = seeds.iter().filter(|s| visited.contains(*s)).collect();
     let mut rest: Vec<&String> = visited.iter().filter(|n| !seed_set.contains(n)).collect();
-    rest.sort_by_key(|n| std::cmp::Reverse(edges.iter().filter(|(a, b, _)| *a == **n || *b == **n).count()));
+    // Busiest first, id as the tie-break: `visited` is a set, and two nodes with
+    // the same edge count used to land in hash order.
+    rest.sort_by_cached_key(|n| {
+        let touching = edges.iter().filter(|(a, b, _)| *a == **n || *b == **n).count();
+        (std::cmp::Reverse(touching), (*n).clone())
+    });
     ordered.extend(rest);
 
     let mut lines: Vec<String> = Vec::new();
@@ -324,4 +528,381 @@ fn synth_prompt(question: &str, subgraph: &str) -> String {
          QUESTION: {question}\n\n\
          GRAPH CONTEXT:\n{subgraph}"
     )
+}
+
+#[cfg(test)]
+mod edge_loading_tests {
+    use super::*;
+    use std::fs;
+
+    const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+    fn ns() -> NamespaceConfig {
+        NamespaceConfig::default()
+    }
+
+    /// A workspace whose `.base/graph.nq` holds exactly `body`.
+    fn workspace(body: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join(".base");
+        fs::create_dir_all(&base).unwrap();
+        fs::write(base.join("graph.nq"), body).unwrap();
+        dir
+    }
+
+    fn load(dir: &tempfile::TempDir) -> GraphMaps {
+        load_graph(dir.path(), &ns(), false).unwrap()
+    }
+
+    fn id(local: &str) -> String {
+        format!("<{}{}>", ns().uri, local)
+    }
+
+    /// Relations on `a`'s adjacency list, sorted — the shape every assert reads.
+    fn rels(adj: &HashMap<String, Vec<(String, String)>>, a: &str) -> Vec<String> {
+        let mut v: Vec<String> = adj
+            .get(&id(a))
+            .map(|v| v.iter().map(|(_, r)| r.clone()).collect())
+            .unwrap_or_default();
+        v.sort();
+        v
+    }
+
+    /// Two named projects wired by a direct ontology predicate, plus the literal
+    /// properties that must NOT become edges.
+    fn direct_body() -> String {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        let mut b = String::new();
+        b += &format!("<{u}project/alpha> <{u}name> \"alpha\" <{g}> .\n");
+        b += &format!("<{u}project/alpha> <{RDF_TYPE}> <{u}Project> <{g}> .\n");
+        b += &format!("<{u}domain/beta> <{u}name> \"beta\" <{g}> .\n");
+        b += &format!("<{u}domain/beta> <{RDF_TYPE}> <{u}Domain> <{g}> .\n");
+        b += &format!("<{u}project/alpha> <{u}hasDomain> <{u}domain/beta> <{g}> .\n");
+        // Literal-object properties: heading and tag strings, not node→node edges.
+        b += &format!("<{u}project/alpha> <{u}hasSection> \"Overview\" <{g}> .\n");
+        b += &format!("<{u}project/alpha> <{u}hasTag> \"launch\" <{g}> .\n");
+        b += &format!("<{u}project/alpha> <{u}description> \"a project\" <{g}> .\n");
+        b
+    }
+
+    /// The reified shape `base graph extract` writes.
+    fn semantic_body() -> String {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        let mut b = String::new();
+        b += &format!("<{u}concept/one> <{u}name> \"one\" <{g}> .\n");
+        b += &format!("<{u}concept/two> <{u}name> \"two\" <{g}> .\n");
+        b += &format!("<{u}edge/e1> <{RDF_TYPE}> <{u}SemanticEdge> <{g}> .\n");
+        b += &format!("<{u}edge/e1> <{u}from> <{u}concept/one> <{g}> .\n");
+        b += &format!("<{u}edge/e1> <{u}to> <{u}concept/two> <{g}> .\n");
+        b += &format!("<{u}edge/e1> <{u}relation> \"explains\" <{g}> .\n");
+        b
+    }
+
+    // ── AC7 case 1: direct-predicate edges only ──────────────────────────────
+
+    #[test]
+    fn direct_predicate_edges_load_and_carry_their_predicate_name() {
+        let dir = workspace(&direct_body());
+        let (nodes, adj) = load(&dir);
+        assert!(nodes.contains_key(&id("project/alpha")));
+        assert!(nodes.contains_key(&id("domain/beta")));
+        // The relation is the predicate, so output says WHY two things connect.
+        assert_eq!(rels(&adj, "project/alpha"), vec!["hasDomain"]);
+        // Undirected: reachable from either end.
+        assert_eq!(rels(&adj, "domain/beta"), vec!["hasDomain"]);
+    }
+
+    #[test]
+    fn literal_object_properties_never_become_edges() {
+        let dir = workspace(&direct_body());
+        let (_, adj) = load(&dir);
+        // hasSection is 9.8k triples on a real store and every object is a string.
+        // If it ever loads as an edge, centrality becomes "longest document wins".
+        let all: Vec<String> = adj.values().flatten().map(|(_, r)| r.clone()).collect();
+        assert!(!all.iter().any(|r| r == "hasSection"), "hasSection loaded as an edge");
+        assert!(!all.iter().any(|r| r == "hasTag"), "hasTag loaded as an edge");
+        assert!(!all.iter().any(|r| r == "description"));
+        assert!(!adj.contains_key("\"Overview\""));
+    }
+
+    // ── AC7 case 2: SemanticEdge only ────────────────────────────────────────
+
+    #[test]
+    fn semantic_edges_still_load_unchanged() {
+        let dir = workspace(&semantic_body());
+        let (nodes, adj) = load(&dir);
+        assert!(nodes.contains_key(&id("concept/one")));
+        assert_eq!(rels(&adj, "concept/one"), vec!["explains"]);
+        assert_eq!(rels(&adj, "concept/two"), vec!["explains"]);
+        // The reification scaffolding is not itself an edge.
+        let all: Vec<String> = adj.values().flatten().map(|(_, r)| r.clone()).collect();
+        assert!(!all.iter().any(|r| r == "from" || r == "to" || r == "relation"));
+        assert!(!adj.contains_key(&id("edge/e1")));
+    }
+
+    // ── AC7 case 3: both shapes in one graph (AC6) ───────────────────────────
+
+    #[test]
+    fn both_edge_shapes_coexist() {
+        let dir = workspace(&format!("{}{}", direct_body(), semantic_body()));
+        let (nodes, adj) = load(&dir);
+        assert_eq!(rels(&adj, "project/alpha"), vec!["hasDomain"]);
+        assert_eq!(rels(&adj, "concept/one"), vec!["explains"]);
+        let edges: usize = adj.values().map(|v| v.len()).sum::<usize>() / 2;
+        assert_eq!(edges, 2, "one direct edge + one semantic edge");
+        assert!(nodes.len() >= 4);
+    }
+
+    // ── AC7 case 4: neither shape — must not panic ───────────────────────────
+
+    #[test]
+    fn a_graph_with_no_edges_loads_empty_without_panicking() {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        let dir = workspace(&format!("<{u}project/lonely> <{u}name> \"lonely\" <{g}> .\n"));
+        let (nodes, adj) = load(&dir);
+        assert_eq!(nodes.len(), 1);
+        assert!(adj.is_empty());
+    }
+
+    #[test]
+    fn an_empty_graph_leaves_nodes_empty_so_the_helpful_message_still_prints() {
+        let dir = workspace("");
+        let (nodes, adj) = load(&dir);
+        assert!(nodes.is_empty(), "run `base graph extract` first' is gated on this");
+        assert!(adj.is_empty());
+    }
+
+    // ── B1: typed subjects with no ops:name ──────────────────────────────────
+
+    #[test]
+    fn a_typed_subject_without_a_name_is_labelled_from_its_body_text() {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        let body = format!(
+            "<{u}note/abc> <{RDF_TYPE}> <{u}Note> <{g}> .\n\
+             <{u}note/abc> <{u}noteText> \"first line here\\nsecond line\" <{g}> .\n"
+        );
+        let dir = workspace(&body);
+        let (nodes, _) = load(&dir);
+        let n = nodes.get(&id("note/abc")).expect("typed subject loaded as a node");
+        assert_eq!(n.label, "first line here", "label is the first line of the body");
+        assert_eq!(n.ntype, "Note");
+    }
+
+    #[test]
+    fn a_typed_subject_with_no_body_falls_back_to_its_iri_slug() {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        let body = format!("<{u}entity/renda-group> <{RDF_TYPE}> <{u}Entity> <{g}> .\n");
+        let dir = workspace(&body);
+        let (nodes, _) = load(&dir);
+        assert_eq!(nodes.get(&id("entity/renda-group")).unwrap().label, "renda group");
+    }
+
+    #[test]
+    fn ops_name_still_wins_over_body_text_and_slug() {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        let body = format!(
+            "<{u}note/abc> <{RDF_TYPE}> <{u}Note> <{g}> .\n\
+             <{u}note/abc> <{u}name> \"Real Name\" <{g}> .\n\
+             <{u}note/abc> <{u}noteText> \"body text\" <{g}> .\n"
+        );
+        let dir = workspace(&body);
+        let (nodes, _) = load(&dir);
+        let n = nodes.get(&id("note/abc")).unwrap();
+        assert_eq!(n.label, "Real Name");
+        // conceptType is absent on every real store, so rdf:type has to fill in.
+        assert_eq!(n.ntype, "Note");
+    }
+
+    // ── B2: endpoints that appear only as edge objects ───────────────────────
+
+    #[test]
+    fn an_endpoint_that_is_only_ever_an_object_is_named_from_its_slug() {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        // `document/railway-cli` carries no triples of its own — 828 real edges
+        // point at IRIs like this, and without B2 the far end prints as a URL.
+        let body = format!(
+            "<{u}note/abc> <{u}name> \"a note\" <{g}> .\n\
+             <{u}note/abc> <{u}references> <{u}document/railway-cli> <{g}> .\n"
+        );
+        let dir = workspace(&body);
+        let (nodes, adj) = load(&dir);
+        let far = nodes
+            .get(&id("document/railway-cli"))
+            .expect("dangling endpoint materialised");
+        assert_eq!(far.label, "railway cli");
+        assert_eq!(far.ntype, "document");
+        assert_eq!(rels(&adj, "note/abc"), vec!["references"]);
+    }
+
+    #[test]
+    fn an_edge_to_a_foreign_namespace_does_not_load() {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        let body = format!(
+            "<{u}note/abc> <{u}name> \"a note\" <{g}> .\n\
+             <{u}note/abc> <http://example.com/links> <http://example.com/thing> <{g}> .\n"
+        );
+        let dir = workspace(&body);
+        let (_, adj) = load(&dir);
+        assert!(adj.is_empty(), "only ops-namespace predicates are edges");
+    }
+
+    #[test]
+    fn adjacency_lists_come_out_in_id_order_whatever_the_store_order() {
+        let u = ns().uri;
+        let g = crate::crud::workspace_graph_iri(&ns(), "t");
+        // Written zebra-first: the loader must not hand the store's order back.
+        let body = format!(
+            "<{u}project/hub> <{u}name> \"hub\" <{g}> .\n\
+             <{u}project/hub> <{u}references> <{u}document/zebra> <{g}> .\n\
+             <{u}project/hub> <{u}references> <{u}document/apple> <{g}> .\n\
+             <{u}project/hub> <{u}hasDomain> <{u}domain/mango> <{g}> .\n"
+        );
+        let dir = workspace(&body);
+        let (_, adj) = load(&dir);
+        let list = &adj[&id("project/hub")];
+        let mut sorted = list.clone();
+        sorted.sort();
+        assert_eq!(list, &sorted);
+    }
+}
+
+#[cfg(test)]
+mod seed_tests {
+    use super::*;
+
+    const U: &str = "http://t.local/o#";
+
+    fn node(label: &str, ntype: &str) -> Node {
+        Node { label: label.into(), ntype: ntype.into(), source: String::new(), summary: String::new() }
+    }
+
+    type Maps = (HashMap<String, Node>, HashMap<String, Vec<(String, String)>>);
+
+    /// Eleven records labelled exactly the same, as on a real store: one Domain
+    /// hub, one Project, nine Handoffs. Every one of them scores the same on text.
+    /// `rotate` varies insertion order; every map also gets its own hash seed.
+    fn tied_store(rotate: usize) -> Maps {
+        let mut recs: Vec<(String, Node, usize)> = vec![
+            (format!("<{U}domain/basemode>"), node("basemode", "Domain"), 114),
+            (format!("<{U}project/basemode>"), node("basemode", "Project"), 18),
+        ];
+        for i in 0..9 {
+            recs.push((format!("<{U}handoff/h{i}-basemode>"), node("basemode", "Handoff"), 1));
+        }
+        let len = recs.len();
+        recs.rotate_left(rotate % len);
+        let mut nodes = HashMap::new();
+        let mut adj: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for (id, n, deg) in recs {
+            for k in 0..deg {
+                adj.entry(id.clone()).or_default().push((format!("<{U}note/{k}>"), "relatedTo".into()));
+            }
+            nodes.insert(id, n);
+        }
+        (nodes, adj)
+    }
+
+    fn seeds_for(nodes: &HashMap<String, Node>, adj: &HashMap<String, Vec<(String, String)>>, q: &str) -> Vec<String> {
+        let degree: HashMap<&String, usize> = adj.iter().map(|(k, v)| (k, v.len())).collect();
+        pick_seeds(&score_nodes(nodes, &query_terms(q), &degree))
+    }
+
+    #[test]
+    fn tied_seeds_resolve_to_the_same_set_every_time() {
+        let mut seen: HashSet<Vec<String>> = HashSet::new();
+        for i in 0..20 {
+            let (nodes, adj) = tied_store(i);
+            seen.insert(seeds_for(&nodes, &adj, "basemode"));
+        }
+        assert_eq!(seen.len(), 1, "seed set varied across runs: {seen:?}");
+        let only = seen.into_iter().next().unwrap();
+        assert_eq!(only[0], format!("<{U}domain/basemode>"), "the busiest record wins the tie");
+        assert_eq!(only[1], format!("<{U}project/basemode>"));
+    }
+
+    #[test]
+    fn a_concept_from_extract_still_outranks_the_hub_on_a_tie() {
+        // 0.13.17 resolved names to concepts only; an extract-era store keeps that.
+        let mut nodes = HashMap::new();
+        nodes.insert(format!("<{U}domain/alpha>"), node("alpha", "Domain"));
+        nodes.insert(format!("<{U}concept/alpha>"), node("alpha", "module"));
+        let mut adj: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for k in 0..5 {
+            adj.entry(format!("<{U}domain/alpha>")).or_default().push((format!("<{U}note/{k}>"), "relatedTo".into()));
+            adj.entry(format!("<{U}concept/alpha>")).or_default().push((format!("<{U}concept/c{k}>"), "explains".into()));
+        }
+        let seeds = seeds_for(&nodes, &adj, "alpha");
+        assert_eq!(seeds[0], format!("<{U}concept/alpha>"));
+    }
+
+    #[test]
+    fn text_score_still_outranks_structure() {
+        // An exact label match on a leaf beats a prefix match on a hub.
+        let mut nodes = HashMap::new();
+        nodes.insert(format!("<{U}domain/basemode-platform>"), node("basemode platform", "Domain"));
+        nodes.insert(format!("<{U}note/n1>"), node("basemode", "Note"));
+        let mut adj: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for k in 0..50 {
+            adj.entry(format!("<{U}domain/basemode-platform>")).or_default().push((format!("<{U}note/{k}>"), "relatedTo".into()));
+        }
+        let seeds = seeds_for(&nodes, &adj, "basemode");
+        assert_eq!(seeds[0], format!("<{U}note/n1>"));
+    }
+
+    /// The tied store plus cross-links, so a traversal has real branching and the
+    /// render has real ties to break. Every map is built fresh, with its own hash
+    /// seed and a rotated insertion order.
+    fn branching_store(rotate: usize) -> Maps {
+        let (mut nodes, mut adj) = tied_store(rotate);
+        let hub = format!("<{U}domain/basemode>");
+        for k in 0..6 {
+            let n = format!("<{U}note/{k}>");
+            nodes.insert(n.clone(), node(&format!("note {k}"), "Note"));
+            let d = format!("<{U}decision/d{k}>");
+            nodes.insert(d.clone(), node(&format!("decision {k}"), "Decision"));
+            adj.entry(n.clone()).or_default().push((d.clone(), "references".into()));
+            adj.entry(d.clone()).or_default().push((n.clone(), "references".into()));
+            adj.entry(d).or_default().push((hub.clone(), "hasDecision".into()));
+        }
+        for list in adj.values_mut() {
+            list.sort();
+        }
+        (nodes, adj)
+    }
+
+    #[test]
+    fn the_whole_rendered_subgraph_is_byte_identical_across_runs() {
+        // A stable seed set is not enough: `visited` is a set and the render used to
+        // list equal-degree nodes in hash order, so the same query produced three
+        // different outputs at one node count. Assert on the bytes, not the count.
+        let mut outputs: HashSet<String> = HashSet::new();
+        for i in 0..20 {
+            let (nodes, adj) = branching_store(i);
+            let degree: HashMap<&String, usize> = adj.iter().map(|(k, v)| (k, v.len())).collect();
+            let seeds = pick_seeds(&score_nodes(&nodes, &query_terms("basemode"), &degree));
+            let hub = hub_threshold(&degree);
+            let (visited, edges) = bfs(&adj, &seeds, 3, hub, &degree);
+            outputs.insert(render(&nodes, &visited, &edges, &seeds, 400));
+        }
+        assert_eq!(outputs.len(), 1, "rendered output varied across runs");
+        let only = outputs.into_iter().next().unwrap();
+        assert!(only.starts_with("NODE basemode type=Domain"), "{only}");
+        assert!(only.contains("EDGE "), "the budget must leave room for edges: {only}");
+    }
+
+    #[test]
+    fn iri_kind_reads_the_segment_before_the_slug() {
+        assert_eq!(iri_kind("<http://ops-sys.local/ontology#domain/base>"), Some("domain"));
+        assert_eq!(iri_kind("<http://ops-sys.local/ontology#handoff/2026-09-05-magpie-basemode>"), Some("handoff"));
+        assert_eq!(iri_kind("<http://example.com/thing>"), Some("example.com"));
+        assert_eq!(iri_kind("\"a literal\""), None);
+    }
 }

--- a/src/graph_tools.rs
+++ b/src/graph_tools.rs
@@ -15,27 +15,37 @@ use anyhow::{bail, Result};
 
 use crate::config::NamespaceConfig;
 use crate::crud;
-use crate::graph_query::{load_graph, Node};
+use crate::graph_query::{iri_kind, kind_rank, load_graph, Node};
 
-/// Resolve a user string to a node id. Tries, in order: exact concept-slug IRI,
-/// exact label (case-insensitive), then unique substring. Returns the id, or a
-/// disambiguation error listing the candidates.
-fn resolve(nodes: &HashMap<String, Node>, ns: &NamespaceConfig, input: &str) -> Result<String> {
-    // 1) Treat input as a concept slug → canonical IRI id (`<iri>`).
-    let slug_iri = format!("<{}>", crud::build_iri(ns, "concept", &crud::slugify(input)));
-    if nodes.contains_key(&slug_iri) {
-        return Ok(slug_iri);
+type Adjacency = HashMap<String, Vec<(String, String)>>;
+
+/// Resolve a user string to a node id. Tries, in order: the input as a record slug
+/// under any kind, exact label (case-insensitive), then unique substring. Only
+/// `concept/<slug>` was ever tried before, so on a store that has not run
+/// `graph extract` the slug step could never hit and every lookup fell through to
+/// substring matching and its ambiguity error. When several records answer to one
+/// slug or name, `pick` decides in a total order, so the same input names the same
+/// record on every run. Returns the id, or a disambiguation error listing candidates.
+fn resolve(nodes: &HashMap<String, Node>, adj: &Adjacency, ns: &NamespaceConfig, input: &str) -> Result<String> {
+    // 1) The input as a slug: `<ns>{kind}/{slug}` under ANY kind. No kind list here
+    //    — a milestone or rule slug must hit too — the list only orders a tie.
+    let slug = crud::slugify(input);
+    let (head, tail) = (format!("<{}", ns.uri), format!("/{slug}>"));
+    let by_slug: Vec<&String> = nodes.keys().filter(|id| id.starts_with(&head) && id.ends_with(&tail)).collect();
+    if let Some(hit) = pick(by_slug, nodes, adj, input) {
+        return Ok(hit);
     }
 
-    // 2) Exact label match (case-insensitive).
+    // 2) Exact label match (case-insensitive). Several records legitimately share a
+    //    name — `domain/base`, `project/base` and every handoff named "base".
     let want = input.trim().to_lowercase();
     let exact: Vec<&String> = nodes
         .iter()
         .filter(|(_, n)| n.label.to_lowercase() == want)
         .map(|(id, _)| id)
         .collect();
-    if exact.len() == 1 {
-        return Ok(exact[0].clone());
+    if let Some(hit) = pick(exact, nodes, adj, input) {
+        return Ok(hit);
     }
 
     // 3) Substring match.
@@ -56,6 +66,31 @@ fn resolve(nodes: &HashMap<String, Node>, ns: &NamespaceConfig, input: &str) -> 
     }
 }
 
+/// The record a name denotes when several answer to it: preferred kind first
+/// (`RESOLVE_KINDS`), then the busiest, then the lowest id. A total order, so the
+/// choice cannot come out of hash iteration — before this, two domains both named
+/// `alpha` resolved to either one, run to run. A tie inside one kind is still a
+/// data smell, so it is said on stderr; the caller still gets an answer.
+fn pick(mut cands: Vec<&String>, nodes: &HashMap<String, Node>, adj: &Adjacency, input: &str) -> Option<String> {
+    if cands.is_empty() {
+        return None;
+    }
+    cands.sort_by_cached_key(|id| {
+        let busy = adj.get(*id).map(|v| v.len()).unwrap_or(0);
+        (kind_rank(id, nodes.get(*id)), std::cmp::Reverse(busy), (*id).clone())
+    });
+    let chosen = cands[0];
+    let kind = iri_kind(chosen).unwrap_or("record");
+    let same_kind = cands.iter().filter(|c| iri_kind(c) == iri_kind(chosen)).count();
+    if same_kind > 1 {
+        eprintln!(
+            "note: {same_kind} {kind} records are named '{input}'; using the busiest ({}). Name the slug to pick another.",
+            chosen.trim_matches(['<', '>'])
+        );
+    }
+    Some(chosen.clone())
+}
+
 fn label<'a>(nodes: &'a HashMap<String, Node>, id: &'a str) -> &'a str {
     nodes.get(id).map(|n| n.label.as_str()).unwrap_or(id)
 }
@@ -63,7 +98,7 @@ fn label<'a>(nodes: &'a HashMap<String, Node>, id: &'a str) -> &'a str {
 /// `base graph get-node <node>` — full detail for one node plus its direct edges.
 pub fn get_node(cwd: &Path, ns: &NamespaceConfig, input: &str) -> Result<()> {
     let (nodes, adj) = load_graph(cwd, ns, true)?;
-    let id = resolve(&nodes, ns, input)?;
+    let id = resolve(&nodes, &adj, ns, input)?;
     let n = &nodes[&id];
 
     println!("NODE {}", n.label);
@@ -88,7 +123,7 @@ pub fn get_node(cwd: &Path, ns: &NamespaceConfig, input: &str) -> Result<()> {
 pub fn neighbors(cwd: &Path, ns: &NamespaceConfig, input: &str, depth: usize) -> Result<()> {
     let g = load_graph(cwd, ns, true)?;
     let (nodes, adj) = &g;
-    let seed = resolve(nodes, ns, input)?;
+    let seed = resolve(nodes, adj, ns, input)?;
 
     let mut visited = std::collections::HashSet::from([seed.clone()]);
     let mut frontier = vec![seed.clone()];
@@ -119,8 +154,8 @@ pub fn neighbors(cwd: &Path, ns: &NamespaceConfig, input: &str, depth: usize) ->
 /// `base graph path <from> <to>` — shortest undirected path between two nodes.
 pub fn shortest_path(cwd: &Path, ns: &NamespaceConfig, from: &str, to: &str) -> Result<()> {
     let (nodes, adj) = load_graph(cwd, ns, true)?;
-    let src = resolve(&nodes, ns, from)?;
-    let dst = resolve(&nodes, ns, to)?;
+    let src = resolve(&nodes, &adj, ns, from)?;
+    let dst = resolve(&nodes, &adj, ns, to)?;
     if src == dst {
         println!("Same node: {}", label(&nodes, &src));
         return Ok(());
@@ -162,4 +197,86 @@ pub fn shortest_path(cwd: &Path, ns: &NamespaceConfig, from: &str, to: &str) -> 
     }
     println!();
     Ok(())
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+
+    fn ns() -> NamespaceConfig {
+        NamespaceConfig::default()
+    }
+
+    fn node(label: &str, ntype: &str) -> Node {
+        Node { label: label.into(), ntype: ntype.into(), source: String::new(), summary: String::new() }
+    }
+
+    fn id(local: &str) -> String {
+        format!("<{}{}>", ns().uri, local)
+    }
+
+    /// Records as (iri local part, label, class, degree), inserted in a varying
+    /// order so the maps never share an iteration order between builds.
+    fn store(recs: &[(&str, &str, &str, usize)], rotate: usize) -> (HashMap<String, Node>, Adjacency) {
+        let mut recs: Vec<_> = recs.to_vec();
+        let len = recs.len();
+        recs.rotate_left(rotate % len);
+        let mut nodes = HashMap::new();
+        let mut adj: Adjacency = HashMap::new();
+        for (local, label, class, deg) in recs {
+            let iri = id(local);
+            for k in 0..deg {
+                adj.entry(iri.clone()).or_default().push((id(&format!("note/{local}-{k}")), "relatedTo".into()));
+            }
+            nodes.insert(iri, node(label, class));
+        }
+        (nodes, adj)
+    }
+
+    fn resolve_always(recs: &[(&str, &str, &str, usize)], input: &str) -> String {
+        let mut seen = std::collections::HashSet::new();
+        for i in 0..20 {
+            let (nodes, adj) = store(recs, i);
+            seen.insert(resolve(&nodes, &adj, &ns(), input).unwrap());
+        }
+        assert_eq!(seen.len(), 1, "resolution varied across runs: {seen:?}");
+        seen.into_iter().next().unwrap()
+    }
+
+    #[test]
+    fn two_records_of_one_kind_with_one_name_resolve_to_the_busiest_every_time() {
+        // hawk's fixture: `get-node alpha` came back with degree 1 or 3, 6/6 over twelve runs.
+        let recs = [("domain/alpha-one", "alpha", "Domain", 3), ("domain/alpha-two", "alpha", "Domain", 1)];
+        assert_eq!(resolve_always(&recs, "alpha"), id("domain/alpha-one"));
+    }
+
+    #[test]
+    fn a_concept_from_extract_keeps_winning_a_shared_slug() {
+        // 0.13.17 resolved `concept/<slug>` and nothing else; an extract-era store
+        // must keep naming the concept, however busy the domain beside it is.
+        let recs = [("domain/alpha", "alpha", "Domain", 40), ("concept/alpha", "alpha", "module", 2)];
+        assert_eq!(resolve_always(&recs, "alpha"), id("concept/alpha"));
+    }
+
+    #[test]
+    fn a_hub_beats_a_busier_handoff_on_an_exact_name() {
+        let recs = [("domain/base", "base", "Domain", 2), ("handoff/2026-09-05-x-base", "base", "Handoff", 9)];
+        assert_eq!(resolve_always(&recs, "base"), id("domain/base"));
+    }
+
+    #[test]
+    fn a_slug_of_any_kind_hits_the_slug_step_not_substring() {
+        // Milestones are outside the preference list; the slug must still resolve
+        // directly instead of falling through to a substring match on a note.
+        let recs = [("milestone/ship-v1", "Ship v1", "Milestone", 1), ("note/n1", "why ship v1 slipped", "Note", 1)];
+        assert_eq!(resolve_always(&recs, "ship-v1"), id("milestone/ship-v1"));
+    }
+
+    #[test]
+    fn substring_ambiguity_still_errors_with_the_candidates() {
+        let recs = [("note/n1", "alpha one", "Note", 1), ("note/n2", "alpha two", "Note", 1)];
+        let (nodes, adj) = store(&recs, 0);
+        let err = resolve(&nodes, &adj, &ns(), "alpha").unwrap_err().to_string();
+        assert!(err.contains("ambiguous (2 matches)"), "{err}");
+    }
 }


### PR DESCRIPTION
## What changes for a user

`base graph analyze`, `query`, `neighbors`, `path` and `get-node` now see every relationship base itself writes (`relatedTo`, `references`, `hasDecision`, `hasDomain`, `belongsTo`, `hasRule`, `hasTask`…), not only the `SemanticEdge` objects that `base graph extract` produces. On a store that never ran extract, which is every store that has not paid for the LLM pass:

```
base graph analyze -n 5     2217 nodes (0 connected) · 0 edges · 0 communities
                        ->  5896 nodes (3554 connected) · 4157 edges · 342 communities
base graph neighbors basemode --depth 1
                            'basemode' is ambiguous (53 matches)
                        ->  113 edges, each naming its relation
```

Every command is faster than before (analyze 0.77s → 0.52s median of 5) because the store is parsed once instead of once per query.

Name resolution is deterministic. Before, the query seeder, `resolve()` and the bridges printer broke ties through `HashMap` iteration: eleven records labelled exactly `basemode` made `graph query basemode --raw` return 3, 74, 140, 141, 211 or 323 nodes on the same store, and two same-kind records sharing a name resolved to either one, run to run. Ties now break on text score, then degree, then record kind, then id; traversal, render, bridge pairs and equal-sized communities are sorted. Six identical runs of every command hash identically.

## Compatibility

- The kind order keeps `concept` first, so a store where `graph extract` has run resolves `neighbors alpha` to `concept/alpha` exactly as 0.13.17 did.
- The slug lookup tries any record kind (milestone, rule, note…), not a fixed list; the list only orders ties.
- A same-kind tie (two domains both named `alpha`) picks the busiest and prints a stderr note naming the pick.
- Stores with no `rdf:type` still get the `base (domain) <-> base (project)` qualifier in the bridges section, read off the IRI.
- Read side only: no write path, no hook, no store format change. Verified on the C10 artefact store (unknown predicate, stamp, new type), an empty scaffold, a TriG-era workspace, a global-tier copy, and read-back by v0.12.0.

## Why

base's read surface was written for an extract-first world: the loader matched only reified edges, the node query read `ops:conceptType`, and `resolve()` built a `concept/<slug>` IRI that no normal write produces. The deterministic graph base writes for itself was never wired into its own readers.

## Verification

- `cargo test` twice in a row and `cargo clippy --all-targets -- -D warnings`, all green.
- 24 unit tests: direct-only, SemanticEdge-only, both, neither, body/slug labelling, namespace boundary, adjacency order, seed determinism (20 rebuilt maps), whole-output determinism, resolve determinism and kind preference, bridge order.
- Independent second reader (hawk): 10-check before/after instrument on the live 13 MB store and fixture stores; the four instabilities it found are fixed here.

Closes #42

https://claude.ai/code/session_014T1oiWH8KA2GduL9v1JXgz