### PR TITLE
fix(update): refresh the installed CLAUDE.md contract once per version

### DIFF
--- a/scripts/changelog-notes/0.13.18.md
+++ b/scripts/changelog-notes/0.13.18.md
@@ -1,0 +1,3 @@
+This release makes the relational graph commands read the edges base writes for itself, makes `sync --repair` actually write the repairs it prints, and refreshes the installed CLAUDE.md contract once per version at session start, so an agent on an old install stops running an old contract.
+
+**Windows installs older than 0.13.4 cannot receive this or any update.** That version fixed self-update on Windows, and the fix ships inside the update those installs cannot apply; `base update` on them prints "Run: base update" and cannot succeed. Bootstrap once with the release zip or `npx chrisai`, after which base updates itself in place.

--- a/src/hook/session_start.rs
+++ b/src/hook/session_start.rs
@@ -48,6 +48,19 @@ pub fn handle(config: &BaseConfig, cwd: &Path, session_id: Option<&str>) -> Resu
         );
     }
 
+    // The installed CLAUDE.md contract refreshes here, once per version, for the
+    // same reason: the process that runs `base update` is the outgoing binary and
+    // carries the old text, so only the new binary's first session can write its own.
+    match crate::install::ensure_claude_md_current() {
+        Some(crate::install::ClaudeMdRefresh::Refreshed) => {
+            println!("[contract] refreshed the BASE CLI section of ~/.claude/CLAUDE.md to this release.");
+        }
+        Some(crate::install::ClaudeMdRefresh::Duplicate(n)) => {
+            println!("[contract] ~/.claude/CLAUDE.md carries {n} '## BASE CLI' sections; base refreshes none until one remains.");
+        }
+        _ => {}
+    }
+
     // Every app gets a code map the first time a session opens in it — a
     // marked repo, or a bare folder of source files nobody has `git init`ed
     // yet — and a refresh when it has one (Chris, 2026-09-01: "anytime a dev

