### PR TITLE
fix(sync): --repair writes the repairs it prints, one statement at a time

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1955,8 +1955,15 @@ pub fn run() {
         // ─── Sync ────────────────────────────────────────
         Some(Commands::Sync { incremental, ast, target, yes, repair }) => {
             if repair {
+                // The lines print after the write has landed: a repair that is on
+                // stdout is on disk.
                 match base::crud::repair_edges(&cwd, &config.namespace) {
-                    Ok(count) => println!("Repair complete: {count} edges backfilled"),
+                    Ok(lines) => {
+                        for line in &lines {
+                            println!("  + {line}");
+                        }
+                        println!("Repair complete: {} edges backfilled", lines.len());
+                    }
                     Err(e) => die("Repair failed", e),
                 }
                 return;

--- a/src/crud/mod.rs
+++ b/src/crud/mod.rs
@@ -301,48 +301,92 @@ pub fn term_display(term: oxigraph::model::TermRef<'_>) -> String {
     }
 }
 
+/// One edge `sync --repair` found missing: the statement that adds it, and the line
+/// a person reads once it has landed.
+struct Repair {
+    line: String,
+    insert: String,
+}
+
 /// Backfill missing relationship edges for existing entities.
 /// Parses entity slugs to infer parent relationships and creates edges where missing.
-pub fn repair_edges(cwd: &Path, ns: &NamespaceConfig) -> Result<usize> {
+///
+/// The repairs are computed first, then applied one statement at a time inside a
+/// single `mutate_and_write`, so the snapshot the change record diffs against is
+/// taken before any of them lands. Nothing prints until the write has reached disk.
+///
+/// 0.13.17 and earlier applied each INSERT to the in-memory store, printed it as
+/// done, then joined every statement — each carrying its own `PREFIX` block — into
+/// ONE update for the write. SPARQL allows one prologue, so the batch died at the
+/// second `PREFIX`: exit 1, thirteen `+` lines already on stdout, store byte-identical.
+/// Returns the human lines for the edges written, in the order they were applied.
+pub fn repair_edges(cwd: &Path, ns: &NamespaceConfig) -> Result<Vec<String>> {
+    // Absent is not empty: `load_workspace_store` starts an empty store when the
+    // file is missing, which is right for a first `base learn` and wrong here — a
+    // repair of nothing would report success and leave a new, empty graph.nq
+    // where a moved or deleted store used to be.
+    let missing = require_base_for_write(cwd)?.join("graph.nq");
+    if !missing.exists() {
+        anyhow::bail!(
+            "no graph at {}: nothing to repair (run `base scaffold`, or restore the store)",
+            missing.display()
+        );
+    }
     let (store, trig_path) = load_workspace_store(cwd)?;
     let ws_slug = workspace_slug(cwd);
     let graph = workspace_graph_iri(ns, &ws_slug);
     let p = &ns.prefix;
     let pfx = prefixes(ns);
-    // Each repair applies its own INSERT DATA; collect them so the change log
-    // carries the actual delta rather than an opaque "a repair happened".
-    let mut applied: Vec<String> = Vec::new();
+    let mut repairs: Vec<Repair> = Vec::new();
 
     // 1. Decisions → domain edges (slug format: {domain}.{decision})
-    applied.extend(repair_entity_edges(
+    repairs.extend(missing_parent_edges(
         &store, &pfx, &graph, ns, p,
         "Decision", "domain", "hasDecision",
     )?);
 
     // 2. Milestones → project edges (slug format: {project}.{milestone})
-    applied.extend(repair_entity_edges(
+    repairs.extend(missing_parent_edges(
         &store, &pfx, &graph, ns, p,
         "Milestone", "project", "hasMilestone",
     )?);
 
     // 3. Tasks → project edges (slug format: {project}.{task})
-    applied.extend(repair_entity_edges(
+    repairs.extend(missing_parent_edges(
         &store, &pfx, &graph, ns, p,
         "Task", "project", "hasTask",
     )?);
 
-    crate::store::update_and_write(
+    if repairs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // The change record carries the statements themselves, so it says which edges
+    // were added rather than "a repair happened". They are logged joined and
+    // executed separately; the join is text, never a single update.
+    let log_text = repairs.iter().map(|r| r.insert.as_str()).collect::<Vec<_>>().join(";\n");
+    crate::store::mutate_and_write(
         &store,
         &trig_path,
-        &applied.join(";\n"),
+        &log_text,
         crate::store::Scope::Target,
         crate::store::Intent::Knowledge,
+        |s| {
+            for r in &repairs {
+                // One failure aborts the batch before the write, so the disk never
+                // holds half a repair and the exit code says so.
+                s.update(&r.insert).with_context(|| format!("applying repair {}", r.line))?;
+            }
+            Ok(Some(log_text.clone()))
+        },
     )?;
-    Ok(applied.len())
+    Ok(repairs.into_iter().map(|r| r.line).collect())
 }
 
+/// The `{parent} --predicate--> {entity}` edges missing for one entity type,
+/// computed without touching the store.
 #[allow(clippy::too_many_arguments)] // internal helper, params are query fragments
-fn repair_entity_edges(
+fn missing_parent_edges(
     store: &Store,
     pfx: &str,
     graph: &str,
@@ -351,16 +395,17 @@ fn repair_entity_edges(
     type_name: &str,
     parent_type: &str,
     predicate: &str,
-) -> Result<Vec<String>> {
-    // Find all entities of this type (check both named graph and any graph)
+) -> Result<Vec<Repair>> {
+    // Find all entities of this type (check both named graph and any graph). The
+    // UNION can yield one entity twice; DISTINCT keeps each repair to one line.
     let sparql = format!(
-        "{pfx}\nSELECT ?s WHERE {{ {{ GRAPH <{graph}> {{ ?s rdf:type {p}:{type_name} }} }} UNION {{ GRAPH ?g {{ ?s rdf:type {p}:{type_name} }} }} }}"
+        "{pfx}\nSELECT DISTINCT ?s WHERE {{ {{ GRAPH <{graph}> {{ ?s rdf:type {p}:{type_name} }} }} UNION {{ GRAPH ?g {{ ?s rdf:type {p}:{type_name} }} }} }}"
     );
 
-    let mut applied: Vec<String> = Vec::new();
+    let mut repairs: Vec<Repair> = Vec::new();
 
     if let Ok(QueryResults::Solutions(solutions)) = store.query(&sparql) {
-        let iris: Vec<String> = solutions
+        let mut iris: Vec<String> = solutions
             .filter_map(|r| r.ok())
             .filter_map(|row| row.get("s").map(|t| {
                 match t.into() {
@@ -369,6 +414,8 @@ fn repair_entity_edges(
                 }
             }))
             .collect();
+        iris.sort();
+        iris.dedup();
 
         for iri in &iris {
             // Extract slug from IRI (everything after the last /)
@@ -400,20 +447,19 @@ fn repair_entity_edges(
                 continue; // Parent doesn't exist
             }
 
-            // Create edge
+            // The edge to add — applied later, inside the write seam, never here.
             let insert = format!(
                 "{pfx}\nINSERT DATA {{ GRAPH <{graph}> {{ <{parent_iri}> {p}:{predicate} <{iri}> }} }}"
             );
-
-            if store.update(&insert).is_ok() {
-                applied.push(insert);
-                let short_slug = slug.split('.').next_back().unwrap_or(slug);
-                println!("  + {parent_slug} → {predicate} → {short_slug}");
-            }
+            let short_slug = slug.split('.').next_back().unwrap_or(slug);
+            repairs.push(Repair {
+                line: format!("{parent_slug} → {predicate} → {short_slug}"),
+                insert,
+            });
         }
     }
 
-    Ok(applied)
+    Ok(repairs)
 }
 
 #[cfg(test)]

--- a/tests/sync_repair_test.rs
+++ b/tests/sync_repair_test.rs
@@ -1,0 +1,162 @@
+//! `base sync --repair` must land the edges it computes.
+//!
+//! 0.13.17 computed the right repairs, applied them to the in-memory store, printed
+//! each as `+ parent → predicate → child`, then joined every statement — each with
+//! its own `PREFIX` block — into ONE update for the write. SPARQL allows a single
+//! prologue, so the batch failed to parse at the second `PREFIX`: exit 1, the `+`
+//! lines already on stdout, and the store byte-identical. These tests hold the
+//! contract the fix restores: repairs reach disk, a run that finds nothing writes
+//! nothing, and the change record names the edges.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base::changelog::LOG_FILE;
+use base::config::NamespaceConfig;
+use base::crud;
+use oxigraph::sparql::QueryResults;
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+/// A workspace whose store holds `n` decisions filed under `domain/alpha` by slug
+/// (`alpha.dec-<i>`) but with no `hasDecision` edge — the shape a store written
+/// before edges existed left behind, and the one `--repair` is for. Plus one
+/// decision whose parent domain does not exist, which must be left alone.
+fn workspace(home: &Path, n: usize) -> PathBuf {
+    let ws = home.join("proj");
+    let base = ws.join(".base");
+    fs::create_dir_all(&base).unwrap();
+    let u = ns().uri.clone();
+    let g = crud::workspace_graph_iri(&ns(), "proj");
+    let mut body = String::new();
+    body += &format!("<{u}domain/alpha> <{RDF_TYPE}> <{u}Domain> <{g}> .\n");
+    body += &format!("<{u}domain/alpha> <{u}name> \"alpha\" <{g}> .\n");
+    for i in 0..n {
+        body += &format!("<{u}decision/alpha.dec-{i}> <{RDF_TYPE}> <{u}Decision> <{g}> .\n");
+        body += &format!("<{u}decision/alpha.dec-{i}> <{u}name> \"decision {i}\" <{g}> .\n");
+    }
+    body += &format!("<{u}decision/ghost.dec-x> <{RDF_TYPE}> <{u}Decision> <{g}> .\n");
+    fs::write(base.join("graph.nq"), body).unwrap();
+    ws
+}
+
+fn graph_file(ws: &Path) -> PathBuf {
+    ws.join(".base").join("graph.nq")
+}
+
+/// `hasDecision` edges on disk — read back from the file, never from memory.
+fn edges_on_disk(ws: &Path) -> Vec<String> {
+    let store = base::store::load_graph(&graph_file(ws)).unwrap();
+    let q = format!(
+        "PREFIX {p}: <{u}>\nSELECT ?parent ?d WHERE {{ GRAPH ?g {{ ?parent {p}:hasDecision ?d }} }}",
+        p = ns().prefix,
+        u = ns().uri
+    );
+    let QueryResults::Solutions(sols) = store.query(&q).unwrap() else { panic!("expected solutions") };
+    let mut out: Vec<String> = sols
+        .filter_map(|r| r.ok())
+        .map(|row| format!("{} {}", row.get("parent").unwrap(), row.get("d").unwrap()))
+        .collect();
+    out.sort();
+    out
+}
+
+fn change_records(ws: &Path) -> Vec<serde_json::Value> {
+    let log = ws.join(".base").join(LOG_FILE);
+    if !log.exists() {
+        return Vec::new();
+    }
+    fs::read_to_string(&log)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("every log line is JSON"))
+        .collect()
+}
+
+#[test]
+fn two_pending_repairs_both_land_on_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let ws = workspace(tmp.path(), 2);
+        let before = fs::read(graph_file(&ws)).unwrap();
+        assert!(edges_on_disk(&ws).is_empty(), "precondition: no edges yet");
+
+        let lines = crud::repair_edges(&ws, &ns()).unwrap();
+
+        assert_eq!(lines.len(), 2, "{lines:?}");
+        assert!(lines.iter().all(|l| l.starts_with("alpha → hasDecision → dec-")), "{lines:?}");
+        let edges = edges_on_disk(&ws);
+        assert_eq!(edges.len(), 2, "both repairs must be in the file: {edges:?}");
+        assert!(edges.iter().all(|e| e.contains("domain/alpha") && e.contains("decision/alpha.dec-")), "{edges:?}");
+        assert_ne!(fs::read(graph_file(&ws)).unwrap(), before, "the store must change on disk");
+    });
+}
+
+#[test]
+fn a_second_run_finds_nothing_and_leaves_the_store_untouched() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let ws = workspace(tmp.path(), 2);
+        crud::repair_edges(&ws, &ns()).unwrap();
+        let after_first = fs::read(graph_file(&ws)).unwrap();
+        let records_after_first = change_records(&ws).len();
+
+        let lines = crud::repair_edges(&ws, &ns()).unwrap();
+
+        assert!(lines.is_empty(), "nothing left to repair: {lines:?}");
+        assert_eq!(fs::read(graph_file(&ws)).unwrap(), after_first, "an empty repair must not rewrite the store");
+        assert_eq!(change_records(&ws).len(), records_after_first, "an empty repair leaves no change record");
+    });
+}
+
+#[test]
+fn an_orphan_without_a_parent_is_skipped_not_invented() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let ws = workspace(tmp.path(), 0);
+        let before = fs::read(graph_file(&ws)).unwrap();
+
+        let lines = crud::repair_edges(&ws, &ns()).unwrap();
+
+        assert!(lines.is_empty(), "{lines:?}");
+        assert!(edges_on_disk(&ws).is_empty());
+        assert_eq!(fs::read(graph_file(&ws)).unwrap(), before);
+        assert!(!fs::read_to_string(graph_file(&ws)).unwrap().contains("domain/ghost"), "no parent may be conjured");
+    });
+}
+
+#[test]
+fn a_workspace_without_a_store_is_refused_and_no_store_is_created() {
+    // Absent is not empty: 0.13.17 answered "Repair complete: 0 edges backfilled"
+    // here and left a new, empty graph.nq behind.
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let ws = tmp.path().join("proj");
+        fs::create_dir_all(ws.join(".base")).unwrap();
+
+        let err = crud::repair_edges(&ws, &ns()).unwrap_err().to_string();
+
+        assert!(err.contains("nothing to repair"), "{err}");
+        assert!(!graph_file(&ws).exists(), "no store may be conjured by a repair");
+    });
+}
+
+#[test]
+fn the_write_leaves_one_change_record_naming_every_edge() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        let ws = workspace(tmp.path(), 3);
+        crud::repair_edges(&ws, &ns()).unwrap();
+
+        let records = change_records(&ws);
+        assert_eq!(records.len(), 1, "one write, one record: {records:?}");
+        let sparql = records[0]["sparql"].as_str().expect("the record carries the statements");
+        assert_eq!(sparql.matches("hasDecision").count(), 3, "every edge is named in the record: {sparql}");
+        assert_eq!(sparql.matches("INSERT DATA").count(), 3);
+    });
+}


### PR DESCRIPTION
## What changes for a user

`base sync --repair` now writes the edges it reports. Before, it computed and printed every repair and wrote none of them: each statement carried its own `PREFIX` block and all of them were joined into one SPARQL update, which fails to parse at the second prologue. Exit was 1 but the `+` lines had already printed, so a reader of the output saw success and the store was byte-identical.

Now the repairs are computed first and applied one statement at a time inside the sanctioned write seam, the change record names every edge, nothing prints until the write has landed, a failing statement aborts before anything reaches disk, and an empty run writes nothing.

## Why

The domain-normalisation migration was going to ride `--repair`; it cannot until the command writes. Separate shipped defect regardless.

## Verification

- Four integration tests (`tests/sync_repair_test.rs`): two pending repairs land on disk, idempotent second run, orphan without a parent skipped, one change record naming every edge.
- `cargo test` twice, `cargo clippy --all-targets -- -D warnings`.
- Independent (hawk): printed == written == expected set from an rdflib reimplementation, on a copy of the live store; only `hasDecision`/`hasMilestone`/`hasTask` counts move; idempotent.

Closes #44

https://claude.ai/code/session_014T1oiWH8KA2GduL9v1JXgz