--- a/src/install.rs
+++ b/src/install.rs
@@ -1492,7 +1492,10 @@ fn seed_system_rules(global_dir: &Path) -> Result<()> {
 
 // ─── Step 7: CLAUDE.md integration ──────────────────────────
 
-const BASE_CLI_SECTION: &str = r#"
+/// The contract `base install` writes into `~/.claude/CLAUDE.md` and
+/// `refresh_claude_md_section` keeps current. Public so a test can hold the
+/// installed text against it.
+pub const BASE_CLI_SECTION: &str = r#"
 ## BASE CLI — Proactive Context Engine
 
 The `base` binary is on PATH. Use these commands proactively during sessions — they write to a knowledge graph that persists across sessions and surfaces context automatically.
@@ -1691,7 +1694,12 @@ fn append_claude_md(claude_md_path: &Path) -> Result<()> {
     let content = std::fs::read_to_string(claude_md_path)?;
 
     if content.contains("## BASE CLI") {
-        println!("already present");
+        // Present from an earlier release: bring it to this one instead of
+        // leaving whatever contract the install date happened to carry.
+        match refresh_claude_md_section(claude_md_path)? {
+            ClaudeMdRefresh::Refreshed => println!("✓ (refreshed BASE CLI section to this release)"),
+            _ => println!("already present"),
+        }
         return Ok(());
     }
 
@@ -1707,6 +1715,131 @@ fn append_claude_md(claude_md_path: &Path) -> Result<()> {
 
     println!("✓ (appended BASE CLI section)");
     Ok(())
+}
+
+/// What `refresh_claude_md_section` found, and did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaudeMdRefresh {
+    /// `~/.claude/CLAUDE.md` does not exist. `base install` creates it; an update does not.
+    Missing,
+    /// The file carries no `## BASE CLI` section: removed on purpose, or never
+    /// installed. Left alone; `base install` adds one.
+    NotInstalled,
+    /// The section already matches this release's text. Nothing written.
+    Current,
+    /// The section was replaced with this release's text; nothing outside it moved.
+    Refreshed,
+    /// More than one `## BASE CLI` heading. Nothing touched: refreshing the first
+    /// would leave the others as stale duplicates, silently, on every run.
+    Duplicate(usize),
+}
+
+/// Bring the `## BASE CLI` section of `claude_md_path` up to this release's text,
+/// touching nothing outside it.
+///
+/// `base update` refreshed the binary, `scripts/` and the coach skill, and never
+/// the installed CLAUDE.md contract, so every change to it since a user's install
+/// date stayed on disk as the day they installed. The section is bounded the way
+/// `remove_claude_md_section` bounds it — from the `## BASE CLI` heading to the
+/// line before the next `## ` heading, or the end of the file — and only that
+/// span is rewritten: the section is base's, so non-blank text a user wrote INSIDE
+/// it is rewritten with it; blank lines before the user's own next heading are
+/// theirs and stay. A file that uses CRLF keeps CRLF; a leading BOM stays. Idempotent:
+/// a section that already matches is not rewritten, so repeat updates do not churn
+/// the file. Two `## BASE CLI` headings are reported, not resolved.
+pub fn refresh_claude_md_section(claude_md_path: &Path) -> Result<ClaudeMdRefresh> {
+    if !claude_md_path.exists() {
+        return Ok(ClaudeMdRefresh::Missing);
+    }
+    let content = std::fs::read_to_string(claude_md_path)
+        .with_context(|| format!("reading {}", claude_md_path.display()))?;
+    // A BOM would hide a heading on the first line from `starts_with`.
+    let bom = if content.starts_with('\u{feff}') { '\u{feff}'.len_utf8() } else { 0 };
+    let headings = content[bom..]
+        .lines()
+        .filter(|l| l.trim_end_matches('\r').starts_with("## BASE CLI"))
+        .count();
+    if headings > 1 {
+        return Ok(ClaudeMdRefresh::Duplicate(headings));
+    }
+    let Some((start, end)) = base_cli_span(&content[bom..]) else {
+        return Ok(ClaudeMdRefresh::NotInstalled);
+    };
+    let (start, end) = (start + bom, end + bom);
+    let current = BASE_CLI_SECTION.trim();
+    if content[start..end].replace("\r\n", "\n") == current {
+        return Ok(ClaudeMdRefresh::Current);
+    }
+    let crlf = content.contains("\r\n");
+    let body = if crlf { current.replace('\n', "\r\n") } else { current.to_string() };
+    let mut out = String::with_capacity(content.len() + body.len());
+    out.push_str(&content[..start]);
+    out.push_str(&body);
+    out.push_str(&content[end..]);
+    let tmp = claude_md_path.with_extension("md.tmp");
+    std::fs::write(&tmp, &out).with_context(|| format!("writing {}", tmp.display()))?;
+    std::fs::rename(&tmp, claude_md_path)
+        .with_context(|| format!("replacing {}", claude_md_path.display()))?;
+    Ok(ClaudeMdRefresh::Refreshed)
+}
+
+/// Byte span `[start, end)` of the installed section: from the `## BASE CLI`
+/// heading through the last non-blank line before the next `## ` heading (a
+/// `### ` sub-heading belongs to the section) or the end of the file. `end` sits
+/// before that last line's newline.
+fn base_cli_span(content: &str) -> Option<(usize, usize)> {
+    let mut start = None;
+    let mut end = None;
+    let mut pos = 0usize;
+    for line in content.split_inclusive('\n') {
+        let text = line.trim_end_matches(['\n', '\r']);
+        if start.is_none() {
+            if text.starts_with("## BASE CLI") {
+                start = Some(pos);
+                end = Some(pos + text.len());
+            }
+        } else if text.starts_with("## ") {
+            break;
+        } else if !text.trim().is_empty() {
+            end = Some(pos + text.len());
+        }
+        pos += line.len();
+    }
+    Some((start?, end?))
+}
+
+/// The stamp `ensure_claude_md_current` leaves: keyed on the section TEXT this
+/// binary carries, not on the version. Two builds can share a version and differ
+/// in text (a dev build beside the release of the same number, on one machine);
+/// keyed on the version, whichever ran first would stamp and the other would be
+/// skipped for good. `DefaultHasher::new()` is SipHash with fixed keys, so the
+/// name is the same for the same text on every run and every machine.
+pub fn claude_md_stamp_name() -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    BASE_CLI_SECTION.hash(&mut h);
+    format!(".claude-md-{:016x}", h.finish())
+}
+
+/// Session start: bring the CLAUDE.md contract up to the text this binary
+/// carries, once per text — the shape of `ensure_hooks_wired`, for the same
+/// reason. The auto-update swaps the binary and touches nothing else, and the
+/// process that runs `base update` is the OUTGOING binary, whose section text is
+/// the old contract; only the new binary can write its own. Returns what
+/// happened, for a one-line notice, or `None` when this text has already run.
+/// The stamp is written only after a successful attempt (the inverse of
+/// `auto_compact_tiers`, deliberately: a retry here costs one stat and one read),
+/// so a transient read error retries at the next session instead of being
+/// skipped for a whole release.
+pub fn ensure_claude_md_current() -> Option<ClaudeMdRefresh> {
+    let home = crate::home::home_root()?;
+    let stamp = home.join(".base-gbl").join(claude_md_stamp_name());
+    if stamp.exists() {
+        return None;
+    }
+    let result = refresh_claude_md_section(&home.join(".claude").join("CLAUDE.md")).ok()?;
+    let _ = std::fs::write(&stamp, b"");
+    Some(result)
 }
 
 #[cfg(test)]

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -583,7 +583,7 @@ fn run_verbose(check_only: bool, force: bool) -> Result<Option<String>> {
             println!("✓ refreshed {n} shipped script file(s) in ~/.base-gbl/scripts/");
         }
         refresh_skills(&skill_ver, crate::install::SkillReport::Line);
-        println!("  (any hook this release adds is wired at the next session start.)");
+        println!("  (any hook this release adds is wired, and the CLAUDE.md section refreshed, at the next session start.)");
         Ok(Some(skill_ver))
     })();
     let _ = std::fs::remove_dir_all(&work);

--- a/tests/claude_md_refresh_test.rs
+++ b/tests/claude_md_refresh_test.rs
@@ -1,0 +1,141 @@
+//! `base update` never refreshed the installed CLAUDE.md contract: the binary,
+//! `scripts/` and the coach skill moved with each release while the `## BASE CLI`
+//! section stayed as the install date left it. These tests hold the refresh that
+//! closes that: only the section is rewritten, everything a user wrote around it is
+//! byte-identical, repeat runs write nothing, and the once-per-version session-start
+//! path runs exactly once.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base::install::{
+    claude_md_stamp_name, ensure_claude_md_current, refresh_claude_md_section, ClaudeMdRefresh, BASE_CLI_SECTION,
+};
+
+const ABOVE: &str = "# Mine\n\nKeep this exactly as it is.\n\n";
+const OLD_SECTION: &str = "## BASE CLI — Proactive Context Engine\n\nSome earlier release's text.\n\n### An old sub-heading\n- stale bullet\n";
+const BELOW: &str = "\n\n## My rules\n\nAnd keep this too.\n";
+
+fn claude_md(home: &Path, body: &str) -> PathBuf {
+    let dir = home.join(".claude");
+    fs::create_dir_all(&dir).unwrap();
+    let p = dir.join("CLAUDE.md");
+    fs::write(&p, body).unwrap();
+    p
+}
+
+fn current() -> &'static str {
+    BASE_CLI_SECTION.trim()
+}
+
+#[test]
+fn an_old_section_is_replaced_and_the_users_text_around_it_is_untouched() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = claude_md(tmp.path(), &format!("{ABOVE}{OLD_SECTION}{BELOW}"));
+
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Refreshed);
+
+    let got = fs::read_to_string(&p).unwrap();
+    // The newline that ended the old section's last line is outside the span and stays.
+    assert_eq!(got, format!("{ABOVE}{}\n{BELOW}", current()), "only the section moves");
+    assert!(!got.contains("stale bullet"));
+    assert!(!p.with_extension("md.tmp").exists(), "the temp file is gone");
+}
+
+#[test]
+fn a_current_section_is_not_rewritten() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = claude_md(tmp.path(), &format!("{ABOVE}{OLD_SECTION}{BELOW}"));
+    refresh_claude_md_section(&p).unwrap();
+    let after_first = fs::read(&p).unwrap();
+    let mtime = fs::metadata(&p).unwrap().modified().unwrap();
+
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Current);
+
+    assert_eq!(fs::read(&p).unwrap(), after_first);
+    assert_eq!(fs::metadata(&p).unwrap().modified().unwrap(), mtime, "no write at all");
+}
+
+#[test]
+fn a_section_at_the_end_of_the_file_is_replaced_in_place() {
+    // The shape `base install` leaves: the section is the last thing in the file.
+    let tmp = tempfile::tempdir().unwrap();
+    let p = claude_md(tmp.path(), &format!("{ABOVE}{OLD_SECTION}"));
+
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Refreshed);
+    assert_eq!(fs::read_to_string(&p).unwrap(), format!("{ABOVE}{}\n", current()));
+}
+
+#[test]
+fn a_crlf_file_keeps_crlf_and_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let body = format!("{ABOVE}{OLD_SECTION}{BELOW}").replace('\n', "\r\n");
+    let p = claude_md(tmp.path(), &body);
+
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Refreshed);
+    let got = fs::read_to_string(&p).unwrap();
+    assert!(got.starts_with(&ABOVE.replace('\n', "\r\n")), "user text keeps its line endings");
+    assert!(got.ends_with(&BELOW.replace('\n', "\r\n")));
+    assert!(!got.contains("stale bullet"));
+    assert!(!got.replace("\r\n", "").contains('\n'), "no bare LF was introduced: the section is CRLF too");
+
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Current);
+}
+
+#[test]
+fn a_missing_file_is_reported_and_not_created() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path().join(".claude").join("CLAUDE.md");
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Missing);
+    assert!(!p.exists());
+}
+
+#[test]
+fn a_file_without_the_section_is_left_alone() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = claude_md(tmp.path(), "# Mine\n\nI removed base's section on purpose.\n");
+    let before = fs::read(&p).unwrap();
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::NotInstalled);
+    assert_eq!(fs::read(&p).unwrap(), before);
+}
+
+#[test]
+fn a_bom_does_not_hide_a_heading_on_the_first_line_and_survives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = claude_md(tmp.path(), &format!("\u{feff}{OLD_SECTION}{BELOW}"));
+
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Refreshed);
+    let got = fs::read_to_string(&p).unwrap();
+    assert_eq!(got, format!("\u{feff}{}\n{BELOW}", current()));
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Current);
+}
+
+#[test]
+fn two_sections_are_reported_and_nothing_is_touched() {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = claude_md(tmp.path(), &format!("{ABOVE}{OLD_SECTION}\n{OLD_SECTION}{BELOW}"));
+    let before = fs::read(&p).unwrap();
+
+    assert_eq!(refresh_claude_md_section(&p).unwrap(), ClaudeMdRefresh::Duplicate(2));
+    assert_eq!(fs::read(&p).unwrap(), before, "a duplicate is a report, never a partial rewrite");
+}
+
+#[test]
+fn session_start_refreshes_once_per_version_and_stamps_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    base::home::with_thread_home(tmp.path(), || {
+        fs::create_dir_all(tmp.path().join(".base-gbl")).unwrap();
+        let p = claude_md(tmp.path(), &format!("{ABOVE}{OLD_SECTION}{BELOW}"));
+
+        assert_eq!(ensure_claude_md_current(), Some(ClaudeMdRefresh::Refreshed));
+        assert!(fs::read_to_string(&p).unwrap().contains(current()));
+        let stamp = tmp.path().join(".base-gbl").join(claude_md_stamp_name());
+        assert!(stamp.exists(), "the once-per-text stamp is written");
+        assert!(!claude_md_stamp_name().contains(env!("CARGO_PKG_VERSION")), "keyed on the text, not the version");
+
+        // Put the old text back: a stamped version must not touch the file again.
+        fs::write(&p, format!("{ABOVE}{OLD_SECTION}{BELOW}")).unwrap();
+        assert_eq!(ensure_claude_md_current(), None);
+        assert!(fs::read_to_string(&p).unwrap().contains("stale bullet"));
+    });
+}


### PR DESCRIPTION
## What changes for a user

After an update, the `## BASE CLI` section in `~/.claude/CLAUDE.md` is brought up to the release at the next session start, once per version. Only that section is rewritten: everything above and below it is byte-identical, blank lines before your own next heading stay, CRLF files stay CRLF, and a section that already matches is not touched. `base install` on an existing file now refreshes the section instead of reporting "already present". The update notice says where the refresh happens.

## Why it runs at session start and not inside `base update`

The process running `base update` is the outgoing binary, and its embedded section text is the old contract. The new binary's first session is the first process that can write the new text. The once-per-version sentinel is the shape `ensure_hooks_wired` already uses, and it also covers background auto-updates, which have no update process output at all, and the first hop from 0.13.17.

## Stragglers

Windows installs older than 0.13.4 cannot self-update; the fix shipped inside the update they cannot apply, and the in-product banner they see cannot be changed from here. The release notes carry the re-bootstrap instruction (`scripts/changelog-notes/0.13.18.md`).

## Verification

- Seven integration tests (`tests/claude_md_refresh_test.rs`).
- `cargo test` twice, `cargo clippy --all-targets -- -D warnings`.
- Independent second read (hawk).

Closes #45

https://claude.ai/code/session_014T1oiWH8KA2GduL9v1JXgz