### PR TITLE
feat(domain): every record carries a domain link, migrated in one idempotent pass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ isolation-guard = []
 [dev-dependencies]
 base = { path = ".", features = ["isolation-guard"] }
 tempfile = "3"
+# The dashboard's node/edge handlers are part of the read surface ruling 4
+# governs, so `tests/transient_kinds_test.rs` drives them directly. Same crate
+# and version the binary already links; nothing new enters the tree.
+axum = { version = "0.8", features = ["ws"] }

--- a/claude/skills/base-help/README.md
+++ b/claude/skills/base-help/README.md
@@ -7,7 +7,7 @@ A self-contained Claude Code skill that turns `/base-help [question]` into a coa
 | File | Role |
 | --- | --- |
 | `SKILL.md` | The skill logic: local-profile audit, bank-first answer flow, coaching format, beginner orientation |
-| `references/qa.md` | 180 question/answer pairs covering orientation, star commands, handoffs/forks, graph and memory, rules and domains, project scoping, ingestion, GraphRAG, AST navigation, hooks, relay, admin surfaces, known bugs, and destructive operations. Every pair carries a provenance tag |
+| `references/qa.md` | 181 question/answer pairs covering orientation, star commands, handoffs/forks, graph and memory, rules and domains, project scoping, ingestion, GraphRAG, AST navigation, hooks, relay, admin surfaces, known bugs, and destructive operations. Every pair carries a provenance tag |
 | `references/commands.md` | The command surface grouped by what is safe to run: read-only, mutating, and destructive, plus alias and flag gotchas |
 | `references/cli.md` | The verbatim `--help` of every subcommand, generated from the binary's own command tree at each release |
 

--- a/claude/skills/base-help/SKILL.md
+++ b/claude/skills/base-help/SKILL.md
@@ -13,7 +13,7 @@ Their question: **$ARGUMENTS**
 
 This skill is portable and contains **no machine-specific facts**. Machine state lives in a local profile; universal knowledge lives in three reference files next to this one:
 
-- `${CLAUDE_SKILL_DIR}/references/qa.md`: 180 verified Q&A pairs, the primary answer source (the count grows whenever the close-the-loop rule below appends one)
+- `${CLAUDE_SKILL_DIR}/references/qa.md`: 181 verified Q&A pairs, the primary answer source (the count grows whenever the close-the-loop rule below appends one)
 - `${CLAUDE_SKILL_DIR}/references/commands.md`: the command surface grouped by safety class (read-only, mutating, destructive), aliases, flag gotchas
 - `${CLAUDE_SKILL_DIR}/references/cli.md`: the verbatim `--help` of every subcommand, generated from the binary at each release; the authority for an exact flag
 

--- a/claude/skills/base-help/references/cli.md
+++ b/claude/skills/base-help/references/cli.md
@@ -140,6 +140,7 @@ Use it for exact syntax. `commands.md` groups the same surface by what is safe t
 - `base doctor`
 - `base graph`
 - `base graph compact`
+- `base graph migrate`
 - `base graph apply-ops`
 - `base graph purge`
 - `base graph extract`
@@ -2783,6 +2784,7 @@ Usage: base graph <COMMAND>
 
 Commands:
   compact    Dedup + canonicalize the workspace graph (atomic rewrite, snapshots first)
+  migrate    Give every covered record a domain link, once, per tier
   apply-ops  Apply inbound fact ops (JSON on stdin) into the local graph
   purge      Remove notes unread past --days (recency only). PREVIEW unless --apply
   extract    LLM semantic extraction over a doc corpus → concepts + edges in the graph. Markdown-only by default; PDF/image/audio/video need multimodal enabled (`base config set multimodal.enabled true`, or one-shot --multimodal)
@@ -2809,6 +2811,23 @@ Usage: base graph compact
 Options:
   -h, --help
           Print help
+```
+
+## base graph migrate
+
+```text
+Give every covered record a domain link, once, per tier.
+
+Normally runs itself at session start and needs no operator. This exists because `base doctor` reports "not migrated" for a tier whose graph was unhealthy when the hook tried — telling an operator about a problem they cannot then act on is worse than not telling them. Repair, then run this.
+
+Usage: base graph migrate [OPTIONS]
+
+Options:
+      --dry-run
+          Show what would be linked, and by which source, without writing
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 ## base graph apply-ops

--- a/claude/skills/base-help/references/commands.md
+++ b/claude/skills/base-help/references/commands.md
@@ -72,6 +72,7 @@ base graph analyze                       # god nodes, communities, bridges
 base graph get-node "<label>"
 base graph neighbors "<node>" -d <N>
 base graph path "<from>" "<to>"
+base graph migrate --dry-run             # what the domain backfill would link, by source
 ```
 
 Relay (read side):
@@ -213,6 +214,7 @@ base milestone delete <slug> [--force]           # without --force, detaches tas
 base task delete <slug> [--yes]
 base project move <slug> ... [--yes]     # preview unless --yes
 base graph compact
+base graph migrate                       # one-time domain backfill; snapshots, then atomic rewrite
 base graph purge --stale [--days N] [--apply]    # dry-run unless --apply
 base graph move ... [--yes]              # preview unless --yes; backs up both tiers
 base domain remove <name>

--- a/claude/skills/base-help/references/qa.md
+++ b/claude/skills/base-help/references/qa.md
@@ -816,6 +816,10 @@ Forks are additive, registering a new one never archives existing forks or the p
 - `base decision delete --keyword <kw>`: deletes decisions matching a keyword. `--keyword` is required (no accidental delete-everything), but there's no dry-run preview shown before the delete happens.
 <!-- v0.12.3 | verified: cli-help|reference -->
 
+### Q: What is `base graph migrate`, and do I ever need to run it?
+**A:** It gives every covered record a domain link, once per tier, and you normally never run it: it runs itself at session start and prints nothing when there is nothing to do. Run it by hand in one case — a tier whose graph was unhealthy when the hook tried is skipped, so `base doctor` keeps reporting `schema: not migrated` until you `base doctor --repair` and then `base graph migrate`. `--dry-run` shows what would be linked and by which source, and writes nothing. It is idempotent the hard way: the work is recomputed from the store on every run, and the schema stamp is written inside the *same* atomic rewrite as the links, so restoring a pre-migration `.bak` correctly re-migrates and restoring a post-migration one correctly does nothing. Where each record's domain came from is reported per source — frontmatter, path-trigger, project-path, fixed, parent, or `unfiled` — so the catchall is a visible line rather than a silent remainder. `base doctor` reports each tier's `schema:` and `without a domain: N` so a migration that never ran is never invisible.
+<!-- v0.13.19 | verified: cli-help -->
+
 ### Q: What does `base graph compact` / `base graph purge` / `base graph move` actually do?
 **A:** `compact` dedups and canonicalizes a workspace graph in an atomic rewrite, snapshotting first. `purge --stale [--days N] [--apply]` removes notes that haven't been read in more than N days (default 21); it's a dry-run preview unless you pass `--apply`. `move` relocates a subgraph between workspace graphs, rewriting its named-graph stamp; it previews by default and requires `--yes` to actually execute, backing up both source and destination tiers with rollback support.
 <!-- v0.12.3 | verified: cli-help -->

--- a/docs/graph-durability.md
+++ b/docs/graph-durability.md
@@ -78,6 +78,34 @@ Dedups + canonicalizes the workspace graph via an atomic rewrite (snapshots firs
 Idempotent — running it twice changes nothing. The safe replacement for a manual cleanup.
 Refuses an unhealthy graph (run `base doctor --repair` first).
 
+### Domain migration — `base graph migrate`
+```
+base graph migrate --dry-run          # what would be linked, and by which source
+base graph migrate                    # snapshot, link, stamp, atomic rewrite
+```
+Gives every covered record a domain link, once per tier. **Normally you never run
+this**: it runs itself at session start, and says nothing when there is nothing to
+do. Run it by hand after `base doctor --repair`, because a migration skips an
+unhealthy graph and `base doctor` will keep reporting `schema: not migrated`
+until it succeeds.
+
+Idempotent, and idempotent the hard way: the work is recomputed from the store
+every time, and the schema stamp is written **inside the same atomic rewrite as
+the links**. A stamp in a file beside the store would survive a `.bak` restore and
+claim a migration that is no longer in the data — so restoring a pre-migration
+snapshot correctly re-migrates, and restoring a post-migration one correctly does
+nothing.
+
+Where a record's domain comes from is reported per source, so the catchall
+(`unfiled`) is one line among the others rather than a silent remainder:
+```
+base: domain migration — 2871 record(s) now carry a domain.
+  by source: fixed 1434, parent 1241, path-trigger 510, unfiled 862, ...
+  by kind:   LoreKnowledge 929, AcceptanceCriteria 375, Document 999, ...
+```
+`base doctor` reports each tier's `schema:` line and `without a domain: N` so a
+migration that never ran is never invisible.
+
 ### Purge stale notes — `base graph purge --stale`
 ```
 base graph purge --stale              # PREVIEW: list notes unread > 21 days (writes nothing)
@@ -96,7 +124,10 @@ if they become relevant again.
 
 - **Naming:** `graph.nq.bak-<op>-<date>` (e.g. `graph.nq.bak-pre-repair-2026-06-19-140817`).
 - **Rotation:** the newest 10 snapshots are kept; older ones are rotated out automatically.
-- **Who snapshots:** repair, restore, compact, and purge all snapshot before mutating.
+- **Who snapshots:** repair, restore, compact, purge and migrate all snapshot before
+  mutating. They share one pool of 10, so a migration snapshot evicts the oldest
+  compact snapshot. A migration that finds nothing to do takes no snapshot, for
+  exactly that reason.
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3628,7 +3628,14 @@ pub fn run() {
                 if dry_run {
                     print!("{}", base::migrate::format_dry_run(&cwd, &config.namespace));
                 } else {
-                    let outcomes = base::migrate::migrate_tiers(&cwd, &config.namespace);
+                    // Manual: always re-plans past the stamp. `base doctor` reporting
+                    // orphans while this printed "nothing to migrate" was a false
+                    // statement to the operator (kite, PR #50).
+                    let outcomes = base::migrate::migrate_tiers(
+                        &cwd,
+                        &config.namespace,
+                        base::migrate::Trigger::Manual,
+                    );
                     let notice = base::migrate::format_outcomes(&outcomes);
                     if notice.is_empty() {
                         println!("Nothing to migrate — every covered record already carries a domain.");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -351,6 +351,17 @@ pub enum Commands {
 pub enum GraphAction {
     /// Dedup + canonicalize the workspace graph (atomic rewrite, snapshots first)
     Compact,
+    /// Give every covered record a domain link, once, per tier.
+    ///
+    /// Normally runs itself at session start and needs no operator. This exists
+    /// because `base doctor` reports "not migrated" for a tier whose graph was
+    /// unhealthy when the hook tried — telling an operator about a problem they
+    /// cannot then act on is worse than not telling them. Repair, then run this.
+    Migrate {
+        /// Show what would be linked, and by which source, without writing.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Apply inbound fact ops (JSON on stdin) into the local graph.
     ///
     /// The pull half of desktop sync. Reads either a bare array of ops or
@@ -3613,6 +3624,19 @@ pub fn run() {
                     std::process::exit(1);
                 }
             },
+            GraphAction::Migrate { dry_run } => {
+                if dry_run {
+                    print!("{}", base::migrate::format_dry_run(&cwd, &config.namespace));
+                } else {
+                    let outcomes = base::migrate::migrate_tiers(&cwd, &config.namespace);
+                    let notice = base::migrate::format_outcomes(&outcomes);
+                    if notice.is_empty() {
+                        println!("Nothing to migrate — every covered record already carries a domain.");
+                    } else {
+                        print!("{notice}");
+                    }
+                }
+            }
             GraphAction::Purge { stale, apply, days } => {
                 if !stale {
                     eprintln!("Usage: base graph purge --stale [--apply] [--days N]");

--- a/src/config.rs
+++ b/src/config.rs
@@ -459,6 +459,11 @@ pub struct GraphConfig {
     /// Minimum hours between auto-compactions of the same tier (anti-churn).
     #[serde(default = "default_compact_cooldown_hours")]
     pub compact_cooldown_hours: i64,
+    /// Master switch for the one-time domain migration (opt-out). On by default
+    /// because Chris's ruling is that it lands automatically with the update and
+    /// nobody straggles; off is for an operator who wants to run it by hand.
+    #[serde(default = "default_true")]
+    pub auto_migrate: bool,
 }
 
 fn default_compact_threshold_mb() -> u64 { 12 }
@@ -470,6 +475,7 @@ impl Default for GraphConfig {
             auto_compact: true,
             compact_threshold_mb: default_compact_threshold_mb(),
             compact_cooldown_hours: default_compact_cooldown_hours(),
+            auto_migrate: true,
         }
     }
 }

--- a/src/crud/handoff.rs
+++ b/src/crud/handoff.rs
@@ -111,6 +111,8 @@ pub fn create(
     let iri = crud::build_iri(ns, "handoff", &slug);
     let (path, graph) = write_tier(cwd, ns)?;
     let p = &ns.prefix;
+    // The project this handoff names, as the IRI its domain hangs off (kite F7b).
+    let project_iri = crud::build_iri(ns, "project", &crud::slugify(project));
     let project = crud::escape_sparql_literal(project);
     let doc = crud::escape_sparql_literal(doc_path);
 
@@ -146,7 +148,9 @@ pub fn create(
          }} }}"
     );
 
-    mutate_file(&path, ns, &format!("{archive_prior};\n{clean_target};\n{insert}"))?;
+    // 4. The handoff takes the domain of the project it names, in the same write.
+    let inherit = crate::domain::link::inherit_update(ns, &graph, &iri, &project_iri);
+    mutate_file(&path, ns, &format!("{archive_prior};\n{clean_target};\n{insert};\n{inherit}"))?;
     Ok(slug)
 }
 
@@ -167,6 +171,8 @@ pub fn create_fork(
     let iri = crud::build_iri(ns, "handoff", &slug);
     let (path, graph) = write_tier(cwd, ns)?;
     let p = &ns.prefix;
+    // The project this handoff names, as the IRI its domain hangs off (kite F7b).
+    let project_iri = crud::build_iri(ns, "project", &crud::slugify(project));
     let project = crud::escape_sparql_literal(project);
     let name = crud::escape_sparql_literal(&slug);
     let doc = crud::escape_sparql_literal(doc_path);
@@ -188,7 +194,9 @@ pub fn create_fork(
          }} }}"
     );
 
-    mutate_file(&path, ns, &insert)?;
+    // The fork takes the domain of the project it names, in the same write (kite F7b).
+    let inherit = crate::domain::link::inherit_update(ns, &graph, &iri, &project_iri);
+    mutate_file(&path, ns, &format!("{insert};\n{inherit}"))?;
     Ok(slug)
 }
 

--- a/src/crud/milestone.rs
+++ b/src/crud/milestone.rs
@@ -39,6 +39,13 @@ pub fn add(
          }}"
     );
 
+    // The milestone takes its project's domain now rather than at the next session
+    // start (kite F7b). A project with no domain links nothing here; the delta pass
+    // files it.
+    let sparql = format!(
+        "{sparql};\n{}",
+        crate::domain::link::inherit_update(ns, &graph, &ms_iri, &project_iri)
+    );
     crud::load_and_mutate(cwd, ns, &sparql)?;
     Ok(slug)
 }

--- a/src/crud/note.rs
+++ b/src/crud/note.rs
@@ -25,11 +25,19 @@ pub fn learn(
 
     let escaped_text = crud::escape_sparql_literal(text);
 
-    // Build relatedTo edges
+    // Build relational edges. The domain link is written under BOTH predicates
+    // for the 0.14.0 overlap: `hasDomain` is what every other record kind already
+    // uses (`crud/project.rs`, `crud/entity.rs`, `extract/paul_toml.rs`) and what
+    // N+1 keeps; `relatedTo` is what every 0.13.x reader still looks for, and
+    // dropping it now would blind a rolled-back binary to notes written meanwhile.
+    // See `domain::link` for the window.
     let mut edge_triples = String::new();
     if let Some(d) = domain {
         let domain_iri = crud::build_iri(ns, "domain", &crud::slugify(d));
-        edge_triples.push_str(&format!("      <{iri}> {p}:relatedTo <{domain_iri}> .\n"));
+        let canonical = crate::domain::link::CANONICAL;
+        let legacy = crate::domain::link::LEGACY;
+        edge_triples.push_str(&format!("      <{iri}> {p}:{canonical} <{domain_iri}> .\n"));
+        edge_triples.push_str(&format!("      <{iri}> {p}:{legacy} <{domain_iri}> .\n"));
     }
     if let Some(proj) = project {
         let proj_iri = crud::build_iri(ns, "project", &crud::slugify(proj));
@@ -69,19 +77,32 @@ pub fn recall_to_string(
     // Session traffic is excluded from every read surface by one list
     // (`ontology::transient`), never by a per-command filter.
     let no_transient = crate::ontology::transient::sparql_exclude(ns, "n");
+    // A note's domain link is `hasDomain` from 0.14.0 and `relatedTo` before it.
+    // Reading only one of them is how `base recall --domain` goes silently empty —
+    // an empty SPARQL result is indistinguishable from "no notes in that domain".
+    // `links_to` is an EXISTS test, not a triple pattern: during the overlap a note
+    // carries both predicates and a pattern would return it twice.
 
     let sparql = match (keyword, domain) {
         (Some(kw), Some(dom)) => {
             let kw_lower = crud::escape_sparql_literal(&kw.to_lowercase());
             let domain_iri = crud::build_iri(ns, "domain", &crud::slugify(dom));
+            let dlink = crate::domain::link::links_to(ns, "n", &domain_iri);
+            // DISTINCT because the two arms are not disjoint: a note that contains
+            // the keyword AND belongs to the domain satisfies both and is returned
+            // twice. Pre-existing in 0.13.x — the arms have never been deduped —
+            // and it only got easier to hit, so it is fixed here rather than left
+            // in a read this fork is already rewriting. It cannot merge two real
+            // notes: a note's IRI is `slugify(text)`, so equal text is one record.
             format!(
-                "SELECT ?text ?type ?created WHERE {{\n\
+                "SELECT DISTINCT ?text ?type ?created WHERE {{\n\
                    GRAPH ?g {{\n\
                      {{ ?n a {p}:Note ; {p}:noteText ?text ; {p}:noteType ?type .\n\
                         OPTIONAL {{ ?n {p}:createdAt ?created }}\n\
                         FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\"))\n\
                      }} UNION {{\n\
-                        ?n a {p}:Note ; {p}:noteText ?text ; {p}:noteType ?type ; {p}:relatedTo <{domain_iri}> .\n\
+                        ?n a {p}:Note ; {p}:noteText ?text ; {p}:noteType ?type .\n\
+                        {dlink}\n\
                         OPTIONAL {{ ?n {p}:createdAt ?created }}\n\
                      }}\n\
                      ?n {p}:status \"active\" .\n\
@@ -138,11 +159,12 @@ pub fn recall_to_string(
         }
         (None, Some(dom)) => {
             let domain_iri = crud::build_iri(ns, "domain", &crud::slugify(dom));
+            let dlink = crate::domain::link::links_to(ns, "n", &domain_iri);
             format!(
                 "SELECT ?text ?type ?created WHERE {{\n\
                    GRAPH ?g {{\n\
-                     ?n a {p}:Note ; {p}:noteText ?text ; {p}:noteType ?type ; {p}:status \"active\" ;\n\
-                       {p}:relatedTo <{domain_iri}> .\n\
+                     ?n a {p}:Note ; {p}:noteText ?text ; {p}:noteType ?type ; {p}:status \"active\" .\n\
+                     {dlink}\n\
                      OPTIONAL {{ ?n {p}:createdAt ?created }}\n\
                      {no_transient}\
                    }}\n\
@@ -230,11 +252,12 @@ pub fn recalled_note_iris(
         (Some(kw), Some(dom)) => {
             let kw_lower = crud::escape_sparql_literal(&kw.to_lowercase());
             let domain_iri = crud::build_iri(ns, "domain", &crud::slugify(dom));
+            let dlink = crate::domain::link::links_to(ns, "n", &domain_iri);
             format!(
                 "{{ ?n a {p}:Note ; {p}:noteText ?text ; {p}:status \"active\" .\n\
                     FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\")) }}\n\
                  UNION\n\
-                 {{ ?n a {p}:Note ; {p}:status \"active\" ; {p}:relatedTo <{domain_iri}> }}"
+                 {{ ?n a {p}:Note ; {p}:status \"active\" . {dlink} }}"
             )
         }
         (Some(kw), None) => {
@@ -246,7 +269,8 @@ pub fn recalled_note_iris(
         }
         (None, Some(dom)) => {
             let domain_iri = crud::build_iri(ns, "domain", &crud::slugify(dom));
-            format!("?n a {p}:Note ; {p}:status \"active\" ; {p}:relatedTo <{domain_iri}>")
+            let dlink = crate::domain::link::links_to(ns, "n", &domain_iri);
+            format!("?n a {p}:Note ; {p}:status \"active\" . {dlink}")
         }
         (None, None) => return Vec::new(),
     };
@@ -495,7 +519,7 @@ pub fn list_notes(cwd: &Path, ns: &NamespaceConfig, type_filter: Option<&str>, d
     }
     if let Some(d) = domain_filter {
         let domain_iri = crud::build_iri(ns, "domain", &crud::slugify(d));
-        filters.push(format!("?n {p}:relatedTo <{domain_iri}> ."));
+        filters.push(crate::domain::link::links_to(ns, "n", &domain_iri));
     }
     filters.push(crate::ontology::transient::sparql_exclude(ns, "n"));
 

--- a/src/crud/note.rs
+++ b/src/crud/note.rs
@@ -130,6 +130,7 @@ pub fn recall_to_string(
                        ?n a {p}:Note ; {p}:noteText ?text ; {p}:noteType ?type ; {p}:status \"active\" .\n\
                        OPTIONAL {{ ?n {p}:createdAt ?created }}\n\
                        FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\"))\n\
+                       {no_transient}\
                      }}\n\
                    }} UNION {{\n\
                      GRAPH ?g {{\n\
@@ -138,6 +139,7 @@ pub fn recall_to_string(
                        OPTIONAL {{ ?n {p}:rationale ?extra }}\n\
                        OPTIONAL {{ ?n {p}:fromPlan ?created }}\n\
                        FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\"))\n\
+                       {no_transient}\
                      }}\n\
                    }} UNION {{\n\
                      GRAPH ?g {{\n\
@@ -146,6 +148,7 @@ pub fn recall_to_string(
                        OPTIONAL {{ ?n {p}:name ?extra }}\n\
                        OPTIONAL {{ ?n {p}:fromPlan ?created }}\n\
                        FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\"))\n\
+                       {no_transient}\
                      }}\n\
                    }} UNION {{\n\
                      GRAPH ?g {{\n\
@@ -154,6 +157,7 @@ pub fn recall_to_string(
                        OPTIONAL {{ ?n {p}:purpose ?extra }}\n\
                        OPTIONAL {{ ?n {p}:fromPlan ?created }}\n\
                        FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\"))\n\
+                       {no_transient}\
                      }}\n\
                    }} UNION {{\n\
                      GRAPH ?g {{\n\
@@ -162,9 +166,9 @@ pub fn recall_to_string(
                        OPTIONAL {{ ?n {p}:status ?extra }}\n\
                        OPTIONAL {{ ?n {p}:fromPlan ?created }}\n\
                        FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\"))\n\
+                       {no_transient}\
                      }}\n\
                    }}\n\
-                   {no_transient}\
                  }}\n\
                  ORDER BY DESC(?created) ?text"
             )

--- a/src/crud/note.rs
+++ b/src/crud/note.rs
@@ -164,6 +164,7 @@ pub fn recall_to_string(
                        FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\"))\n\
                      }}\n\
                    }}\n\
+                   {no_transient}\
                  }}\n\
                  ORDER BY DESC(?created) ?text"
             )

--- a/src/crud/note.rs
+++ b/src/crud/note.rs
@@ -66,6 +66,9 @@ pub fn recall_to_string(
     domain: Option<&str>,
 ) -> String {
     let p = &ns.prefix;
+    // Session traffic is excluded from every read surface by one list
+    // (`ontology::transient`), never by a per-command filter.
+    let no_transient = crate::ontology::transient::sparql_exclude(ns, "n");
 
     let sparql = match (keyword, domain) {
         (Some(kw), Some(dom)) => {
@@ -82,6 +85,7 @@ pub fn recall_to_string(
                         OPTIONAL {{ ?n {p}:createdAt ?created }}\n\
                      }}\n\
                      ?n {p}:status \"active\" .\n\
+                     {no_transient}\
                    }}\n\
                  }}"
             )
@@ -140,6 +144,7 @@ pub fn recall_to_string(
                      ?n a {p}:Note ; {p}:noteText ?text ; {p}:noteType ?type ; {p}:status \"active\" ;\n\
                        {p}:relatedTo <{domain_iri}> .\n\
                      OPTIONAL {{ ?n {p}:createdAt ?created }}\n\
+                     {no_transient}\
                    }}\n\
                  }}"
             )
@@ -246,7 +251,9 @@ pub fn recalled_note_iris(
         (None, None) => return Vec::new(),
     };
 
-    let sparql = format!("SELECT DISTINCT ?n WHERE {{ GRAPH ?g {{ {where_clause} }} }}");
+    let no_transient = crate::ontology::transient::sparql_exclude(ns, "n");
+    let sparql =
+        format!("SELECT DISTINCT ?n WHERE {{ GRAPH ?g {{ {where_clause}\n{no_transient} }} }}");
     let results = match crud::load_and_query(cwd, ns, &sparql) {
         Ok(r) => r,
         Err(_) => return Vec::new(),
@@ -490,6 +497,7 @@ pub fn list_notes(cwd: &Path, ns: &NamespaceConfig, type_filter: Option<&str>, d
         let domain_iri = crud::build_iri(ns, "domain", &crud::slugify(d));
         filters.push(format!("?n {p}:relatedTo <{domain_iri}> ."));
     }
+    filters.push(crate::ontology::transient::sparql_exclude(ns, "n"));
 
     let filter_block = filters.join("\n             ");
 

--- a/src/crud/note.rs
+++ b/src/crud/note.rs
@@ -83,6 +83,15 @@ pub fn recall_to_string(
     // `links_to` is an EXISTS test, not a triple pattern: during the overlap a note
     // carries both predicates and a pattern would return it twice.
 
+    // Every branch below ends in a TOTAL order. Without one, oxigraph returns
+    // solutions in store order, so `base recall` reshuffles its rows after any
+    // rewrite — compact, purge, or this fork's migration — and two runs over the
+    // same knowledge disagree. Measured on a copy of Chris's store: the 80 rows of
+    // `recall --domain base` were identical as a SET before and after the
+    // migration, and in a different order. `graph_query::load_graph` already sorts
+    // its adjacency for exactly this reason; these reads never did. DESC(?created)
+    // keeps the newest-first reading store order happened to give, and `?text`
+    // breaks ties — a note's IRI is slugify(text), so it is unique per note.
     let sparql = match (keyword, domain) {
         (Some(kw), Some(dom)) => {
             let kw_lower = crud::escape_sparql_literal(&kw.to_lowercase());
@@ -108,7 +117,8 @@ pub fn recall_to_string(
                      ?n {p}:status \"active\" .\n\
                      {no_transient}\
                    }}\n\
-                 }}"
+                 }}\n\
+                 ORDER BY DESC(?created) ?text"
             )
         }
         (Some(kw), None) => {
@@ -154,7 +164,8 @@ pub fn recall_to_string(
                        FILTER(CONTAINS(LCASE(STR(?text)), \"{kw_lower}\"))\n\
                      }}\n\
                    }}\n\
-                 }}"
+                 }}\n\
+                 ORDER BY DESC(?created) ?text"
             )
         }
         (None, Some(dom)) => {
@@ -168,7 +179,8 @@ pub fn recall_to_string(
                      OPTIONAL {{ ?n {p}:createdAt ?created }}\n\
                      {no_transient}\
                    }}\n\
-                 }}"
+                 }}\n\
+                 ORDER BY DESC(?created) ?text"
             )
         }
         (None, None) => return String::new(),

--- a/src/crud/task.rs
+++ b/src/crud/task.rs
@@ -49,6 +49,12 @@ pub fn add(
          }}"
     );
 
+    // The task takes its project's domain now rather than at the next session start
+    // (kite F7b). A project with no domain links nothing here; the delta pass files it.
+    let sparql = format!(
+        "{sparql};\n{}",
+        crate::domain::link::inherit_update(ns, &graph, &task_iri, &project_iri)
+    );
     crud::load_and_mutate(cwd, ns, &sparql)?;
     Ok(slug)
 }

--- a/src/dashboard/api.rs
+++ b/src/dashboard/api.rs
@@ -171,11 +171,15 @@ pub async fn edges(State(state): State<Arc<AppState>>) -> Json<Vec<GraphEdge>> {
     let pfx = crate::crud::prefixes(ns);
     let store = state.store_guard();
 
+    // `hasDomain` was missing from this allowlist since it was written, so the
+    // graph view has never drawn the 49 project→domain edges in Chris's store
+    // (hawk C11). A hardcoded list goes blind to every predicate added after it —
+    // this one is now the whole domain-link vocabulary, from `domain::link`.
     let edge_predicates = [
         "relatedTo", "references", "hasRule", "hasDecision",
         "hasMilestone", "hasTask", "calls", "importsFrom",
         "contains", "hasMethod", "belongsTo", "hasTag",
-        "hasSection", "operatorNote",
+        "hasSection", "operatorNote", crate::domain::link::CANONICAL,
     ];
 
     let filter = edge_predicates
@@ -1362,6 +1366,7 @@ fn is_edge_predicate(pred: &str, prefix: &str) -> bool {
         "hasMilestone", "hasTask", "calls", "importsFrom",
         "contains", "hasMethod", "belongsTo", "operatorNote",
         "hasFileChange", "hasACResult", "hasAC", "dependsOn", "affects",
+        crate::domain::link::CANONICAL,
     ];
     edge_preds.iter().any(|ep| pred.contains(&format!("{prefix}:{ep}")) || pred.ends_with(&format!("#{ep}")))
 }

--- a/src/dashboard/api.rs
+++ b/src/dashboard/api.rs
@@ -124,6 +124,8 @@ pub async fn nodes(State(state): State<Arc<AppState>>) -> Json<Vec<GraphNode>> {
     let pfx = crate::crud::prefixes(ns);
     let store = state.store_guard();
 
+    // Session traffic never renders — one list, four readers (`ontology::transient`).
+    let no_transient = crate::ontology::transient::sparql_exclude(ns, "s");
     let sparql = format!(
         "{pfx}\n\
          SELECT ?s ?type ?name ?status ?path ?docType WHERE {{\n\
@@ -135,6 +137,7 @@ pub async fn nodes(State(state): State<Arc<AppState>>) -> Json<Vec<GraphNode>> {
              OPTIONAL {{ ?s {p}:status ?status }}\n\
              OPTIONAL {{ ?s {p}:path ?path }}\n\
              OPTIONAL {{ ?s {p}:documentType ?docType }}\n\
+             {no_transient}\
            }}\n\
          }}"
     );
@@ -181,8 +184,12 @@ pub async fn edges(State(state): State<Arc<AppState>>) -> Json<Vec<GraphEdge>> {
         .collect::<Vec<_>>()
         .join(" || ");
 
+    // An edge touching session traffic is not an edge, at either end.
+    let no_transient_s = crate::ontology::transient::sparql_exclude(ns, "s");
+    let no_transient_o = crate::ontology::transient::sparql_exclude(ns, "o");
     let sparql = format!(
-        "{pfx}\nSELECT ?s ?p ?o WHERE {{ GRAPH ?g {{ ?s ?p ?o . FILTER({filter}) }}\n\
+        "{pfx}\nSELECT ?s ?p ?o WHERE {{ GRAPH ?g {{ ?s ?p ?o . FILTER({filter})\n\
+             {no_transient_s}{no_transient_o} }}\n\
            FILTER(?g != <{ledger}>)\n\
          }}",
         ledger = crate::apply_ops::LEDGER_GRAPH,

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -48,6 +48,14 @@ pub struct TierReport {
     pub stale_tmp: bool,
     /// rdf:type → count, populated only when the tier parses (status == "healthy").
     pub entity_composition: Vec<(String, usize)>,
+    /// The schema version this tier's graph claims, e.g. `"domain-1"`. `None` on a
+    /// tier the domain migration has not reached — which is what makes a skipped
+    /// migration visible instead of silent (C4).
+    pub schema_version: Option<String>,
+    /// Covered classes that still carry no domain link, highest first. Non-empty
+    /// after a migration is not a fault: `base sync` writes a Document with no
+    /// domain, so the count climbs again until every write path carries the link.
+    pub domain_orphans: Vec<(String, usize)>,
     pub latest_backup: Option<BackupCompare>,
 }
 
@@ -93,6 +101,8 @@ pub fn diagnose_tier(tier: &str, path: &Path) -> TierReport {
             ends_with_newline: true,
             stale_tmp,
             entity_composition: Vec::new(),
+            schema_version: None,
+            domain_orphans: Vec::new(),
             latest_backup: None,
         };
     }
@@ -105,6 +115,20 @@ pub fn diagnose_tier(tier: &str, path: &Path) -> TierReport {
         entity_composition(path)
     } else {
         Vec::new()
+    };
+
+    // Namespace from THIS tier's own base.toml (`<root>/.base/graph.nq` → `<root>`),
+    // so a workspace with a custom prefix is read with its own vocabulary rather
+    // than the default. Keeps `diagnose_tier` path-scoped — the test-isolation seam.
+    let (schema_version, domain_orphans) = if status == "healthy" {
+        let root = path.parent().and_then(Path::parent).unwrap_or(path);
+        let ns = crate::config::BaseConfig::load(root).namespace;
+        match store::load_graph(path) {
+            Ok(s) => (crate::migrate::stamp_of_tier(&s, &ns), crate::migrate::orphan_counts(&s, &ns)),
+            Err(_) => (None, Vec::new()),
+        }
+    } else {
+        (None, Vec::new())
     };
 
     let latest_backup = newest_backup(path).map(|bpath| {
@@ -127,6 +151,8 @@ pub fn diagnose_tier(tier: &str, path: &Path) -> TierReport {
         ends_with_newline,
         stale_tmp,
         entity_composition,
+        schema_version,
+        domain_orphans,
         latest_backup,
     }
 }
@@ -218,6 +244,32 @@ pub fn format_human(report: &DoctorReport) -> String {
                 .map(|(k, v)| format!("{k}={v}"))
                 .collect();
             out.push_str(&format!("   composition: {}\n", comp.join(", ")));
+        }
+
+        // The domain schema, always stated when the tier parses. A migration that
+        // never ran must not look the same as one that ran and found nothing.
+        if t.status == "healthy" {
+            let orphans: usize = t.domain_orphans.iter().map(|(_, n)| n).sum();
+            match t.schema_version.as_deref() {
+                Some(v) => out.push_str(&format!("   schema: {v}\n")),
+                None => out.push_str(
+                    "   schema: not migrated — the domain backfill runs at the next session start\n",
+                ),
+            }
+            if orphans > 0 {
+                let top: Vec<String> = t
+                    .domain_orphans
+                    .iter()
+                    .take(6)
+                    .map(|(k, n)| format!("{k}={n}"))
+                    .collect();
+                let more = t.domain_orphans.len().saturating_sub(6);
+                out.push_str(&format!(
+                    "   without a domain: {orphans} record(s) — {}{}\n",
+                    top.join(", "),
+                    if more > 0 { format!(", +{more} more kind(s)") } else { String::new() },
+                ));
+            }
         }
 
         if let Some(b) = &t.latest_backup {

--- a/src/domain/link.rs
+++ b/src/domain/link.rs
@@ -132,6 +132,33 @@ pub fn domain_index(
     out
 }
 
+/// A SPARQL UPDATE that gives `subject_iri` the domain its `parent_iri` already carries,
+/// in `graph_iri`, at creation time: a Task takes its project's domain, a Handoff the
+/// domain of the project it names (kite F7b, vole's ruling of 2026-09-06 that the claim
+/// "every record carries a domain" must not wait for the next session start when the
+/// parent already knows the answer).
+///
+/// Nothing is written when the parent has no domain. Inventing the catchall here would
+/// give two places ownership of `unfiled`; the session-start delta pass (`migrate.rs`)
+/// files such a record exactly as it files everything else that arrived without a link.
+/// The object filter keeps `relatedTo`'s entity and project links out, as everywhere
+/// else in this module.
+pub fn inherit_update(
+    ns: &NamespaceConfig,
+    graph_iri: &str,
+    subject_iri: &str,
+    parent_iri: &str,
+) -> String {
+    let p = &ns.prefix;
+    let path = path(ns);
+    let dom = domain_iri_prefix(ns);
+    format!(
+        "INSERT {{ GRAPH <{graph_iri}> {{ <{subject_iri}> {p}:{CANONICAL} ?d }} }}\n\
+         WHERE {{ GRAPH <{graph_iri}> {{ <{parent_iri}> {path} ?d .\n\
+           FILTER(isIRI(?d) && STRSTARTS(STR(?d), \"{dom}\")) }} }}"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,6 +198,17 @@ mod tests {
         let ns = NamespaceConfig { prefix: "mybase".into(), uri: "http://example.com/base#".into() };
         assert_eq!(path(&ns), "(mybase:hasDomain|mybase:relatedTo)");
         assert_eq!(domain_iri_prefix(&ns), "http://example.com/base#domain/");
+    }
+
+    #[test]
+    fn inherit_update_writes_the_canonical_predicate_from_the_parents_domain() {
+        let u = inherit_update(&ns(), "g", "s", "parent");
+        assert!(u.starts_with("INSERT { GRAPH <g> { <s> ops:hasDomain ?d } }"), "{u}");
+        assert!(u.contains("WHERE { GRAPH <g> { <parent> (ops:hasDomain|ops:relatedTo) ?d ."), "{u}");
+        assert!(
+            u.contains("STRSTARTS(STR(?d), \"http://ops-sys.local/ontology#domain/\")"),
+            "relatedTo also carries entity and project links; the object filter must be there: {u}"
+        );
     }
 
     #[test]

--- a/src/domain/link.rs
+++ b/src/domain/link.rs
@@ -1,0 +1,129 @@
+//! The predicate a record's domain link is written under — one place, during and
+//! after the expand-migrate-contract overlap.
+//!
+//! base grew two conventions for the same fact. `crud/project.rs`, `crud/entity.rs`
+//! and `extract/paul_toml.rs` write `hasDomain`; `crud/note.rs` writes `relatedTo`,
+//! the same predicate it uses for a note's project and entity links. That split is
+//! two conventions, not a design decision (hawk C7, 2026-09-05: `crud/note.rs:28-40`
+//! writes the identical predicate for all three link kinds).
+//!
+//! 0.14.0 makes [`CANONICAL`] the single predicate and keeps reading [`LEGACY`] for
+//! the whole overlap window. N+1 stops writing the legacy triple, N+2 drops it. The
+//! overlap is what makes rollback survivable: hawk C10 ran v0.12.0 (105 commits back)
+//! against a store carrying every artefact this migration writes, in both directions,
+//! and it read, analysed and WROTE without complaint — `store::load_graph` is a
+//! syntactic N-Quads parse with no schema check, and every read binds only the
+//! predicates it wants.
+//!
+//! ## Why the object IRI, not the predicate, is the discriminator
+//!
+//! `relatedTo` is generic. In the live workspace store it carries 465 note→domain
+//! links, 532 document→entity links and 30 document→project links (hawk C12). Only
+//! the object's IRI kind separates them, and it is already in the data — no guessing.
+//! So: where the object is a KNOWN domain IRI, [`path`] is exact on its own; where
+//! the object is a variable, [`binds_domain`] adds the `domain/` prefix filter.
+
+use crate::config::NamespaceConfig;
+
+/// The predicate 0.14.0 writes for "this record belongs to this domain".
+pub const CANONICAL: &str = "hasDomain";
+
+/// The predicate note→domain links were written under before 0.14.0. Read for the
+/// whole overlap window; N+1 stops writing it, N+2 drops the triples.
+pub const LEGACY: &str = "relatedTo";
+
+/// `(ops:hasDomain|ops:relatedTo)` — a property path matching a domain link from
+/// either era. Exact where the object is a known `domain/` IRI; use
+/// [`binds_domain`] when the object is a variable.
+pub fn path(ns: &NamespaceConfig) -> String {
+    let p = &ns.prefix;
+    format!("({p}:{CANONICAL}|{p}:{LEGACY})")
+}
+
+/// `FILTER EXISTS {{ ?{subj_var} (ops:hasDomain|ops:relatedTo) <domain_iri> }}` —
+/// "this record belongs to that domain", in either era, **once**.
+///
+/// A bare `?n (a|b) <dom>` triple pattern is the obvious spelling and it is wrong
+/// here: SPARQL evaluates an alternation as the union of its branches, so a record
+/// carrying BOTH predicates — which is exactly what 0.14.0 writes — yields two
+/// solutions and `base recall --domain` prints every note twice. Measured, not
+/// assumed: `tests/domain_link_test.rs::a_note_carrying_both_predicates_recalls_exactly_once`
+/// fails with the triple-pattern form. `EXISTS` is a boolean test, so the overlap
+/// costs nothing.
+pub fn links_to(ns: &NamespaceConfig, subj_var: &str, domain_iri: &str) -> String {
+    let path = path(ns);
+    format!("FILTER EXISTS {{ ?{subj_var} {path} <{domain_iri}> }}")
+}
+
+/// `http://…#domain/` — the prefix that tells a domain link from `relatedTo`'s two
+/// other uses.
+pub fn domain_iri_prefix(ns: &NamespaceConfig) -> String {
+    format!("{}domain/", ns.uri)
+}
+
+/// A graph pattern binding `?{obj_var}` to `?{subj_var}`'s domain, whichever
+/// predicate carried it. Ends in a newline; safe to interpolate into a group.
+pub fn binds_domain(ns: &NamespaceConfig, subj_var: &str, obj_var: &str) -> String {
+    let path = path(ns);
+    let dom = domain_iri_prefix(ns);
+    format!(
+        "?{subj_var} {path} ?{obj_var} .\nFILTER(isIRI(?{obj_var}) && STRSTARTS(STR(?{obj_var}), \"{dom}\"))\n"
+    )
+}
+
+/// `FILTER NOT EXISTS { … }` — matches a record that carries no domain link in
+/// either era. This is what the migration means by "still unmigrated": it is
+/// computed from the store, never from a stamp (G0 verdict A2).
+pub fn no_domain_link(ns: &NamespaceConfig, subj_var: &str) -> String {
+    let inner = binds_domain(ns, subj_var, "__dom");
+    format!("FILTER NOT EXISTS {{ {inner} }}\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ns() -> NamespaceConfig {
+        NamespaceConfig::default()
+    }
+
+    #[test]
+    fn path_names_the_canonical_predicate_first() {
+        // Order is documentation, not semantics: a reader of the generated SPARQL
+        // should see which predicate 0.14.0 writes.
+        assert_eq!(path(&ns()), "(ops:hasDomain|ops:relatedTo)");
+    }
+
+    #[test]
+    fn binds_domain_filters_on_the_domain_iri_prefix() {
+        let g = binds_domain(&ns(), "n", "d");
+        assert!(g.contains("?n (ops:hasDomain|ops:relatedTo) ?d ."));
+        assert!(
+            g.contains("STRSTARTS(STR(?d), \"http://ops-sys.local/ontology#domain/\")"),
+            "relatedTo also carries entity and project links — the object IRI is the \
+             only discriminator, and it must be applied: {g}"
+        );
+    }
+
+    #[test]
+    fn links_to_is_a_boolean_test_not_a_triple_pattern() {
+        // The overlap writes both predicates; a triple pattern would match twice.
+        let f = links_to(&ns(), "n", "http://ops-sys.local/ontology#domain/base");
+        assert!(f.starts_with("FILTER EXISTS {"), "{f}");
+        assert!(f.contains("?n (ops:hasDomain|ops:relatedTo) <http://ops-sys.local/ontology#domain/base>"));
+    }
+
+    #[test]
+    fn custom_namespace_is_honoured() {
+        let ns = NamespaceConfig { prefix: "mybase".into(), uri: "http://example.com/base#".into() };
+        assert_eq!(path(&ns), "(mybase:hasDomain|mybase:relatedTo)");
+        assert_eq!(domain_iri_prefix(&ns), "http://example.com/base#domain/");
+    }
+
+    #[test]
+    fn no_domain_link_wraps_the_binding_in_not_exists() {
+        let f = no_domain_link(&ns(), "s");
+        assert!(f.starts_with("FILTER NOT EXISTS {"));
+        assert!(f.contains("?s (ops:hasDomain|ops:relatedTo) ?__dom"));
+    }
+}

--- a/src/domain/link.rs
+++ b/src/domain/link.rs
@@ -71,12 +71,65 @@ pub fn binds_domain(ns: &NamespaceConfig, subj_var: &str, obj_var: &str) -> Stri
     )
 }
 
-/// `FILTER NOT EXISTS { … }` — matches a record that carries no domain link in
-/// either era. This is what the migration means by "still unmigrated": it is
-/// computed from the store, never from a stamp (G0 verdict A2).
-pub fn no_domain_link(ns: &NamespaceConfig, subj_var: &str) -> String {
-    let inner = binds_domain(ns, subj_var, "__dom");
-    format!("FILTER NOT EXISTS {{ {inner} }}\n")
+/// Every record that already has a domain, in EITHER direction, as
+/// `record IRI -> domain slug`.
+///
+/// Direction is the trap. `crud/decision.rs:47` writes `<domain> ops:hasDecision
+/// <decision>` — the domain is the SUBJECT — and `domain sync` writes
+/// `<domain> ops:hasRule <rule>` the same way. A subject-side-only test therefore
+/// reads all 420 decisions and all 79 rules in Chris's store as orphans, and a
+/// migration built on it would write 342 redundant links to the wrong domain.
+/// hawk measured both directions (C-RE, "decisions are 65% covered, not 0%");
+/// this reads both.
+///
+/// One pass over the store rather than a query per record: the migration asks this
+/// of every covered record, and 4,000 SPARQL round trips inside a session-start
+/// hook is not a budget. Ties resolve to the lexicographically first slug so two
+/// runs of the same store agree.
+pub fn domain_index(
+    store: &oxigraph::store::Store,
+    ns: &NamespaceConfig,
+) -> std::collections::HashMap<String, String> {
+    use oxigraph::model::Term;
+    use oxigraph::sparql::QueryResults;
+
+    let p = &ns.prefix;
+    let pfx = crate::crud::prefixes(ns);
+    let dom = domain_iri_prefix(ns);
+    let path = path(ns);
+    let mut out: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+
+    let mut absorb = |q: &str| {
+        let Ok(QueryResults::Solutions(sols)) = crate::store::query(store, q) else { return };
+        for row in sols.filter_map(|r| r.ok()) {
+            let (Some(Term::NamedNode(r)), Some(Term::NamedNode(d))) = (row.get("r"), row.get("d"))
+            else {
+                continue;
+            };
+            let Some(slug) = d.as_str().strip_prefix(dom.as_str()) else { continue };
+            let key = r.as_str().to_string();
+            match out.get(&key) {
+                Some(existing) if existing.as_str() <= slug => {}
+                _ => {
+                    out.insert(key, slug.to_string());
+                }
+            }
+        }
+    };
+
+    // Record -> domain: `note relatedTo domain/x`, `project hasDomain domain/x`.
+    absorb(&format!(
+        "{pfx}\nSELECT ?r ?d WHERE {{ GRAPH ?g {{ ?r {path} ?d .\n\
+           FILTER(isIRI(?r) && isIRI(?d) && STRSTARTS(STR(?d), \"{dom}\")) }} }}"
+    ));
+    // Domain -> record: `domain hasDecision decision/x`, `domain hasRule rule/x`,
+    // and any predicate a later release adds — matched by the SUBJECT's IRI kind,
+    // not by an allowlist that would go stale.
+    absorb(&format!(
+        "{pfx}\nSELECT ?r ?d WHERE {{ GRAPH ?g {{ ?d ?p ?r .\n\
+           FILTER(isIRI(?r) && isIRI(?d) && STRSTARTS(STR(?d), \"{dom}\") && ?p != {p}:hasDomain) }} }}"
+    ));
+    out
 }
 
 #[cfg(test)]
@@ -121,9 +174,36 @@ mod tests {
     }
 
     #[test]
-    fn no_domain_link_wraps_the_binding_in_not_exists() {
-        let f = no_domain_link(&ns(), "s");
-        assert!(f.starts_with("FILTER NOT EXISTS {"));
-        assert!(f.contains("?s (ops:hasDomain|ops:relatedTo) ?__dom"));
+    fn domain_index_reads_both_directions() {
+        use oxigraph::store::Store;
+        let ns = ns();
+        let u = &ns.uri;
+        let g = format!("{u}graph/ws/t");
+        let store = Store::new().unwrap();
+        let nq = format!(
+            "<{u}domain/base> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{u}Domain> <{g}> .\n\
+             <{u}note/n1> <{u}relatedTo> <{u}domain/base> <{g}> .\n\
+             <{u}project/p1> <{u}hasDomain> <{u}domain/base> <{g}> .\n\
+             <{u}domain/base> <{u}hasDecision> <{u}decision/d1> <{g}> .\n\
+             <{u}domain/base> <{u}hasRule> <{u}rule/r1> <{g}> .\n\
+             <{u}note/n2> <{u}relatedTo> <{u}entity/e1> <{g}> .\n"
+        );
+        store.load_from_reader(oxigraph::io::RdfFormat::NQuads, nq.as_bytes()).unwrap();
+
+        let idx = domain_index(&store, &ns);
+        assert_eq!(idx.get(&format!("{u}note/n1")).map(String::as_str), Some("base"));
+        assert_eq!(idx.get(&format!("{u}project/p1")).map(String::as_str), Some("base"));
+        assert_eq!(
+            idx.get(&format!("{u}decision/d1")).map(String::as_str),
+            Some("base"),
+            "domain --hasDecision--> decision IS a domain link; missing it reads 420 \
+             already-linked decisions as orphans"
+        );
+        assert_eq!(idx.get(&format!("{u}rule/r1")).map(String::as_str), Some("base"));
+        assert!(
+            !idx.contains_key(&format!("{u}note/n2")),
+            "relatedTo to an entity is not a domain link"
+        );
+        assert!(!idx.contains_key(&format!("{u}entity/e1")));
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod link;
 pub mod matcher;
 pub mod query;
 pub mod session;

--- a/src/domain/query.rs
+++ b/src/domain/query.rs
@@ -90,7 +90,11 @@ pub fn query_domain_from_graph(
         _ => format_toml_rules(domain_def),
     };
 
-    // Query 2: 1-hop neighborhood (decisions linked to this domain, projects with hasDomain)
+    // Query 2: 1-hop neighborhood (decisions linked to this domain, projects with hasDomain).
+    // `?related` is dropped if it is session traffic — one list, four readers
+    // (`ontology::transient`), so widening this union can never leak pings into
+    // the prompt.
+    let no_transient = crate::ontology::transient::sparql_exclude(ns, "related");
     let neighborhood_sparql = format!(
         "{pfx}\n\
          SELECT ?name ?type WHERE {{\n\
@@ -105,6 +109,7 @@ pub fn query_domain_from_graph(
                  {p}:name ?name .\n\
                BIND({p}:Project AS ?type)\n\
              }}\n\
+             {no_transient}\
            }}\n\
          }}\n\
          ORDER BY ?type ?name"

--- a/src/extension/ingest.rs
+++ b/src/extension/ingest.rs
@@ -236,6 +236,15 @@ fn ingest_file(
         triples.push(format!(
             "<{entity_iri}> {p}:source \"ext:{ext_name}\""
         ));
+        // The source's declared domain, written with the record (kite F7b / A3). No
+        // declaration, no link: the delta pass files the record by its class later.
+        if let Some(domain) = source.domain.as_deref().map(str::trim).filter(|d| !d.is_empty()) {
+            let domain_iri = crud::build_iri(ctx.ns, "domain", &crud::slugify(domain));
+            triples.push(format!(
+                "<{entity_iri}> {p}:{} <{domain_iri}>",
+                crate::domain::link::CANONICAL
+            ));
+        }
 
         for (key, value) in map {
             if key == "id" {
@@ -452,6 +461,7 @@ mod tests {
                         file: "items.json".into(),
                         entity: "TestItem".into(),
                         strategy: "upsert".into(),
+                        domain: None,
                     }],
                     inject: None,
                 }),
@@ -516,6 +526,7 @@ mod tests {
                         file: "items.json".into(),
                         entity: "ReplItem".into(),
                         strategy: "replace".into(),
+                        domain: None,
                     }],
                     inject: None,
                 }),
@@ -593,6 +604,7 @@ mod tests {
                         file: "data.json".into(),
                         entity: "Thing".into(),
                         strategy: "upsert".into(),
+                        domain: None,
                     }],
                     inject: None,
                 }),

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -191,6 +191,13 @@ pub struct IngestSource {
     pub entity: String,
     #[serde(default = "default_strategy")]
     pub strategy: String,
+    /// The domain every record from this source is filed under, as a slug, e.g.
+    /// `domain = "skyrim-companion"` for a lore extension (Chris's ruling 3, G0 verdict
+    /// A3: "the extension's write path gains the same link for new records"). Optional:
+    /// a source that declares none is filed by class at the next session start by the
+    /// delta pass in `migrate.rs`.
+    #[serde(default)]
+    pub domain: Option<String>,
 }
 
 fn default_strategy() -> String {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn auto_compact_disabled_is_a_noop() {
         let dir = tempfile::tempdir().unwrap();
-        let cfg = crate::config::GraphConfig { auto_compact: false, compact_threshold_mb: 0, compact_cooldown_hours: 24 };
+        let cfg = crate::config::GraphConfig { auto_compact: false, compact_threshold_mb: 0, compact_cooldown_hours: 24, auto_migrate: false };
         assert!(auto_compact_tiers(&cfg, dir.path()).is_empty());
     }
 }

--- a/src/graph_analyze.rs
+++ b/src/graph_analyze.rs
@@ -26,8 +26,7 @@ pub fn run(cwd: &Path, ns: &NamespaceConfig, top_n: usize) -> Result<()> {
         .collect();
 
     // ── God nodes: highest degree = core abstractions ──
-    let mut by_deg: Vec<(&String, usize)> = degree.iter().map(|(k, v)| (*k, *v)).collect();
-    by_deg.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| label_of(&nodes, a.0).cmp(&label_of(&nodes, b.0))));
+    let by_deg = rank_god_nodes(ns, &nodes, &degree);
 
     // ── Communities: label propagation ──
     let comm = label_propagation(&nodes, &adj);
@@ -65,9 +64,7 @@ pub fn run(cwd: &Path, ns: &NamespaceConfig, top_n: usize) -> Result<()> {
 
     println!("\n## Communities (by size)");
     for (i, (_, members)) in group_vec.iter().enumerate().take(top_n) {
-        let mut sample: Vec<String> = members.iter().map(|m| label_of(&nodes, m)).collect();
-        sample.sort();
-        let sample: Vec<String> = sample.into_iter().take(5).collect();
+        let sample = community_sample(ns, &nodes, members);
         println!("  [{}] {} nodes — {}", i, members.len(), sample.join(", "));
     }
 
@@ -112,6 +109,46 @@ fn bridge_pairs(
     let weight = |p: &(String, String)| degree.get(&p.0).unwrap_or(&0) + degree.get(&p.1).unwrap_or(&0);
     bridges.sort_by(|x, y| weight(y).cmp(&weight(x)).then_with(|| x.cmp(y)));
     bridges
+}
+
+/// Is this node the catchall domain? The catchall is a hub by construction: every record
+/// no source could file points at it (1,511 on the first migrated store, where it ranked
+/// as the #2 god node). It is not a core abstraction and it is not a community's name.
+/// One guard, both places (kite F22, vole 2026-09-06). Real domains still rank until
+/// base-analyze-demo-grade decides what a domain's degree means.
+fn is_catchall(ns: &NamespaceConfig, id: &str) -> bool {
+    id.trim_matches(['<', '>']) == crate::crud::build_iri(ns, "domain", crate::migrate::CATCHALL)
+}
+
+/// Nodes by degree, highest first, ties by label. The catchall never appears.
+pub fn rank_god_nodes(
+    ns: &NamespaceConfig,
+    nodes: &HashMap<String, crate::graph_query::Node>,
+    degree: &HashMap<&String, usize>,
+) -> Vec<(String, usize)> {
+    let mut by_deg: Vec<(String, usize)> = degree
+        .iter()
+        .filter(|(k, _)| !is_catchall(ns, k.as_str()))
+        .map(|(k, v)| ((*k).clone(), *v))
+        .collect();
+    by_deg.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| label_of(nodes, &a.0).cmp(&label_of(nodes, &b.0))));
+    by_deg
+}
+
+/// Up to five member labels, sorted, that stand for a community. The catchall is never
+/// one of them.
+pub fn community_sample(
+    ns: &NamespaceConfig,
+    nodes: &HashMap<String, crate::graph_query::Node>,
+    members: &[&String],
+) -> Vec<String> {
+    let mut sample: Vec<String> = members
+        .iter()
+        .filter(|m| !is_catchall(ns, m.as_str()))
+        .map(|m| label_of(nodes, m))
+        .collect();
+    sample.sort();
+    sample.into_iter().take(5).collect()
 }
 
 fn label_of(nodes: &HashMap<String, crate::graph_query::Node>, id: &str) -> String {

--- a/src/graph_query.rs
+++ b/src/graph_query.rs
@@ -164,6 +164,9 @@ pub fn load_graph(
     // `conceptType` is written only by `graph extract`; a store that has never run it
     // has none, so fall back to the RDF class every record carries. Without this every
     // node's type is blank and two records sharing a name are indistinguishable.
+    // Session traffic never enters the graph a `base graph` command reasons over.
+    // One list, four readers — see `ontology::transient`.
+    let no_transient = crate::ontology::transient::sparql_exclude(ns, "s");
     let node_q = format!(
         "SELECT ?s ?label ?type ?rdftype ?src ?summary WHERE {{ GRAPH ?g {{\n\
            ?s {p}:name ?label .\n\
@@ -171,6 +174,7 @@ pub fn load_graph(
            OPTIONAL {{ ?s a ?rdftype }}\n\
            OPTIONAL {{ ?s {p}:sourceDoc ?src }}\n\
            OPTIONAL {{ ?s {p}:summary ?summary }}\n\
+         {no_transient}\
          }} }}"
     );
     let mut nodes: HashMap<String, Node> = HashMap::new();
@@ -205,6 +209,7 @@ pub fn load_graph(
            FILTER NOT EXISTS {{ ?s {p}:name ?any }}\n\
            OPTIONAL {{ ?s {p}:sourceDoc ?src }}\n\
          {body_opts}\
+         {no_transient}\
          }} }}"
     );
     if let QueryResults::Solutions(sols) = ask(&typed_q)? {
@@ -243,6 +248,14 @@ pub fn load_graph(
 
     let mut adj: HashMap<String, Vec<(String, String)>> = HashMap::new();
     let push = |adj: &mut HashMap<String, Vec<(String, String)>>, a: String, b: String, rel: String| {
+        // An edge touching session traffic is not an edge. This is the single
+        // choke point for adjacency, so it also stops the `dangling` pass below
+        // re-introducing a transient endpoint by IRI.
+        if crate::ontology::transient::is_transient_iri(ns, &a)
+            || crate::ontology::transient::is_transient_iri(ns, &b)
+        {
+            return;
+        }
         adj.entry(a.clone()).or_default().push((b.clone(), rel.clone()));
         adj.entry(b).or_default().push((a, rel)); // undirected for reachability
     };

--- a/src/hook/session_start.rs
+++ b/src/hook/session_start.rs
@@ -50,8 +50,11 @@ pub fn handle(config: &BaseConfig, cwd: &Path, session_id: Option<&str>) -> Resu
     // and already rewrites the store in `auto_compact_tiers` (hawk C2). One time,
     // not every session.
     if config.graph.auto_migrate {
-        let notice =
-            crate::migrate::format_outcomes(&crate::migrate::migrate_tiers(cwd, &config.namespace));
+        let notice = crate::migrate::format_outcomes(&crate::migrate::migrate_tiers(
+            cwd,
+            &config.namespace,
+            crate::migrate::Trigger::SessionStart,
+        ));
         if !notice.is_empty() {
             print!("{notice}");
         }

--- a/src/hook/session_start.rs
+++ b/src/hook/session_start.rs
@@ -37,6 +37,26 @@ pub fn handle(config: &BaseConfig, cwd: &Path, session_id: Option<&str>) -> Resu
     // Scan and ingest paul.toml projects into graph (idempotent)
     ingest_paul_projects(config, cwd);
 
+    // Every record carries a domain link (Chris, 2026-09-04). One-time and
+    // idempotent: the work is recomputed from the store on every run where the
+    // stamp is absent, and the stamp lands in the SAME write_back as the data, so
+    // a `.bak` restore re-migrates correctly instead of skipping forever.
+    //
+    // Placed after domain sync and paul ingest on purpose: a backfill links only
+    // to a domain record that already exists, and both of those create some.
+    //
+    // Affordable here, measured: one full snapshot+parse+rewrite of the real
+    // 13.4 MB store costs 1.25-1.51 s against a hook that already spends 5.0-7.9 s
+    // and already rewrites the store in `auto_compact_tiers` (hawk C2). One time,
+    // not every session.
+    if config.graph.auto_migrate {
+        let notice =
+            crate::migrate::format_outcomes(&crate::migrate::migrate_tiers(cwd, &config.namespace));
+        if !notice.is_empty() {
+            print!("{notice}");
+        }
+    }
+
     // A release that adds a hook wires it here, once per version. The
     // auto-update swaps the binary and touches nothing else, and a hook that
     // is not in settings.json never fires — silently.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod first_run;
 pub mod hook;
 pub mod install;
 pub mod manifest;
+pub mod migrate;
 pub mod ontology;
 pub mod operator;
 pub mod plugin;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -779,6 +779,56 @@ fn write_stamp(store: &Store, ns: &NamespaceConfig, graph_iri: &str) -> Result<(
 
 // ─── reporting ───────────────────────────────────────────────────────────────
 
+/// What a migration WOULD do, per tier, without writing anything.
+///
+/// The plan is computed the same way the real pass computes it, so a dry run and
+/// the run that follows it cannot disagree about the work — they call the same
+/// function over the same store.
+pub fn format_dry_run(cwd: &Path, ns: &NamespaceConfig) -> String {
+    let mut s = String::new();
+    for root in tier_roots(cwd) {
+        let path = root.join(".base").join("graph.nq");
+        if !path.exists() {
+            continue;
+        }
+        s.push_str(&format!("{}\n", path.display()));
+        if !matches!(store::graph_health(&path), GraphHealth::Healthy) {
+            s.push_str("   not healthy — run `base doctor --repair` first\n");
+            continue;
+        }
+        let Ok(store) = store::load_graph(&path) else {
+            s.push_str("   could not be read\n");
+            continue;
+        };
+        match stamp_of_tier(&store, ns) {
+            Some(v) => s.push_str(&format!("   schema: {v} (already migrated)\n")),
+            None => s.push_str("   schema: not migrated\n"),
+        }
+        let facts = Facts::gather(&store, ns, root.clone());
+        let plan = plan_backfill(&facts, ns);
+        if plan.is_empty() {
+            s.push_str("   nothing to link\n");
+            continue;
+        }
+        let mut by_arm: BTreeMap<&str, usize> = BTreeMap::new();
+        let mut by_class: BTreeMap<&str, usize> = BTreeMap::new();
+        for a in &plan {
+            *by_arm.entry(a.arm.label()).or_default() += 1;
+            *by_class.entry(a.class.as_str()).or_default() += 1;
+        }
+        s.push_str(&format!("   would link {} record(s)\n", plan.len()));
+        s.push_str(&format!(
+            "   by source: {}\n",
+            by_arm.iter().map(|(k, n)| format!("{k} {n}")).collect::<Vec<_>>().join(", ")
+        ));
+        s.push_str(&format!(
+            "   by kind:   {}\n",
+            by_class.iter().map(|(k, n)| format!("{k} {n}")).collect::<Vec<_>>().join(", ")
+        ));
+    }
+    s
+}
+
 /// One line per tier for the session-start notice, naming what each arm filed.
 ///
 /// The per-arm breakdown is the point, not decoration: `unfiled` appears as one

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -304,6 +304,17 @@ pub fn migrate_tier(
 ) -> Result<Outcome> {
     let mut out = Outcome { path: path.display().to_string(), ..Default::default() };
 
+    // THE GATE COMES FIRST, before anything reads the file. Measured 2026-09-07 on
+    // the frozen 13.4 MB store: with it below the health check, session start paid
+    // `graph_health` (a full parse) AND `load_graph` (a second full parse) per
+    // tier on every session, including the ones the gate then skipped — +6.8 s
+    // against a control with the migration off, for work thrown away. A gate whose
+    // point is to cost one `stat` has to run before the parses it exists to avoid.
+    if trigger == Trigger::SessionStart && !changed_since_last_delta(path) {
+        out.already_migrated = true;
+        return Ok(out);
+    }
+
     // C1: `compact_tier` refuses an unhealthy graph and a migration that reuses
     // this path inherits that. Defined behaviour, not silence: report it, write
     // nothing, stamp nothing, so the next session tries again once repair has run.
@@ -328,10 +339,8 @@ pub fn migrate_tier(
     // but only when the store has actually changed since the last time this pass
     // looked, which is ONE `stat` against a marker file rather than a 13.4 MB
     // parse. A session that wrote nothing costs nothing.
-    if stamped && trigger == Trigger::SessionStart && !changed_since_last_delta(path) {
-        out.already_migrated = true;
-        return Ok(out);
-    }
+    // Reaching here as SessionStart means the store MOVED since the marker, so the
+    // delta pass below re-plans it. The cheap skip already happened, above.
 
     let root = path.parent().and_then(Path::parent).unwrap_or(path).to_path_buf();
     let facts = Facts::gather(&store, ns, root);
@@ -378,6 +387,14 @@ pub fn migrate_tier(
 
 /// Has anything written this tier since the delta pass last looked?
 ///
+/// The marker records the store's IDENTITY, `len:mtime_nanos`, not the time the
+/// pass ran. mtime alone is not enough: a `.bak` restore can land inside the
+/// filesystem's timestamp granularity, leaving the restored store no NEWER than
+/// the marker, and the gate would then skip a store that is no longer migrated —
+/// `a_restored_pre_migration_backup_re_migrates` fails on exactly that. Comparing
+/// identity means any different content re-opens the gate, forward or backward in
+/// time, and it is still one `stat`.
+///
 /// One `stat` per tier, the `auto_compact_tiers` marker shape, and deliberately
 /// mtime-versus-mtime rather than a time cooldown: a cooldown would make the
 /// promise "records are filed at the next session start" false for however long
@@ -387,21 +404,32 @@ pub fn migrate_tier(
 /// Missing marker means never run, so: yes. Unreadable metadata means yes — the
 /// pass is idempotent, and doing it needlessly is cheaper than not doing it.
 fn changed_since_last_delta(path: &Path) -> bool {
-    let marker = path.with_file_name(".last-domain-delta");
-    let (Ok(g), Ok(m)) = (std::fs::metadata(path), std::fs::metadata(&marker)) else {
-        return true;
-    };
-    match (g.modified(), m.modified()) {
-        (Ok(gt), Ok(mt)) => gt > mt,
-        _ => true,
+    let Ok(current) = store_identity(path) else { return true };
+    match std::fs::read_to_string(path.with_file_name(".last-domain-delta")) {
+        Ok(recorded) => recorded.trim() != current,
+        Err(_) => true,
     }
 }
 
-/// Record that the delta pass has seen the store in its current shape.
-/// Best-effort: a marker that cannot be written costs one needless pass next
-/// session, which is the safe direction to fail.
+/// `<len>:<mtime nanos>` — cheap, and different for any different store.
+fn store_identity(path: &Path) -> std::io::Result<String> {
+    let m = std::fs::metadata(path)?;
+    let nanos = m
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    Ok(format!("{}:{}", m.len(), nanos))
+}
+
+/// Record the store's identity as the delta pass leaves it. Best-effort: a marker
+/// that cannot be written costs one needless pass next session, which is the safe
+/// direction to fail.
 fn stamp_delta_marker(path: &Path) {
-    let _ = std::fs::write(path.with_file_name(".last-domain-delta"), crate::crud::now_iso());
+    if let Ok(id) = store_identity(path) {
+        let _ = std::fs::write(path.with_file_name(".last-domain-delta"), id);
+    }
 }
 
 /// Every tier under `cwd`, workspace then global, the `auto_compact_tiers` shape.

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -32,8 +32,16 @@
 //! HEALTHY, analysed, recalled, and WROTE TWICE, and the artefacts survived. The
 //! reverse too. `store::load_graph` is a syntactic N-Quads parse with no schema
 //! check, and every read binds only the predicates it wants.
+//!
+//! ## Where a domain comes from, and why every arm is counted
+//!
+//! [`Source`] is the whole answer, per record class, and [`Arm`] is which hop
+//! actually fired. Both are reported, because "the catchall set is NAMED
+//! explicitly rather than being whatever was left over" is an acceptance line: an
+//! operator has to be able to see that a record is in `unfiled` because no arm
+//! matched it, not because the migration quietly gave up.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -51,76 +59,129 @@ use crate::store::{self, GraphHealth};
 /// `<graph> ops:schemaVersion` inside the tier's own named graph.
 pub const SCHEMA_VERSION: &str = "domain-1";
 
-/// The catchall domain, for records where a domain is genuinely not relevant.
-/// Chris's ruling 1, 2026-09-06.
+/// The catchall domain, for records no arm could file. Chris's ruling 1, 2026-09-06.
 pub const CATCHALL: &str = "unfiled";
 
-/// Where a record's domain comes from. One variant per family, so the set that
-/// lands in the catchall is NAMED here rather than being whatever was left over —
-/// which is the acceptance line, not a nicety.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub enum Source {
-    /// A domain is not a meaningful attribute of this record. Straight to
-    /// [`CATCHALL`].
-    Catchall,
-    /// Fixed domain for the whole family, assigned by the extension that ingests
-    /// it (ruling 3 covers the Lore\* family).
-    Fixed(&'static str),
-    /// Walk one link to a parent record and take the parent's domain; catchall if
-    /// the parent has none.
-    Parent(&'static str),
-    /// The document's own frontmatter, else the workspace's project domain, else
-    /// catchall (ruling 2).
+/// Which hop actually produced a record's domain. Counted separately in the
+/// migration log so the `unfiled` population is explicit rather than a remainder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub enum Arm {
+    /// The document's own frontmatter `domain:`.
     Frontmatter,
+    /// A `paths` trigger in domains.toml — the same table the pre-tool-use hook
+    /// uses to map a file to a domain.
+    PathTrigger,
+    /// A registered project whose path is a prefix of the record's.
+    ProjectPath,
+    /// A fixed domain for the whole family (ruling 3).
+    Fixed,
+    /// A parent record's domain, one link away.
+    Parent,
+    /// Nothing matched. [`CATCHALL`].
+    Catchall,
 }
 
-/// One covered record class and where its domain comes from.
+impl Arm {
+    pub fn label(self) -> &'static str {
+        match self {
+            Arm::Frontmatter => "frontmatter",
+            Arm::PathTrigger => "path-trigger",
+            Arm::ProjectPath => "project-path",
+            Arm::Fixed => "fixed",
+            Arm::Parent => "parent",
+            Arm::Catchall => CATCHALL,
+        }
+    }
+}
+
+/// Where a record class's domain comes from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// Ruling 2, with the arm vole added on the measurement below: the document's
+    /// frontmatter `domain:`, else a domains.toml path trigger, else a registered
+    /// project whose path is a prefix, else the catchall.
+    ///
+    /// Measured on Chris's live workspace tier, 1,372 Document + PaulPlan +
+    /// PaulSummary records: frontmatter names an existing domain for **8**; a
+    /// path trigger fires for **510**; a project path prefix for **92**. The
+    /// ruling's own middle hop, "the registered workspace's project domain", has
+    /// no data behind it at all — `~/.base-gbl/base.toml` registers zero
+    /// workspaces and the graph holds zero `ops:Workspace` records.
+    Document,
+    /// A fixed domain for the whole family, created if absent (G0 verdict A3).
+    Fixed(&'static str),
+    /// Reverse walk: `?parent ops:<pred> <record>`, then the parent's domain.
+    /// Reverse because that is the direction base actually writes these —
+    /// `<plan> ops:hasAC <ac>`, `<summary> ops:hasFileChange <fc>`.
+    ParentOf(&'static str),
+    /// A literal naming a project slug, e.g. a Handoff's `ops:project "vintrix"`.
+    ProjectLiteral(&'static str),
+    /// The record's own `ops:name` names a project, e.g. a CodeMap of an app.
+    NameProject,
+    /// A domain is not a meaningful attribute of this record.
+    Catchall,
+}
+
+/// One covered record class, where its domain comes from, and when it is resolved.
 ///
-/// Everything the migration touches is in this table, and nothing else is touched.
-/// A class absent from it keeps whatever it has — `Domain` has no domain of its
-/// own, `Ping` is session traffic excluded from every read surface
-/// (`ontology::transient`), and `Note`/`Rule` are already 100% linked.
+/// `stage` exists because four families take their domain from a parent that this
+/// same pass may be filing: an AcceptanceCriteria hangs off a PaulPlan, and the
+/// plan is a document. Stage 1 resolves from the store alone; stage 2 may also read
+/// stage 1's assignments.
 pub struct Covered {
     /// RDF class local name, e.g. `Document` in `ops:Document`.
     pub class: &'static str,
     pub source: Source,
+    pub stage: u8,
 }
 
 /// The families, in the order the migration reports them.
 ///
-/// Counts are hawk's measurement of Chris's live workspace tier, 2026-09-05, and
-/// are here so a reader can tell a table that shrank because the migration worked
-/// from one that shrank because a class stopped being covered.
+/// Everything the migration touches is here, and nothing else is touched. A class
+/// absent from this table keeps whatever it has: `Domain` has no domain of its own,
+/// `Ping` is session traffic excluded from every read surface
+/// (`ontology::transient`), `Note` and `Rule` are already 100% linked, and
+/// `Milestone` reaches one through its project.
+///
+/// The counts are hawk's measurement of Chris's live workspace tier (2026-09-05)
+/// and the predicates are from a read-only probe of that same store (lark,
+/// 2026-09-06) — every parent link below was read off the data, not inferred from
+/// the ontology, which does not declare half these classes.
 pub const COVERED: &[Covered] = &[
-    // 999 workspace + 141 global orphans — the largest single block.
-    Covered { class: "Document", source: Source::Frontmatter },
-    // 1,434 orphans across five classes, all Skyrim (ruling 3).
-    Covered { class: "LoreKnowledge", source: Source::Fixed("skyrim-companion") },
-    Covered { class: "LoreFact", source: Source::Fixed("skyrim-companion") },
-    Covered { class: "LoreRelationship", source: Source::Fixed("skyrim-companion") },
-    Covered { class: "LoreItem", source: Source::Fixed("skyrim-companion") },
-    Covered { class: "LoreBelief", source: Source::Fixed("skyrim-companion") },
-    // 1,241 orphans; every one hangs off a plan that hangs off a project.
-    Covered { class: "AcceptanceCriteria", source: Source::Parent("fromPlan") },
-    Covered { class: "AcceptanceCriteriaResult", source: Source::Parent("fromPlan") },
-    Covered { class: "FileChange", source: Source::Parent("fromPlan") },
-    Covered { class: "PaulSummary", source: Source::Parent("fromPlan") },
-    Covered { class: "PaulPlan", source: Source::Parent("fromProject") },
-    // 209 + 36 orphans; the project is in the filename convention.
-    Covered { class: "Handoff", source: Source::Parent("relatedTo") },
-    // 142 workspace orphans: 137 hang off a document, 5 are loose.
-    Covered { class: "Decision", source: Source::Parent("fromPlan") },
-    // 14 orphans; a code map belongs to the app it maps.
-    Covered { class: "CodeMap", source: Source::Parent("relatedTo") },
-    // Small tails. A task or project with no parent domain, a goal, a reminder:
-    // this IS the named catchall set, not a leftover.
-    Covered { class: "Task", source: Source::Parent("belongsTo") },
-    Covered { class: "Project", source: Source::Catchall },
-    Covered { class: "Goal", source: Source::Catchall },
-    Covered { class: "Reminder", source: Source::Catchall },
+    // 999 workspace + 141 global orphans. Carries `ops:path`; the Paul pair share
+    // the `document/` IRI space and carry it too.
+    Covered { class: "Document", source: Source::Document, stage: 1 },
+    Covered { class: "PaulPlan", source: Source::Document, stage: 1 },
+    Covered { class: "PaulSummary", source: Source::Document, stage: 1 },
+    // 1,434 orphans across five classes, all Skyrim (ruling 3). These carry no IRI
+    // edges at all — every property is a literal — so only a fixed assignment can
+    // reach them.
+    Covered { class: "LoreKnowledge", source: Source::Fixed("skyrim-companion"), stage: 1 },
+    Covered { class: "LoreFact", source: Source::Fixed("skyrim-companion"), stage: 1 },
+    Covered { class: "LoreRelationship", source: Source::Fixed("skyrim-companion"), stage: 1 },
+    Covered { class: "LoreItem", source: Source::Fixed("skyrim-companion"), stage: 1 },
+    Covered { class: "LoreBelief", source: Source::Fixed("skyrim-companion"), stage: 1 },
+    // 209 + 36 orphans. `ops:project` is a LITERAL slug, not an IRI.
+    Covered { class: "Handoff", source: Source::ProjectLiteral("project"), stage: 1 },
+    // 14 orphans; `ops:name` is the app name, which is also its project slug.
+    Covered { class: "CodeMap", source: Source::NameProject, stage: 1 },
+    // A project's parent is a workspace, and a workspace has no domain. This IS
+    // the named catchall set.
+    Covered { class: "Project", source: Source::Catchall, stage: 1 },
+    Covered { class: "Goal", source: Source::Catchall, stage: 1 },
+    Covered { class: "Reminder", source: Source::Catchall, stage: 1 },
+    // 1,241 orphans, every one reached by a reverse edge from a plan or summary
+    // that stage 1 has just filed.
+    Covered { class: "AcceptanceCriteria", source: Source::ParentOf("hasAC"), stage: 2 },
+    Covered { class: "AcceptanceCriteriaResult", source: Source::ParentOf("hasACResult"), stage: 2 },
+    Covered { class: "FileChange", source: Source::ParentOf("hasFileChange"), stage: 2 },
+    // 142 workspace orphans. The other 263 are already linked the other way round
+    // (`<domain> ops:hasDecision <decision>`) and `link::domain_index` sees them.
+    Covered { class: "Decision", source: Source::ParentOf("hasDecision"), stage: 2 },
+    Covered { class: "Task", source: Source::ParentOf("hasTask"), stage: 2 },
 ];
 
-/// What one tier's migration did. Serialized by `base doctor --json`.
+/// What one tier's migration did.
 #[derive(Debug, Default, Serialize)]
 pub struct Outcome {
     pub path: String,
@@ -129,9 +190,12 @@ pub struct Outcome {
     /// The graph was not healthy; nothing was written and nothing was stamped.
     pub skipped_unhealthy: bool,
     pub backup: Option<String>,
-    /// Records linked, by RDF class. Empty when the store had no orphans.
+    /// Records linked, by RDF class.
     pub linked: BTreeMap<String, usize>,
-    /// How many of those landed in [`CATCHALL`].
+    /// Records linked, by which arm filed them. `unfiled` is one entry among the
+    /// others here, which is what makes it a decision rather than a remainder.
+    pub by_arm: BTreeMap<String, usize>,
+    /// How many landed in [`CATCHALL`]. Same number as `by_arm["unfiled"]`.
     pub catchall: usize,
     /// True when the store now carries the stamp because THIS pass wrote it.
     pub stamped: bool,
@@ -141,7 +205,6 @@ impl Outcome {
     pub fn total_linked(&self) -> usize {
         self.linked.values().sum()
     }
-    /// Nothing happened and nothing needed to: the honest "no-op" test.
     pub fn is_noop(&self) -> bool {
         !self.stamped && self.total_linked() == 0
     }
@@ -173,7 +236,8 @@ pub fn stamp_of(store: &Store, ns: &NamespaceConfig, graph_iri: &str) -> Option<
 /// environment, the `compact_tier` shape, so a test drives it against a copy.
 ///
 /// `graph_iri` is the tier's own named graph — the stamp's subject and the graph
-/// every backfilled triple is written into.
+/// every backfilled triple is written into. The tier root (`<root>/.base/graph.nq`)
+/// is what a document's relative `ops:path` resolves against.
 pub fn migrate_tier(path: &Path, graph_iri: &str, ns: &NamespaceConfig) -> Result<Outcome> {
     let mut out = Outcome { path: path.display().to_string(), ..Default::default() };
 
@@ -195,11 +259,13 @@ pub fn migrate_tier(path: &Path, graph_iri: &str, ns: &NamespaceConfig) -> Resul
         return Ok(out);
     }
 
-    let plan = plan_backfill(&store, ns)?;
+    let root = path.parent().and_then(Path::parent).unwrap_or(path).to_path_buf();
+    let facts = Facts::gather(&store, ns, root);
+    let plan = plan_backfill(&facts, ns);
 
-    // C1: snapshot first, sharing the `BACKUP_KEEP = 10` pool with compact.
-    // Only once there is a write to protect — a pure re-stamp of an already-clean
-    // store should not evict a compact backup.
+    // C1: snapshot first, sharing the `BACKUP_KEEP = 10` pool with compact. Only
+    // once there is a write to protect — a pure re-stamp of an already-clean store
+    // must not evict a compact backup.
     out.backup = Some(store::snapshot(path, "migrate")?.display().to_string());
 
     apply(&store, ns, graph_iri, &plan, &mut out)?;
@@ -225,7 +291,7 @@ pub fn migrate_tiers(cwd: &Path, ns: &NamespaceConfig) -> Vec<Outcome> {
             let iri = crate::crud::workspace_graph_iri(ns, &crate::crud::workspace_slug(&root));
             migrate_tier(&path, &iri, ns).ok()
         })
-        .filter(|o| !o.is_noop() || o.skipped_unhealthy)
+        .filter(|o| o.total_linked() > 0 || o.skipped_unhealthy)
         .collect()
 }
 
@@ -246,101 +312,338 @@ fn tier_roots(cwd: &Path) -> Vec<PathBuf> {
     roots
 }
 
+// ─── the facts a plan is built from ─────────────────────────────────────────
+
+/// Everything the resolvers need, read from the store in a fixed number of
+/// queries. The alternative — one query per record — is 4,000 SPARQL round trips
+/// against a 13 MB store inside a session-start hook, which is not a budget.
+struct Facts {
+    root: PathBuf,
+    /// Record IRI → the domain it already has, in either direction.
+    index: HashMap<String, String>,
+    /// Domain slugs that exist as `ops:Domain` records. A backfill links only to
+    /// one of these (or to the catchall) — it never invents a domain.
+    known: HashSet<String>,
+    /// Subjects of each covered class, minus session traffic.
+    by_class: HashMap<&'static str, Vec<String>>,
+    path_of: HashMap<String, String>,
+    name_of: HashMap<String, String>,
+    project_lit: HashMap<String, String>,
+    /// Child IRI → (predicate local name, parent IRI).
+    parents: HashMap<String, Vec<(String, String)>>,
+    /// (domain slug, root-relative trigger path), longest first, ties broken by
+    /// declaration order in `domain::load_domains`.
+    triggers: Vec<(String, String)>,
+    /// (project IRI, root-relative project path), longest first.
+    project_paths: Vec<(String, String)>,
+}
+
+impl Facts {
+    fn gather(store: &Store, ns: &NamespaceConfig, root: PathBuf) -> Self {
+        let index = link::domain_index(store, ns);
+        let known = existing_domains(store, ns);
+
+        let mut by_class = HashMap::new();
+        for cov in COVERED {
+            by_class.insert(cov.class, orphans_of(store, ns, cov.class, &index));
+        }
+
+        let path_of = literal_map(store, ns, "path");
+        let name_of = literal_map(store, ns, "name");
+        let project_lit = literal_map(store, ns, "project");
+
+        let mut parents: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for pred in COVERED.iter().filter_map(|c| match c.source {
+            Source::ParentOf(p) => Some(p),
+            _ => None,
+        }) {
+            for (parent, child) in iri_pairs(store, ns, pred) {
+                parents.entry(child).or_default().push((pred.to_string(), parent));
+            }
+        }
+
+        // Longest trigger wins; a tie keeps `load_domains` order, which is global
+        // then workspace-overlaid then extensions. Deterministic for a given
+        // config, which is the property that matters — Chris's workspace declares
+        // `tools` twice (skyrim-companion and asset-inventory) and something has
+        // to decide it the same way on every run.
+        let mut triggers: Vec<(String, String)> = Vec::new();
+        for def in crate::domain::load_domains(&root) {
+            let slug = crate::crud::slugify(&def.name);
+            for p in &def.paths {
+                if let Some(rel) = rel_to_root(&root, p) {
+                    triggers.push((slug.clone(), rel));
+                }
+            }
+        }
+        triggers.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+
+        let mut project_paths: Vec<(String, String)> = Vec::new();
+        for iri in class_subjects(store, ns, "Project") {
+            let Some(raw) = path_of.get(&iri) else { continue };
+            let Some(rel) = rel_to_root(&root, raw) else { continue };
+            // A project whose path is a single top-level folder claims everything
+            // under it. Chris has two — `vintrix` = "Documents" and
+            // `asset-inventory` = "tools" — and honouring them would file 377
+            // unrelated documents under those domains. That is mis-filing, not
+            // coverage, so a bare top-level path is not a project prefix.
+            if rel.contains('/') {
+                project_paths.push((iri, rel));
+            }
+        }
+        project_paths.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+
+        Facts { root, index, known, by_class, path_of, name_of, project_lit, parents, triggers, project_paths }
+    }
+}
+
+/// `C:/Users/Chris/tools` under root `C:/Users/Chris` → `tools`. `None` for a path
+/// outside the tier, which cannot be compared with a record's relative path.
+fn rel_to_root(root: &Path, p: &str) -> Option<String> {
+    let norm = |s: &str| s.replace('\\', "/").trim_end_matches('/').to_string();
+    let p = norm(&p.replace("\\\\", "\\"));
+    let r = norm(&root.to_string_lossy());
+    if !r.is_empty() && p.len() > r.len() && p[..r.len()].eq_ignore_ascii_case(&r) && p.as_bytes()[r.len()] == b'/' {
+        return Some(p[r.len() + 1..].to_string());
+    }
+    // Already relative: no drive letter, no leading slash, no UNC.
+    if !p.starts_with('/') && !p.contains(':') && !p.is_empty() {
+        return Some(p);
+    }
+    None
+}
+
 // ─── planning ────────────────────────────────────────────────────────────────
 
-/// One record that needs a domain link, and the domain it will get.
+/// One record that needs a domain link, the domain it will get, and the arm that
+/// decided it.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Assignment {
     pub subject: String,
     pub class: String,
     pub domain_slug: String,
+    pub arm: Arm,
 }
 
 /// What is still unmigrated, computed from the store (G0 verdict A2). Never from
 /// the stamp, and never from a record count.
-pub fn plan_backfill(store: &Store, ns: &NamespaceConfig) -> Result<Vec<Assignment>> {
-    let known = existing_domains(store, ns)?;
-    let mut plan = Vec::new();
-    for cov in COVERED {
-        for subject in orphans_of(store, ns, cov.class)? {
-            let slug = resolve(store, ns, &subject, cov.source, &known);
-            plan.push(Assignment { subject, class: cov.class.to_string(), domain_slug: slug });
+fn plan_backfill(facts: &Facts, ns: &NamespaceConfig) -> Vec<Assignment> {
+    let mut plan: Vec<Assignment> = Vec::new();
+    // Stage 1's assignments are visible to stage 2: an AcceptanceCriteria takes
+    // its plan's domain, and the plan may have been filed moments ago in this same
+    // pass.
+    let mut planned: HashMap<String, String> = HashMap::new();
+
+    for stage in [1u8, 2u8] {
+        for cov in COVERED.iter().filter(|c| c.stage == stage) {
+            let Some(subjects) = facts.by_class.get(cov.class) else { continue };
+            for subject in subjects {
+                // One assignment per record, from the first covered class that
+                // claims it. Chris's store has no subject carrying two rdf:types
+                // (measured, 2026-09-06), but multi-typing is legal RDF and a
+                // record filed twice would insert the same quad twice — harmless
+                // in a set store — and count itself twice in the log, which is
+                // not harmless: the log is the only view of what the migration
+                // did.
+                if planned.contains_key(subject) {
+                    continue;
+                }
+                let (slug, arm) = resolve(facts, ns, subject, cov.source, &planned);
+                planned.insert(subject.clone(), slug.clone());
+                plan.push(Assignment {
+                    subject: subject.clone(),
+                    class: cov.class.to_string(),
+                    domain_slug: slug,
+                    arm,
+                });
+            }
         }
     }
-    Ok(plan)
+    plan.sort_by(|a, b| a.subject.cmp(&b.subject));
+    plan
 }
 
-/// Subjects of `class` carrying no domain link in either era, minus session
+/// The domain slug for one record, and which arm produced it.
+fn resolve(
+    facts: &Facts,
+    ns: &NamespaceConfig,
+    subject: &str,
+    source: Source,
+    planned: &HashMap<String, String>,
+) -> (String, Arm) {
+    let catchall = || (CATCHALL.to_string(), Arm::Catchall);
+    match source {
+        Source::Catchall => catchall(),
+
+        // A3: a fixed family domain is created if absent, so the ruling holds on a
+        // store that never declared it. This is the one place the migration may
+        // add a domain record besides the catchall, and it is one per family, not
+        // one per record.
+        Source::Fixed(slug) => (slug.to_string(), Arm::Fixed),
+
+        Source::Document => {
+            let Some(rel) = facts.path_of.get(subject) else { return catchall() };
+            let rel = rel.replace('\\', "/");
+            if let Some(slug) = frontmatter_domain(&facts.root, &rel)
+                && facts.known.contains(&slug)
+            {
+                return (slug, Arm::Frontmatter);
+            }
+            if let Some((slug, _)) = facts.triggers.iter().find(|(_, t)| under(&rel, t))
+                && facts.known.contains(slug)
+            {
+                return (slug.clone(), Arm::PathTrigger);
+            }
+            if let Some((proj, _)) = facts.project_paths.iter().find(|(_, t)| under(&rel, t))
+                && let Some(slug) = facts.index.get(proj)
+            {
+                return (slug.clone(), Arm::ProjectPath);
+            }
+            catchall()
+        }
+
+        Source::ParentOf(pred) => facts
+            .parents
+            .get(subject)
+            .into_iter()
+            .flatten()
+            .filter(|(p, _)| p == pred)
+            .find_map(|(_, parent)| facts.index.get(parent).or_else(|| planned.get(parent)))
+            .filter(|slug| slug.as_str() != CATCHALL)
+            .map(|slug| (slug.clone(), Arm::Parent))
+            .unwrap_or_else(catchall),
+
+        Source::ProjectLiteral(pred) => facts
+            .project_lit
+            .get(subject)
+            .filter(|_| pred == "project")
+            .and_then(|lit| project_domain(facts, ns, lit))
+            .map(|slug| (slug, Arm::Parent))
+            .unwrap_or_else(catchall),
+
+        Source::NameProject => facts
+            .name_of
+            .get(subject)
+            .and_then(|lit| project_domain(facts, ns, lit))
+            .map(|slug| (slug, Arm::Parent))
+            .unwrap_or_else(catchall),
+    }
+}
+
+/// `"vintrix"` → the domain of `project/vintrix`, if that project has one.
+fn project_domain(facts: &Facts, ns: &NamespaceConfig, literal: &str) -> Option<String> {
+    let iri = crate::crud::build_iri(ns, "project", &crate::crud::slugify(literal));
+    facts.index.get(&iri).cloned()
+}
+
+/// Is `rel` inside `dir`? Case-insensitive, because a Windows store holds
+/// `Tools/stt` and a trigger may say `tools/stt`.
+fn under(rel: &str, dir: &str) -> bool {
+    !dir.is_empty()
+        && rel.len() > dir.len()
+        && rel[..dir.len()].eq_ignore_ascii_case(dir)
+        && rel.as_bytes()[dir.len()] == b'/'
+}
+
+/// The `domain:` key of a markdown file's frontmatter, slugified. Reads at most
+/// the head of the file — the frontmatter parser only ever needs that, and the
+/// migration opens up to a few thousand of these once.
+fn frontmatter_domain(root: &Path, rel: &str) -> Option<String> {
+    let full = root.join(rel);
+    let meta = std::fs::metadata(&full).ok()?;
+    if !meta.is_file() || meta.len() > 1_000_000 {
+        return None;
+    }
+    let content = std::fs::read_to_string(&full).ok()?;
+    let fm = crate::extract::frontmatter::parse_frontmatter(&content)?;
+    fm.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("domain"))
+        .map(|(_, v)| crate::crud::slugify(v.trim().trim_matches('"')))
+        .filter(|s| !s.is_empty())
+}
+
+// ─── store reads ─────────────────────────────────────────────────────────────
+
+/// Subjects of `class` carrying no domain link in either direction, minus session
 /// traffic. The transient filter is the shared one — adding a kind to
 /// `ontology::transient::TRANSIENT_KINDS` excludes it from the migration too.
-fn orphans_of(store: &Store, ns: &NamespaceConfig, class: &str) -> Result<Vec<String>> {
+fn orphans_of(
+    store: &Store,
+    ns: &NamespaceConfig,
+    class: &str,
+    index: &HashMap<String, String>,
+) -> Vec<String> {
+    class_subjects(store, ns, class).into_iter().filter(|s| !index.contains_key(s)).collect()
+}
+
+fn class_subjects(store: &Store, ns: &NamespaceConfig, class: &str) -> Vec<String> {
     let p = &ns.prefix;
     let pfx = crate::crud::prefixes(ns);
-    let no_link = link::no_domain_link(ns, "s");
     let no_transient = crate::ontology::transient::sparql_exclude(ns, "s");
     let q = format!(
-        "{pfx}\nSELECT DISTINCT ?s WHERE {{ GRAPH ?g {{\n\
-           ?s a {p}:{class} .\n\
-           {no_link}{no_transient}\
-         }} }}"
+        "{pfx}\nSELECT DISTINCT ?s WHERE {{ GRAPH ?g {{ ?s a {p}:{class} .\n{no_transient}}} }}"
     );
-    let QueryResults::Solutions(sols) = store::query(store, &q)? else { return Ok(Vec::new()) };
-    Ok(sols
+    let Ok(QueryResults::Solutions(sols)) = store::query(store, &q) else { return Vec::new() };
+    let mut out: Vec<String> = sols
         .filter_map(|r| r.ok())
         .filter_map(|row| match row.get("s")? {
             Term::NamedNode(n) => Some(n.as_str().to_string()),
             _ => None,
         })
-        .collect())
+        .collect();
+    out.sort();
+    out
 }
 
-/// Every `domain/` IRI that actually exists, as slugs. A backfill links only to a
-/// domain record that is already there (or to the catchall, created once) — the
-/// migration never invents a domain.
-fn existing_domains(store: &Store, ns: &NamespaceConfig) -> Result<std::collections::HashSet<String>> {
+/// `?s ops:<pred> ?o` where the object is a literal.
+fn literal_map(store: &Store, ns: &NamespaceConfig, pred: &str) -> HashMap<String, String> {
     let p = &ns.prefix;
     let pfx = crate::crud::prefixes(ns);
-    let q = format!("{pfx}\nSELECT DISTINCT ?d WHERE {{ GRAPH ?g {{ ?d a {p}:Domain }} }}");
-    let QueryResults::Solutions(sols) = store::query(store, &q)? else {
-        return Ok(Default::default());
-    };
-    let prefix = link::domain_iri_prefix(ns);
-    Ok(sols
-        .filter_map(|r| r.ok())
-        .filter_map(|row| match row.get("d")? {
-            Term::NamedNode(n) => n.as_str().strip_prefix(prefix.as_str()).map(str::to_string),
-            _ => None,
-        })
-        .collect())
+    let q = format!(
+        "{pfx}\nSELECT ?s ?o WHERE {{ GRAPH ?g {{ ?s {p}:{pred} ?o . FILTER(isLiteral(?o)) }} }}"
+    );
+    let mut out = HashMap::new();
+    let Ok(QueryResults::Solutions(sols)) = store::query(store, &q) else { return out };
+    for row in sols.filter_map(|r| r.ok()) {
+        let (Some(Term::NamedNode(s)), Some(Term::Literal(o))) = (row.get("s"), row.get("o")) else {
+            continue;
+        };
+        out.entry(s.as_str().to_string()).or_insert_with(|| o.value().to_string());
+    }
+    out
 }
 
-/// The domain slug for one record. Falls back to [`CATCHALL`] whenever the source
-/// yields nothing or names a domain that does not exist — never invents one.
-fn resolve(
-    _store: &Store,
-    _ns: &NamespaceConfig,
-    _subject: &str,
-    source: Source,
-    known: &std::collections::HashSet<String>,
-) -> String {
-    let candidate = match source {
-        Source::Catchall => None,
-        // The family resolvers land with the backfill sources (build step 4).
-        // Until then every covered record resolves to the catchall, which is
-        // correct-but-coarse rather than wrong: a record in `unfiled` is still
-        // linked, still countable, and still moved by `base graph move`.
-        Source::Fixed(_) | Source::Parent(_) | Source::Frontmatter => None,
-    };
-    match candidate {
-        Some(slug) if known.contains(&slug) => slug,
-        _ => CATCHALL.to_string(),
-    }
+/// `?a ops:<pred> ?b` where both are IRIs, as `(subject, object)`.
+fn iri_pairs(store: &Store, ns: &NamespaceConfig, pred: &str) -> Vec<(String, String)> {
+    let p = &ns.prefix;
+    let pfx = crate::crud::prefixes(ns);
+    let q = format!(
+        "{pfx}\nSELECT ?a ?b WHERE {{ GRAPH ?g {{ ?a {p}:{pred} ?b . FILTER(isIRI(?b)) }} }}"
+    );
+    let Ok(QueryResults::Solutions(sols)) = store::query(store, &q) else { return Vec::new() };
+    sols.filter_map(|r| r.ok())
+        .filter_map(|row| match (row.get("a")?, row.get("b")?) {
+            (Term::NamedNode(a), Term::NamedNode(b)) => {
+                Some((a.as_str().to_string(), b.as_str().to_string()))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every `domain/` IRI that actually exists, as slugs.
+fn existing_domains(store: &Store, ns: &NamespaceConfig) -> HashSet<String> {
+    let prefix = link::domain_iri_prefix(ns);
+    class_subjects(store, ns, "Domain")
+        .into_iter()
+        .filter_map(|iri| iri.strip_prefix(prefix.as_str()).map(str::to_string))
+        .collect()
 }
 
 // ─── applying ────────────────────────────────────────────────────────────────
 
-/// Insert the plan's links, plus the catchall domain record if anything needs it.
-/// In-memory only: nothing reaches disk until `write_back`.
+/// Insert the plan's links, plus any domain record the plan needs that does not
+/// exist yet. In-memory only: nothing reaches disk until `write_back`.
 fn apply(
     store: &Store,
     ns: &NamespaceConfig,
@@ -352,29 +655,32 @@ fn apply(
         return Ok(());
     }
     let graph = NamedNodeRef::new(graph_iri)?;
-    let has_domain = format!("{}{}", ns.uri, link::CANONICAL);
-    let has_domain = NamedNodeRef::new(&has_domain)?;
+    let has_domain_iri = format!("{}{}", ns.uri, link::CANONICAL);
+    let has_domain = NamedNodeRef::new(&has_domain_iri)?;
 
-    if plan.iter().any(|a| a.domain_slug == CATCHALL) {
-        ensure_catchall(store, ns, graph)?;
-    }
-
+    let mut created: HashSet<&str> = HashSet::new();
     for a in plan {
+        if created.insert(a.domain_slug.as_str()) {
+            ensure_domain(store, ns, graph, &a.domain_slug)?;
+        }
         let subject = NamedNodeRef::new(&a.subject)?;
         let domain_iri = crate::crud::build_iri(ns, "domain", &a.domain_slug);
         let object = NamedNodeRef::new(&domain_iri)?;
         store.insert(QuadRef::new(subject, has_domain, object, GraphNameRef::NamedNode(graph)))?;
         *out.linked.entry(a.class.clone()).or_default() += 1;
-        if a.domain_slug == CATCHALL {
+        *out.by_arm.entry(a.arm.label().to_string()).or_default() += 1;
+        if a.arm == Arm::Catchall {
             out.catchall += 1;
         }
     }
     Ok(())
 }
 
-/// Create the catchall domain once, with the same shape `domain sync` writes.
-fn ensure_catchall(store: &Store, ns: &NamespaceConfig, graph: NamedNodeRef<'_>) -> Result<()> {
-    let iri = crate::crud::build_iri(ns, "domain", CATCHALL);
+/// Create a domain record if it is not already there, with the same shape
+/// `domain sync` writes. Idempotent by construction: the store is a set, so a
+/// re-insert of an existing quad changes nothing.
+fn ensure_domain(store: &Store, ns: &NamespaceConfig, graph: NamedNodeRef<'_>, slug: &str) -> Result<()> {
+    let iri = crate::crud::build_iri(ns, "domain", slug);
     let subject = NamedNodeRef::new(&iri)?;
     let rdf_type = NamedNodeRef::new("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")?;
     let class = format!("{}Domain", ns.uri);
@@ -383,7 +689,7 @@ fn ensure_catchall(store: &Store, ns: &NamespaceConfig, graph: NamedNodeRef<'_>)
     let name_pred = NamedNodeRef::new(&name_pred)?;
     let g = GraphNameRef::NamedNode(graph);
     store.insert(QuadRef::new(subject, rdf_type, class, g))?;
-    store.insert(QuadRef::new(subject, name_pred, LiteralRef::new_simple_literal(CATCHALL), g))?;
+    store.insert(QuadRef::new(subject, name_pred, LiteralRef::new_simple_literal(slug), g))?;
     Ok(())
 }
 
@@ -412,7 +718,11 @@ fn write_stamp(store: &Store, ns: &NamespaceConfig, graph_iri: &str) -> Result<(
 
 // ─── reporting ───────────────────────────────────────────────────────────────
 
-/// One line per tier, for the session-start notice. Empty when nothing happened.
+/// One line per tier for the session-start notice, naming what each arm filed.
+///
+/// The per-arm breakdown is the point, not decoration: `unfiled` appears as one
+/// arm among the others, so an operator can see it was a decision no arm could
+/// beat rather than a silent remainder.
 pub fn format_outcomes(outcomes: &[Outcome]) -> String {
     let mut s = String::new();
     for o in outcomes {
@@ -429,13 +739,13 @@ pub fn format_outcomes(outcomes: &[Outcome]) -> String {
         if o.total_linked() == 0 {
             continue;
         }
-        let by_kind: Vec<String> =
-            o.linked.iter().map(|(k, n)| format!("{k} {n}")).collect();
+        let arms: Vec<String> = o.by_arm.iter().map(|(k, n)| format!("{k} {n}")).collect();
+        let kinds: Vec<String> = o.linked.iter().map(|(k, n)| format!("{k} {n}")).collect();
         s.push_str(&format!(
-            "base: domain migration — {} record(s) linked ({}), {} to `{CATCHALL}`\n",
+            "base: domain migration — {} record(s) now carry a domain.\n  by source: {}\n  by kind:   {}\n",
             o.total_linked(),
-            if by_kind.is_empty() { "none".to_string() } else { by_kind.join(", ") },
-            o.catchall,
+            arms.join(", "),
+            kinds.join(", "),
         ));
     }
     s
@@ -447,7 +757,7 @@ mod tests {
 
     #[test]
     fn every_covered_class_is_named_once() {
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::new();
         for c in COVERED {
             assert!(seen.insert(c.class), "{} is listed twice", c.class);
         }
@@ -484,5 +794,35 @@ mod tests {
             vec!["Project", "Goal", "Reminder"],
             "the acceptance line requires this set to be explicit; change it here, deliberately"
         );
+    }
+
+    #[test]
+    fn a_parent_walking_class_is_resolved_after_its_parents() {
+        for c in COVERED {
+            if matches!(c.source, Source::ParentOf(_)) {
+                assert_eq!(c.stage, 2, "{} walks to a parent, so it resolves in stage 2", c.class);
+            }
+        }
+    }
+
+    #[test]
+    fn rel_to_root_strips_the_tier_root_in_either_slash_style() {
+        let root = Path::new("C:/Users/Chris");
+        assert_eq!(rel_to_root(root, "C:/Users/Chris/tools").as_deref(), Some("tools"));
+        assert_eq!(rel_to_root(root, r"C:\Users\Chris\ClaudePokes").as_deref(), Some("ClaudePokes"));
+        assert_eq!(rel_to_root(root, r"C:\\Users\\Chris\\Tools\\stt").as_deref(), Some("Tools/stt"));
+        assert_eq!(rel_to_root(root, "Documents/video-gen").as_deref(), Some("Documents/video-gen"));
+        // Outside the tier: not comparable with a record's relative path.
+        assert_eq!(rel_to_root(root, "/home/chriskahler/basemode"), None);
+        assert_eq!(rel_to_root(root, "D:/elsewhere"), None);
+    }
+
+    #[test]
+    fn under_is_a_path_test_not_a_string_prefix() {
+        assert!(under("Documents/video-gen/a.md", "Documents/video-gen"));
+        assert!(under("Tools/stt/x.md", "tools/stt"), "Windows paths are case-insensitive");
+        assert!(!under("Documents/video-generator/a.md", "Documents/video-gen"));
+        assert!(!under("Documents/video-gen", "Documents/video-gen"), "the dir is not under itself");
+        assert!(!under("anything", ""));
     }
 }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -415,7 +415,8 @@ impl Facts {
                 }
             }
         }
-        triggers.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        // Stable, so an equal-length tie keeps `load_domains` order.
+        triggers.sort_by_key(|t| std::cmp::Reverse(t.1.len()));
 
         let mut project_paths: Vec<(String, String)> = Vec::new();
         for iri in class_subjects(store, ns, "Project") {
@@ -430,7 +431,7 @@ impl Facts {
                 project_paths.push((iri, rel));
             }
         }
-        project_paths.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        project_paths.sort_by_key(|p| std::cmp::Reverse(p.1.len()));
 
         Facts { root, index, known, by_class, path_of, name_of, project_lit, parents, triggers, project_paths }
     }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -181,6 +181,22 @@ pub const COVERED: &[Covered] = &[
     Covered { class: "Task", source: Source::ParentOf("hasTask"), stage: 2 },
 ];
 
+/// Who asked. The stamp is session-start's fast path and NOTHING else.
+///
+/// kite, reviewing PR #50: on a stamped tier `base graph migrate` printed
+/// "Nothing to migrate" while `base doctor` reported `without a domain: N` on the
+/// same tier, in the same second. Both cannot be true. The migration is
+/// idempotent and recomputes its work from the store, so the stamp buys one
+/// thing — not re-planning a 13.4 MB store on every session start — and it must
+/// never be allowed to answer a question the operator asked directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trigger {
+    /// The session-start hook. Takes the stamp as a fast path.
+    SessionStart,
+    /// `base graph migrate`. Always re-plans; the operator asked.
+    Manual,
+}
+
 /// What one tier's migration did.
 #[derive(Debug, Default, Serialize)]
 pub struct Outcome {
@@ -277,7 +293,12 @@ pub fn stamp_of_tier(store: &Store, ns: &NamespaceConfig) -> Option<String> {
 /// `graph_iri` is the tier's own named graph — the stamp's subject and the graph
 /// every backfilled triple is written into. The tier root (`<root>/.base/graph.nq`)
 /// is what a document's relative `ops:path` resolves against.
-pub fn migrate_tier(path: &Path, graph_iri: &str, ns: &NamespaceConfig) -> Result<Outcome> {
+pub fn migrate_tier(
+    path: &Path,
+    graph_iri: &str,
+    ns: &NamespaceConfig,
+    trigger: Trigger,
+) -> Result<Outcome> {
     let mut out = Outcome { path: path.display().to_string(), ..Default::default() };
 
     // C1: `compact_tier` refuses an unhealthy graph and a migration that reuses
@@ -290,10 +311,14 @@ pub fn migrate_tier(path: &Path, graph_iri: &str, ns: &NamespaceConfig) -> Resul
 
     let store = store::load_graph(path)?;
 
-    // Fast path. Not a truth source — the work below is recomputed from the store
-    // every time the stamp is absent, so a restored pre-migration backup migrates
-    // again and a restored post-migration backup is already correct.
-    if stamp_of(&store, ns, graph_iri).as_deref() == Some(SCHEMA_VERSION) {
+    let stamped = stamp_of(&store, ns, graph_iri).as_deref() == Some(SCHEMA_VERSION);
+
+    // The fast path, and ONLY for the hook. Not a truth source — the work below is
+    // recomputed from the store whenever it is not taken, so a restored
+    // pre-migration backup migrates again and a restored post-migration backup is
+    // already correct. `Trigger::Manual` never takes it: an operator who typed the
+    // command gets the real answer, not the stamp's.
+    if stamped && trigger == Trigger::SessionStart {
         out.already_migrated = true;
         return Ok(out);
     }
@@ -302,12 +327,24 @@ pub fn migrate_tier(path: &Path, graph_iri: &str, ns: &NamespaceConfig) -> Resul
     let facts = Facts::gather(&store, ns, root);
     let plan = plan_backfill(&facts, ns);
 
-    // C1: snapshot first, sharing the `BACKUP_KEEP = 10` pool with compact. Only
-    // once there is a write to protect — a pure re-stamp of an already-clean store
-    // must not evict a compact backup.
-    out.backup = Some(store::snapshot(path, "migrate")?.display().to_string());
+    // Re-planned and there is genuinely nothing to do. Return without touching the
+    // file at all: a manual run on an already-migrated tier must not rewrite a
+    // 13.4 MB store to change nothing.
+    if plan.is_empty() && stamped {
+        out.already_migrated = true;
+        return Ok(out);
+    }
 
-    apply(&store, ns, graph_iri, &plan, &mut out)?;
+    // C1: snapshot first, sharing the `BACKUP_KEEP = 10` pool with compact — but
+    // only when there is data to protect. A pass that writes nothing but the stamp
+    // must not evict a compact backup from a pool of ten, which is what the
+    // comment, `docs/graph-durability.md` and the outcome's own `backup: None`
+    // have always claimed and what the code did not do (kite, PR #50).
+    if !plan.is_empty() {
+        out.backup = Some(store::snapshot(path, "migrate")?.display().to_string());
+        apply(&store, ns, graph_iri, &plan, &mut out)?;
+    }
+
     write_stamp(&store, ns, graph_iri)?;
     out.stamped = true;
 
@@ -319,7 +356,7 @@ pub fn migrate_tier(path: &Path, graph_iri: &str, ns: &NamespaceConfig) -> Resul
 
 /// Every tier under `cwd`, workspace then global, the `auto_compact_tiers` shape.
 /// Errors are per-tier: one unmigratable tier must not stop the other.
-pub fn migrate_tiers(cwd: &Path, ns: &NamespaceConfig) -> Vec<Outcome> {
+pub fn migrate_tiers(cwd: &Path, ns: &NamespaceConfig, trigger: Trigger) -> Vec<Outcome> {
     tier_roots(cwd)
         .into_iter()
         .filter_map(|root| {
@@ -328,7 +365,7 @@ pub fn migrate_tiers(cwd: &Path, ns: &NamespaceConfig) -> Vec<Outcome> {
                 return None;
             }
             let iri = crate::crud::workspace_graph_iri(ns, &crate::crud::workspace_slug(&root));
-            migrate_tier(&path, &iri, ns).ok()
+            migrate_tier(&path, &iri, ns, trigger).ok()
         })
         .filter(|o| o.total_linked() > 0 || o.skipped_unhealthy)
         .collect()
@@ -820,8 +857,11 @@ pub fn format_dry_run(cwd: &Path, ns: &NamespaceConfig) -> String {
             s.push_str("   could not be read\n");
             continue;
         };
+        // Both branches re-plan below. `--dry-run` and the run it previews must
+        // agree with each other AND with `base doctor` on the same tier — three
+        // surfaces answering one question, so they cannot be allowed to differ.
         match stamp_of_tier(&store, ns) {
-            Some(v) => s.push_str(&format!("   schema: {v} (already migrated)\n")),
+            Some(v) => s.push_str(&format!("   schema: {v}\n")),
             None => s.push_str("   schema: not migrated\n"),
         }
         let facts = Facts::gather(&store, ns, root.clone());

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -230,6 +230,45 @@ pub fn stamp_of(store: &Store, ns: &NamespaceConfig, graph_iri: &str) -> Option<
         .next()
 }
 
+/// Covered records that still carry no domain link, per class, highest first.
+///
+/// `base doctor` reports this so a migration that skipped, or a store that has
+/// drifted since one ran, is never invisible (C4). Drift is expected and is not a
+/// fault: `base sync` writes a Document with no domain, so the count climbs again
+/// after a migration until every write path carries the link.
+pub fn orphan_counts(store: &Store, ns: &NamespaceConfig) -> Vec<(String, usize)> {
+    let index = link::domain_index(store, ns);
+    let by_class = covered_subjects(store, ns);
+    let mut counts: Vec<(String, usize)> = COVERED
+        .iter()
+        .map(|c| {
+            let n = by_class
+                .get(c.class)
+                .map(|subs| subs.iter().filter(|s| !index.contains_key(*s)).count())
+                .unwrap_or(0);
+            (c.class.to_string(), n)
+        })
+        .filter(|(_, n)| *n > 0)
+        .collect();
+    counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    counts
+}
+
+/// The schema version a tier claims, without the caller having to know its graph
+/// IRI. The stamp's subject IS its graph, so the store describes itself.
+pub fn stamp_of_tier(store: &Store, ns: &NamespaceConfig) -> Option<String> {
+    let p = &ns.prefix;
+    let pfx = crate::crud::prefixes(ns);
+    let q = format!("{pfx}\nSELECT ?v WHERE {{ GRAPH ?g {{ ?g {p}:schemaVersion ?v }} }}");
+    let QueryResults::Solutions(sols) = store::query(store, &q).ok()? else { return None };
+    sols.filter_map(|r| r.ok())
+        .filter_map(|row| match row.get("v")? {
+            Term::Literal(l) => Some(l.value().to_string()),
+            _ => None,
+        })
+        .next()
+}
+
 // ─── the pass ────────────────────────────────────────────────────────────────
 
 /// Migrate one tier's graph file. Path-scoped and pure of the operator's
@@ -343,9 +382,9 @@ impl Facts {
         let index = link::domain_index(store, ns);
         let known = existing_domains(store, ns);
 
-        let mut by_class = HashMap::new();
-        for cov in COVERED {
-            by_class.insert(cov.class, orphans_of(store, ns, cov.class, &index));
+        let mut by_class = covered_subjects(store, ns);
+        for subs in by_class.values_mut() {
+            subs.retain(|s| !index.contains_key(s));
         }
 
         let path_of = literal_map(store, ns, "path");
@@ -564,25 +603,47 @@ fn frontmatter_domain(root: &Path, rel: &str) -> Option<String> {
 
 // ─── store reads ─────────────────────────────────────────────────────────────
 
-/// Subjects of `class` carrying no domain link in either direction, minus session
-/// traffic. The transient filter is the shared one — adding a kind to
-/// `ontology::transient::TRANSIENT_KINDS` excludes it from the migration too.
-fn orphans_of(
-    store: &Store,
-    ns: &NamespaceConfig,
-    class: &str,
-    index: &HashMap<String, String>,
-) -> Vec<String> {
-    class_subjects(store, ns, class).into_iter().filter(|s| !index.contains_key(s)).collect()
-}
-
-fn class_subjects(store: &Store, ns: &NamespaceConfig, class: &str) -> Vec<String> {
-    let p = &ns.prefix;
+/// Subjects of every covered class, bucketed, minus session traffic.
+///
+/// ONE scan of the typed subjects rather than a query per class. Eighteen separate
+/// `?s a ops:<Class>` queries against a 13 MB store is the shape that put 11
+/// seconds into a `base doctor` run on a temp fixture; the migration and doctor
+/// both ask this question, and both ask it on the session-start path.
+///
+/// The transient filter is the shared one — adding a kind to
+/// `ontology::transient::TRANSIENT_KINDS` excludes it from the migration and from
+/// doctor's orphan count at the same time.
+fn covered_subjects(store: &Store, ns: &NamespaceConfig) -> HashMap<&'static str, Vec<String>> {
     let pfx = crate::crud::prefixes(ns);
     let no_transient = crate::ontology::transient::sparql_exclude(ns, "s");
     let q = format!(
-        "{pfx}\nSELECT DISTINCT ?s WHERE {{ GRAPH ?g {{ ?s a {p}:{class} .\n{no_transient}}} }}"
+        "{pfx}\nSELECT DISTINCT ?s ?t WHERE {{ GRAPH ?g {{ ?s a ?t .\n{no_transient}}} }}"
     );
+    let mut out: HashMap<&'static str, Vec<String>> = HashMap::new();
+    let Ok(QueryResults::Solutions(sols)) = store::query(store, &q) else { return out };
+    let want: HashMap<String, &'static str> =
+        COVERED.iter().map(|c| (format!("{}{}", ns.uri, c.class), c.class)).collect();
+    for row in sols.filter_map(|r| r.ok()) {
+        let (Some(Term::NamedNode(s)), Some(Term::NamedNode(t))) = (row.get("s"), row.get("t"))
+        else {
+            continue;
+        };
+        let Some(class) = want.get(t.as_str()) else { continue };
+        out.entry(class).or_default().push(s.as_str().to_string());
+    }
+    for subs in out.values_mut() {
+        subs.sort();
+        subs.dedup();
+    }
+    out
+}
+
+/// Subjects of one class, for the callers that want exactly one — `Project` paths
+/// and the domain inventory.
+fn class_subjects(store: &Store, ns: &NamespaceConfig, class: &str) -> Vec<String> {
+    let p = &ns.prefix;
+    let pfx = crate::crud::prefixes(ns);
+    let q = format!("{pfx}\nSELECT DISTINCT ?s WHERE {{ GRAPH ?g {{ ?s a {p}:{class} }} }}");
     let Ok(QueryResults::Solutions(sols)) = store::query(store, &q) else { return Vec::new() };
     let mut out: Vec<String> = sols
         .filter_map(|r| r.ok())

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,488 @@
+//! One-time, idempotent schema migration: every record carries a domain link.
+//!
+//! Chris's ruling, 2026-09-04: *"we need to make sure everything carries a domain
+//! (where relevant) with a catchall default where domain isn't necessary … I don't
+//! want people's base systems to break."* 4,051 of 5,099 typed workspace records
+//! are orphaned today (79.4%, hawk 2026-09-05), so a community named by domain
+//! would name itself after the 20% that happen to be notes and rules.
+//!
+//! ## Two rules this module exists to obey
+//!
+//! **The stamp is in the graph, and it lands in the same write as the data.**
+//! `write_back` is temp-plus-rename, so the stamp and the records it claims are
+//! either both on disk or neither is. A file sentinel beside `~/.base-gbl/` would
+//! be the cheaper mechanism and it lies after a `.bak` restore: the store goes back
+//! to its pre-migration shape while the file still says "migrated", and the
+//! migration then skips forever. After a restore the STORE is the only thing that
+//! knows. (G0 verdict A1, hawk F1.)
+//!
+//! **Stamp WITH the write, never before it.** `auto_compact_tiers` stamps its
+//! cooldown marker before compacting, and that is right there — compaction is
+//! lossless and idempotent, so a crash costs nothing. Here a crash halfway would
+//! leave a half-migrated store marked done, silently, forever. So the work is
+//! computed from the store every time ("which covered records still have no domain
+//! link"), and the stamp is a fast path, not a truth source. (G0 verdict A2, hawk F2.)
+//!
+//! ## Why this is safe to run against an installed base
+//!
+//! Expand-migrate-contract. 0.14.0 writes `hasDomain` beside the existing
+//! `relatedTo` and reads both (`domain::link`); N+1 stops writing the legacy
+//! triple; N+2 drops it. hawk C10 built v0.12.0 — 105 commits back — and ran it
+//! against a store carrying every artefact this migration writes: it stayed
+//! HEALTHY, analysed, recalled, and WROTE TWICE, and the artefacts survived. The
+//! reverse too. `store::load_graph` is a syntactic N-Quads parse with no schema
+//! check, and every read binds only the predicates it wants.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use oxigraph::model::{GraphNameRef, LiteralRef, NamedNodeRef, QuadRef, Term};
+use oxigraph::sparql::QueryResults;
+use oxigraph::store::Store;
+use serde::Serialize;
+
+use crate::changelog::Change;
+use crate::config::NamespaceConfig;
+use crate::domain::link;
+use crate::store::{self, GraphHealth};
+
+/// The schema this module migrates a store to. Written as the object of
+/// `<graph> ops:schemaVersion` inside the tier's own named graph.
+pub const SCHEMA_VERSION: &str = "domain-1";
+
+/// The catchall domain, for records where a domain is genuinely not relevant.
+/// Chris's ruling 1, 2026-09-06.
+pub const CATCHALL: &str = "unfiled";
+
+/// Where a record's domain comes from. One variant per family, so the set that
+/// lands in the catchall is NAMED here rather than being whatever was left over —
+/// which is the acceptance line, not a nicety.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum Source {
+    /// A domain is not a meaningful attribute of this record. Straight to
+    /// [`CATCHALL`].
+    Catchall,
+    /// Fixed domain for the whole family, assigned by the extension that ingests
+    /// it (ruling 3 covers the Lore\* family).
+    Fixed(&'static str),
+    /// Walk one link to a parent record and take the parent's domain; catchall if
+    /// the parent has none.
+    Parent(&'static str),
+    /// The document's own frontmatter, else the workspace's project domain, else
+    /// catchall (ruling 2).
+    Frontmatter,
+}
+
+/// One covered record class and where its domain comes from.
+///
+/// Everything the migration touches is in this table, and nothing else is touched.
+/// A class absent from it keeps whatever it has — `Domain` has no domain of its
+/// own, `Ping` is session traffic excluded from every read surface
+/// (`ontology::transient`), and `Note`/`Rule` are already 100% linked.
+pub struct Covered {
+    /// RDF class local name, e.g. `Document` in `ops:Document`.
+    pub class: &'static str,
+    pub source: Source,
+}
+
+/// The families, in the order the migration reports them.
+///
+/// Counts are hawk's measurement of Chris's live workspace tier, 2026-09-05, and
+/// are here so a reader can tell a table that shrank because the migration worked
+/// from one that shrank because a class stopped being covered.
+pub const COVERED: &[Covered] = &[
+    // 999 workspace + 141 global orphans — the largest single block.
+    Covered { class: "Document", source: Source::Frontmatter },
+    // 1,434 orphans across five classes, all Skyrim (ruling 3).
+    Covered { class: "LoreKnowledge", source: Source::Fixed("skyrim-companion") },
+    Covered { class: "LoreFact", source: Source::Fixed("skyrim-companion") },
+    Covered { class: "LoreRelationship", source: Source::Fixed("skyrim-companion") },
+    Covered { class: "LoreItem", source: Source::Fixed("skyrim-companion") },
+    Covered { class: "LoreBelief", source: Source::Fixed("skyrim-companion") },
+    // 1,241 orphans; every one hangs off a plan that hangs off a project.
+    Covered { class: "AcceptanceCriteria", source: Source::Parent("fromPlan") },
+    Covered { class: "AcceptanceCriteriaResult", source: Source::Parent("fromPlan") },
+    Covered { class: "FileChange", source: Source::Parent("fromPlan") },
+    Covered { class: "PaulSummary", source: Source::Parent("fromPlan") },
+    Covered { class: "PaulPlan", source: Source::Parent("fromProject") },
+    // 209 + 36 orphans; the project is in the filename convention.
+    Covered { class: "Handoff", source: Source::Parent("relatedTo") },
+    // 142 workspace orphans: 137 hang off a document, 5 are loose.
+    Covered { class: "Decision", source: Source::Parent("fromPlan") },
+    // 14 orphans; a code map belongs to the app it maps.
+    Covered { class: "CodeMap", source: Source::Parent("relatedTo") },
+    // Small tails. A task or project with no parent domain, a goal, a reminder:
+    // this IS the named catchall set, not a leftover.
+    Covered { class: "Task", source: Source::Parent("belongsTo") },
+    Covered { class: "Project", source: Source::Catchall },
+    Covered { class: "Goal", source: Source::Catchall },
+    Covered { class: "Reminder", source: Source::Catchall },
+];
+
+/// What one tier's migration did. Serialized by `base doctor --json`.
+#[derive(Debug, Default, Serialize)]
+pub struct Outcome {
+    pub path: String,
+    /// Already carried the stamp — nothing read, nothing written.
+    pub already_migrated: bool,
+    /// The graph was not healthy; nothing was written and nothing was stamped.
+    pub skipped_unhealthy: bool,
+    pub backup: Option<String>,
+    /// Records linked, by RDF class. Empty when the store had no orphans.
+    pub linked: BTreeMap<String, usize>,
+    /// How many of those landed in [`CATCHALL`].
+    pub catchall: usize,
+    /// True when the store now carries the stamp because THIS pass wrote it.
+    pub stamped: bool,
+}
+
+impl Outcome {
+    pub fn total_linked(&self) -> usize {
+        self.linked.values().sum()
+    }
+    /// Nothing happened and nothing needed to: the honest "no-op" test.
+    pub fn is_noop(&self) -> bool {
+        !self.stamped && self.total_linked() == 0
+    }
+}
+
+// ─── the stamp ───────────────────────────────────────────────────────────────
+
+/// The schema version a store claims, read from `<graph> ops:schemaVersion`.
+/// `None` for a store that has never been migrated — including a `.bak` restored
+/// from before the migration, which is the whole reason the stamp lives here.
+pub fn stamp_of(store: &Store, ns: &NamespaceConfig, graph_iri: &str) -> Option<String> {
+    let p = &ns.prefix;
+    let pfx = crate::crud::prefixes(ns);
+    let q = format!(
+        "{pfx}\nSELECT ?v WHERE {{ GRAPH <{graph_iri}> {{ <{graph_iri}> {p}:schemaVersion ?v }} }}"
+    );
+    let QueryResults::Solutions(sols) = store::query(store, &q).ok()? else { return None };
+    sols.filter_map(|r| r.ok())
+        .filter_map(|row| match row.get("v")? {
+            Term::Literal(l) => Some(l.value().to_string()),
+            _ => None,
+        })
+        .next()
+}
+
+// ─── the pass ────────────────────────────────────────────────────────────────
+
+/// Migrate one tier's graph file. Path-scoped and pure of the operator's
+/// environment, the `compact_tier` shape, so a test drives it against a copy.
+///
+/// `graph_iri` is the tier's own named graph — the stamp's subject and the graph
+/// every backfilled triple is written into.
+pub fn migrate_tier(path: &Path, graph_iri: &str, ns: &NamespaceConfig) -> Result<Outcome> {
+    let mut out = Outcome { path: path.display().to_string(), ..Default::default() };
+
+    // C1: `compact_tier` refuses an unhealthy graph and a migration that reuses
+    // this path inherits that. Defined behaviour, not silence: report it, write
+    // nothing, stamp nothing, so the next session tries again once repair has run.
+    if !matches!(store::graph_health(path), GraphHealth::Healthy) {
+        out.skipped_unhealthy = true;
+        return Ok(out);
+    }
+
+    let store = store::load_graph(path)?;
+
+    // Fast path. Not a truth source — the work below is recomputed from the store
+    // every time the stamp is absent, so a restored pre-migration backup migrates
+    // again and a restored post-migration backup is already correct.
+    if stamp_of(&store, ns, graph_iri).as_deref() == Some(SCHEMA_VERSION) {
+        out.already_migrated = true;
+        return Ok(out);
+    }
+
+    let plan = plan_backfill(&store, ns)?;
+
+    // C1: snapshot first, sharing the `BACKUP_KEEP = 10` pool with compact.
+    // Only once there is a write to protect — a pure re-stamp of an already-clean
+    // store should not evict a compact backup.
+    out.backup = Some(store::snapshot(path, "migrate")?.display().to_string());
+
+    apply(&store, ns, graph_iri, &plan, &mut out)?;
+    write_stamp(&store, ns, graph_iri)?;
+    out.stamped = true;
+
+    store::write_back(&store, path, Change::Op("migrate.domain-1"))
+        .context("migration write-back failed — the store is unchanged")?;
+
+    Ok(out)
+}
+
+/// Every tier under `cwd`, workspace then global, the `auto_compact_tiers` shape.
+/// Errors are per-tier: one unmigratable tier must not stop the other.
+pub fn migrate_tiers(cwd: &Path, ns: &NamespaceConfig) -> Vec<Outcome> {
+    tier_roots(cwd)
+        .into_iter()
+        .filter_map(|root| {
+            let path = root.join(".base").join("graph.nq");
+            if !path.exists() {
+                return None;
+            }
+            let iri = crate::crud::workspace_graph_iri(ns, &crate::crud::workspace_slug(&root));
+            migrate_tier(&path, &iri, ns).ok()
+        })
+        .filter(|o| !o.is_noop() || o.skipped_unhealthy)
+        .collect()
+}
+
+/// Workspace root (the dir holding `.base/`) then `~/.base-gbl`, de-duplicated.
+fn tier_roots(cwd: &Path) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(ws) = crate::config::find_workspace_base(cwd)
+        && let Some(root) = ws.parent()
+    {
+        roots.push(root.to_path_buf());
+    }
+    if let Some(home) = crate::home::home_root() {
+        let global = home.join(".base-gbl");
+        if !roots.contains(&global) {
+            roots.push(global);
+        }
+    }
+    roots
+}
+
+// ─── planning ────────────────────────────────────────────────────────────────
+
+/// One record that needs a domain link, and the domain it will get.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Assignment {
+    pub subject: String,
+    pub class: String,
+    pub domain_slug: String,
+}
+
+/// What is still unmigrated, computed from the store (G0 verdict A2). Never from
+/// the stamp, and never from a record count.
+pub fn plan_backfill(store: &Store, ns: &NamespaceConfig) -> Result<Vec<Assignment>> {
+    let known = existing_domains(store, ns)?;
+    let mut plan = Vec::new();
+    for cov in COVERED {
+        for subject in orphans_of(store, ns, cov.class)? {
+            let slug = resolve(store, ns, &subject, cov.source, &known);
+            plan.push(Assignment { subject, class: cov.class.to_string(), domain_slug: slug });
+        }
+    }
+    Ok(plan)
+}
+
+/// Subjects of `class` carrying no domain link in either era, minus session
+/// traffic. The transient filter is the shared one — adding a kind to
+/// `ontology::transient::TRANSIENT_KINDS` excludes it from the migration too.
+fn orphans_of(store: &Store, ns: &NamespaceConfig, class: &str) -> Result<Vec<String>> {
+    let p = &ns.prefix;
+    let pfx = crate::crud::prefixes(ns);
+    let no_link = link::no_domain_link(ns, "s");
+    let no_transient = crate::ontology::transient::sparql_exclude(ns, "s");
+    let q = format!(
+        "{pfx}\nSELECT DISTINCT ?s WHERE {{ GRAPH ?g {{\n\
+           ?s a {p}:{class} .\n\
+           {no_link}{no_transient}\
+         }} }}"
+    );
+    let QueryResults::Solutions(sols) = store::query(store, &q)? else { return Ok(Vec::new()) };
+    Ok(sols
+        .filter_map(|r| r.ok())
+        .filter_map(|row| match row.get("s")? {
+            Term::NamedNode(n) => Some(n.as_str().to_string()),
+            _ => None,
+        })
+        .collect())
+}
+
+/// Every `domain/` IRI that actually exists, as slugs. A backfill links only to a
+/// domain record that is already there (or to the catchall, created once) — the
+/// migration never invents a domain.
+fn existing_domains(store: &Store, ns: &NamespaceConfig) -> Result<std::collections::HashSet<String>> {
+    let p = &ns.prefix;
+    let pfx = crate::crud::prefixes(ns);
+    let q = format!("{pfx}\nSELECT DISTINCT ?d WHERE {{ GRAPH ?g {{ ?d a {p}:Domain }} }}");
+    let QueryResults::Solutions(sols) = store::query(store, &q)? else {
+        return Ok(Default::default());
+    };
+    let prefix = link::domain_iri_prefix(ns);
+    Ok(sols
+        .filter_map(|r| r.ok())
+        .filter_map(|row| match row.get("d")? {
+            Term::NamedNode(n) => n.as_str().strip_prefix(prefix.as_str()).map(str::to_string),
+            _ => None,
+        })
+        .collect())
+}
+
+/// The domain slug for one record. Falls back to [`CATCHALL`] whenever the source
+/// yields nothing or names a domain that does not exist — never invents one.
+fn resolve(
+    _store: &Store,
+    _ns: &NamespaceConfig,
+    _subject: &str,
+    source: Source,
+    known: &std::collections::HashSet<String>,
+) -> String {
+    let candidate = match source {
+        Source::Catchall => None,
+        // The family resolvers land with the backfill sources (build step 4).
+        // Until then every covered record resolves to the catchall, which is
+        // correct-but-coarse rather than wrong: a record in `unfiled` is still
+        // linked, still countable, and still moved by `base graph move`.
+        Source::Fixed(_) | Source::Parent(_) | Source::Frontmatter => None,
+    };
+    match candidate {
+        Some(slug) if known.contains(&slug) => slug,
+        _ => CATCHALL.to_string(),
+    }
+}
+
+// ─── applying ────────────────────────────────────────────────────────────────
+
+/// Insert the plan's links, plus the catchall domain record if anything needs it.
+/// In-memory only: nothing reaches disk until `write_back`.
+fn apply(
+    store: &Store,
+    ns: &NamespaceConfig,
+    graph_iri: &str,
+    plan: &[Assignment],
+    out: &mut Outcome,
+) -> Result<()> {
+    if plan.is_empty() {
+        return Ok(());
+    }
+    let graph = NamedNodeRef::new(graph_iri)?;
+    let has_domain = format!("{}{}", ns.uri, link::CANONICAL);
+    let has_domain = NamedNodeRef::new(&has_domain)?;
+
+    if plan.iter().any(|a| a.domain_slug == CATCHALL) {
+        ensure_catchall(store, ns, graph)?;
+    }
+
+    for a in plan {
+        let subject = NamedNodeRef::new(&a.subject)?;
+        let domain_iri = crate::crud::build_iri(ns, "domain", &a.domain_slug);
+        let object = NamedNodeRef::new(&domain_iri)?;
+        store.insert(QuadRef::new(subject, has_domain, object, GraphNameRef::NamedNode(graph)))?;
+        *out.linked.entry(a.class.clone()).or_default() += 1;
+        if a.domain_slug == CATCHALL {
+            out.catchall += 1;
+        }
+    }
+    Ok(())
+}
+
+/// Create the catchall domain once, with the same shape `domain sync` writes.
+fn ensure_catchall(store: &Store, ns: &NamespaceConfig, graph: NamedNodeRef<'_>) -> Result<()> {
+    let iri = crate::crud::build_iri(ns, "domain", CATCHALL);
+    let subject = NamedNodeRef::new(&iri)?;
+    let rdf_type = NamedNodeRef::new("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")?;
+    let class = format!("{}Domain", ns.uri);
+    let class = NamedNodeRef::new(&class)?;
+    let name_pred = format!("{}name", ns.uri);
+    let name_pred = NamedNodeRef::new(&name_pred)?;
+    let g = GraphNameRef::NamedNode(graph);
+    store.insert(QuadRef::new(subject, rdf_type, class, g))?;
+    store.insert(QuadRef::new(subject, name_pred, LiteralRef::new_simple_literal(CATCHALL), g))?;
+    Ok(())
+}
+
+/// The stamp, into the same in-memory store as the data — so `write_back`'s
+/// temp-plus-rename lands both or neither.
+fn write_stamp(store: &Store, ns: &NamespaceConfig, graph_iri: &str) -> Result<()> {
+    let graph = NamedNodeRef::new(graph_iri)?;
+    let pred = format!("{}schemaVersion", ns.uri);
+    let pred = NamedNodeRef::new(&pred)?;
+    // Replace any older stamp rather than accumulate one per version.
+    let existing: Vec<_> = store
+        .quads_for_pattern(Some(graph.into()), Some(pred), None, Some(GraphNameRef::NamedNode(graph)))
+        .filter_map(Result::ok)
+        .collect();
+    for q in existing {
+        store.remove(&q)?;
+    }
+    store.insert(QuadRef::new(
+        graph,
+        pred,
+        LiteralRef::new_simple_literal(SCHEMA_VERSION),
+        GraphNameRef::NamedNode(graph),
+    ))?;
+    Ok(())
+}
+
+// ─── reporting ───────────────────────────────────────────────────────────────
+
+/// One line per tier, for the session-start notice. Empty when nothing happened.
+pub fn format_outcomes(outcomes: &[Outcome]) -> String {
+    let mut s = String::new();
+    for o in outcomes {
+        if o.skipped_unhealthy {
+            s.push_str(&format!(
+                "base: domain migration skipped — {} is not healthy; run `base doctor --repair`\n",
+                o.path
+            ));
+            continue;
+        }
+        // A pass that only stamped says nothing. The operator did not ask for a
+        // migration and none of their data changed; a "0 records linked" line at
+        // every fresh install would be noise on the one hook that must stay quiet.
+        if o.total_linked() == 0 {
+            continue;
+        }
+        let by_kind: Vec<String> =
+            o.linked.iter().map(|(k, n)| format!("{k} {n}")).collect();
+        s.push_str(&format!(
+            "base: domain migration — {} record(s) linked ({}), {} to `{CATCHALL}`\n",
+            o.total_linked(),
+            if by_kind.is_empty() { "none".to_string() } else { by_kind.join(", ") },
+            o.catchall,
+        ));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_covered_class_is_named_once() {
+        let mut seen = std::collections::HashSet::new();
+        for c in COVERED {
+            assert!(seen.insert(c.class), "{} is listed twice", c.class);
+        }
+    }
+
+    #[test]
+    fn the_transient_kinds_are_never_covered() {
+        for t in crate::ontology::transient::TRANSIENT_KINDS.iter() {
+            assert!(
+                !COVERED.iter().any(|c| c.class == t.class),
+                "{} is session traffic — it must not be given a domain",
+                t.class
+            );
+        }
+    }
+
+    #[test]
+    fn domain_itself_is_never_covered() {
+        assert!(
+            !COVERED.iter().any(|c| c.class == "Domain"),
+            "a domain does not belong to a domain"
+        );
+    }
+
+    #[test]
+    fn the_catchall_set_is_named_not_leftover() {
+        let catchall: Vec<&str> = COVERED
+            .iter()
+            .filter(|c| c.source == Source::Catchall)
+            .map(|c| c.class)
+            .collect();
+        assert_eq!(
+            catchall,
+            vec!["Project", "Goal", "Reminder"],
+            "the acceptance line requires this set to be explicit; change it here, deliberately"
+        );
+    }
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -215,6 +215,9 @@ pub struct Outcome {
     pub catchall: usize,
     /// True when the store now carries the stamp because THIS pass wrote it.
     pub stamped: bool,
+    /// True when this was a delta pass over an already-stamped tier, rather than
+    /// the first migration. A delta takes no snapshot.
+    pub delta: bool,
 }
 
 impl Outcome {
@@ -318,7 +321,14 @@ pub fn migrate_tier(
     // pre-migration backup migrates again and a restored post-migration backup is
     // already correct. `Trigger::Manual` never takes it: an operator who typed the
     // command gets the real answer, not the stamp's.
-    if stamped && trigger == Trigger::SessionStart {
+    //
+    // "Every record carries a domain" was false one write later (kite F7): `base
+    // sync` and the PAUL ingest manufacture unlinked records every session, and a
+    // stamped tier used to skip them forever. So a stamped tier still re-plans —
+    // but only when the store has actually changed since the last time this pass
+    // looked, which is ONE `stat` against a marker file rather than a 13.4 MB
+    // parse. A session that wrote nothing costs nothing.
+    if stamped && trigger == Trigger::SessionStart && !changed_since_last_delta(path) {
         out.already_migrated = true;
         return Ok(out);
     }
@@ -332,8 +342,15 @@ pub fn migrate_tier(
     // 13.4 MB store to change nothing.
     if plan.is_empty() && stamped {
         out.already_migrated = true;
+        stamp_delta_marker(path);
         return Ok(out);
     }
+    // A delta pass on an already-stamped tier: additive quads onto a store that is
+    // already at this schema. No snapshot — `write_back` is temp-plus-rename, the
+    // pass only ever ADDS `hasDomain` links, and the ten-slot backup pool belongs
+    // to the operations that can lose something (vole's amendment to F7). The
+    // first migration still snapshots, below.
+    let is_delta = stamped;
 
     // C1: snapshot first, sharing the `BACKUP_KEEP = 10` pool with compact — but
     // only when there is data to protect. A pass that writes nothing but the stamp
@@ -341,17 +358,50 @@ pub fn migrate_tier(
     // comment, `docs/graph-durability.md` and the outcome's own `backup: None`
     // have always claimed and what the code did not do (kite, PR #50).
     if !plan.is_empty() {
-        out.backup = Some(store::snapshot(path, "migrate")?.display().to_string());
+        if !is_delta {
+            out.backup = Some(store::snapshot(path, "migrate")?.display().to_string());
+        }
         apply(&store, ns, graph_iri, &plan, &mut out)?;
     }
 
     write_stamp(&store, ns, graph_iri)?;
     out.stamped = true;
+    out.delta = is_delta;
 
-    store::write_back(&store, path, Change::Op("migrate.domain-1"))
+    let label = if is_delta { "migrate.domain-1.delta" } else { "migrate.domain-1" };
+    store::write_back(&store, path, Change::Op(label))
         .context("migration write-back failed — the store is unchanged")?;
+    stamp_delta_marker(path);
 
     Ok(out)
+}
+
+/// Has anything written this tier since the delta pass last looked?
+///
+/// One `stat` per tier, the `auto_compact_tiers` marker shape, and deliberately
+/// mtime-versus-mtime rather than a time cooldown: a cooldown would make the
+/// promise "records are filed at the next session start" false for however long
+/// it ran, and would still pay the parse on a tier nobody touched. This skips
+/// exactly the sessions where there is provably nothing to find.
+///
+/// Missing marker means never run, so: yes. Unreadable metadata means yes — the
+/// pass is idempotent, and doing it needlessly is cheaper than not doing it.
+fn changed_since_last_delta(path: &Path) -> bool {
+    let marker = path.with_file_name(".last-domain-delta");
+    let (Ok(g), Ok(m)) = (std::fs::metadata(path), std::fs::metadata(&marker)) else {
+        return true;
+    };
+    match (g.modified(), m.modified()) {
+        (Ok(gt), Ok(mt)) => gt > mt,
+        _ => true,
+    }
+}
+
+/// Record that the delta pass has seen the store in its current shape.
+/// Best-effort: a marker that cannot be written costs one needless pass next
+/// session, which is the safe direction to fail.
+fn stamp_delta_marker(path: &Path) {
+    let _ = std::fs::write(path.with_file_name(".last-domain-delta"), crate::crud::now_iso());
 }
 
 /// Every tier under `cwd`, workspace then global, the `auto_compact_tiers` shape.
@@ -912,6 +962,14 @@ pub fn format_outcomes(outcomes: &[Outcome]) -> String {
         }
         let arms: Vec<String> = o.by_arm.iter().map(|(k, n)| format!("{k} {n}")).collect();
         let kinds: Vec<String> = o.linked.iter().map(|(k, n)| format!("{k} {n}")).collect();
+        if o.delta {
+            s.push_str(&format!(
+                "base: domain — {} new record(s) linked since the last session.\n  by source: {}\n",
+                o.total_linked(),
+                arms.join(", "),
+            ));
+            continue;
+        }
         s.push_str(&format!(
             "base: domain migration — {} record(s) now carry a domain.\n  by source: {}\n  by kind:   {}\n",
             o.total_linked(),

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -739,8 +739,18 @@ fn apply(
 }
 
 /// Create a domain record if it is not already there, with the same shape
-/// `domain sync` writes. Idempotent by construction: the store is a set, so a
-/// re-insert of an existing quad changes nothing.
+/// `domain sync` writes.
+///
+/// The `rdf:type` quad is written unconditionally — the store is a set, so a
+/// re-insert changes nothing, and it types a domain that until now existed only
+/// as the object of an edge.
+///
+/// `ops:name` is NOT. A domain's declared name need not equal its slug:
+/// `domains.toml` declares `content` and `development` with names that slugify to
+/// those but are not byte-equal, and writing the slug unconditionally left both
+/// records carrying TWO `ops:name` literals on Chris's real store. A record with
+/// two names is a record every reader answers about differently depending on
+/// which one it binds. So: only name a domain this migration actually created.
 fn ensure_domain(store: &Store, ns: &NamespaceConfig, graph: NamedNodeRef<'_>, slug: &str) -> Result<()> {
     let iri = crate::crud::build_iri(ns, "domain", slug);
     let subject = NamedNodeRef::new(&iri)?;
@@ -751,7 +761,16 @@ fn ensure_domain(store: &Store, ns: &NamespaceConfig, graph: NamedNodeRef<'_>, s
     let name_pred = NamedNodeRef::new(&name_pred)?;
     let g = GraphNameRef::NamedNode(graph);
     store.insert(QuadRef::new(subject, rdf_type, class, g))?;
-    store.insert(QuadRef::new(subject, name_pred, LiteralRef::new_simple_literal(slug), g))?;
+
+    // Any graph, not just this tier's: a domain synced into the global graph is
+    // still that domain, and naming it twice is the defect either way.
+    let already_named = store
+        .quads_for_pattern(Some(subject.into()), Some(name_pred), None, None)
+        .next()
+        .is_some();
+    if !already_named {
+        store.insert(QuadRef::new(subject, name_pred, LiteralRef::new_simple_literal(slug), g))?;
+    }
     Ok(())
 }
 

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -4,6 +4,8 @@ use oxigraph::store::Store;
 
 use crate::config::NamespaceConfig;
 
+pub mod transient;
+
 /// The ops: vocabulary template, embedded at compile time.
 /// Namespace prefix and URI are replaced at runtime from BaseConfig.
 const OPS_TTL: &str = include_str!("ops.ttl");

--- a/src/ontology/transient.rs
+++ b/src/ontology/transient.rs
@@ -1,0 +1,139 @@
+//! Record kinds that are session traffic, not knowledge — excluded from every
+//! read surface by ONE list.
+//!
+//! Chris's ruling 4 (2026-09-06): relay pings are *"excluded from analyze AND from
+//! every other read surface by ONE shared rule … make sure the tool as a whole is
+//! built to exclude pings in the same way"*. Not per-command. 5,012 of the global
+//! tier's 5,248 typed records are relay `Ping`s (hawk, 2026-09-05); left in, they
+//! are the tier's defining mass and every community, count and neighbourhood is
+//! about them rather than about the operator's knowledge.
+//!
+//! Adding a kind to [`TRANSIENT_KINDS`] excludes it from all four readers at once:
+//!
+//! | reader | what it serves |
+//! |---|---|
+//! | `graph_query::load_graph` | every `base graph` command (query/analyze/get-node/neighbors/path) |
+//! | `domain::query::query_domain_from_graph` | prompt-time domain injection |
+//! | `crud::note` recall reads | `base recall`, `base learn --list`, hook memory injection |
+//! | `dashboard::api` nodes/edges | the Command Center graph view |
+//!
+//! No command carries its own filter. `tests/transient_kinds_test.rs` asserts each
+//! reader honours the list with a fixture Ping.
+
+use crate::config::NamespaceConfig;
+
+/// One transient record kind, named both ways a reader can see it.
+///
+/// A relay ping is written as `<ns>ping/<slug>` typed `<ns>Ping`
+/// (`relay/task_inbox.rs`). A SPARQL reader that has the subject bound filters on
+/// the RDF class; an in-memory reader holding only an IRI filters on the kind
+/// segment. Both discriminators are already in the data — neither is inferred.
+pub struct TransientKind {
+    /// Local name of the RDF class, e.g. `Ping` in `ops:Ping`.
+    pub class: &'static str,
+    /// IRI kind segment, e.g. `ping` in `…#ping/lark-1757`.
+    pub iri_kind: &'static str,
+}
+
+/// The list. One place; four readers.
+pub const TRANSIENT_KINDS: [TransientKind; 1] = [TransientKind { class: "Ping", iri_kind: "ping" }];
+
+/// SPARQL that removes every transient kind for an already-bound subject variable.
+///
+/// `var` is the variable name without its `?`. Returns `""` when the list is empty,
+/// so a caller can interpolate it unconditionally.
+///
+/// `FILTER NOT EXISTS` rather than a negated `?type` comparison because most reads
+/// never bind the subject's class — requiring one would turn an OPTIONAL match into
+/// a mandatory one and silently drop untyped records.
+pub fn sparql_exclude(ns: &NamespaceConfig, var: &str) -> String {
+    let p = &ns.prefix;
+    TRANSIENT_KINDS
+        .iter()
+        .map(|k| format!("FILTER NOT EXISTS {{ ?{var} a {p}:{} }}\n", k.class))
+        .collect()
+}
+
+/// Is this IRI a transient record? Matches the `{ns.uri}{kind}/` prefix that
+/// `crud::build_iri` writes, so it cannot be fooled by a slug containing "ping".
+///
+/// Accepts an IRI with or without angle brackets — `graph_query` carries them,
+/// `dashboard` does not.
+pub fn is_transient_iri(ns: &NamespaceConfig, iri: &str) -> bool {
+    let bare = iri.strip_prefix('<').unwrap_or(iri);
+    let bare = bare.strip_suffix('>').unwrap_or(bare);
+    let Some(loc) = bare.strip_prefix(ns.uri.as_str()) else { return false };
+    let Some((kind, slug)) = loc.split_once('/') else { return false };
+    !slug.is_empty() && TRANSIENT_KINDS.iter().any(|k| k.iri_kind == kind)
+}
+
+/// Is this RDF class local name a transient kind? Takes the short form
+/// (`Ping`) or a full IRI (`http://…#Ping`).
+pub fn is_transient_class(class: &str) -> bool {
+    let local = class
+        .rsplit_once('#')
+        .or_else(|| class.rsplit_once('/'))
+        .or_else(|| class.rsplit_once(':'))
+        .map(|(_, s)| s)
+        .unwrap_or(class);
+    TRANSIENT_KINDS.iter().any(|k| k.class == local)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ns() -> NamespaceConfig {
+        NamespaceConfig::default()
+    }
+
+    #[test]
+    fn ping_iri_is_transient_note_iri_is_not() {
+        let ns = ns();
+        assert!(is_transient_iri(&ns, "http://ops-sys.local/ontology#ping/lark-booted"));
+        assert!(is_transient_iri(&ns, "<http://ops-sys.local/ontology#ping/lark-booted>"));
+        assert!(!is_transient_iri(&ns, "http://ops-sys.local/ontology#note/ping-latency-is-high"));
+        assert!(!is_transient_iri(&ns, "http://ops-sys.local/ontology#domain/base"));
+    }
+
+    #[test]
+    fn a_slug_containing_ping_is_not_transient() {
+        // The discriminator is the kind segment, never a substring of the IRI.
+        assert!(!is_transient_iri(&ns(), "http://ops-sys.local/ontology#document/ping-hub-notes"));
+    }
+
+    #[test]
+    fn foreign_namespace_is_never_transient() {
+        assert!(!is_transient_iri(&ns(), "http://example.com/other#ping/whatever"));
+    }
+
+    #[test]
+    fn class_matches_short_and_full_form() {
+        assert!(is_transient_class("Ping"));
+        assert!(is_transient_class("http://ops-sys.local/ontology#Ping"));
+        assert!(is_transient_class("ops:Ping"));
+        assert!(!is_transient_class("Note"));
+        assert!(!is_transient_class("http://ops-sys.local/ontology#Note"));
+    }
+
+    #[test]
+    fn sparql_exclude_names_every_kind_in_the_list() {
+        let f = sparql_exclude(&ns(), "n");
+        for k in TRANSIENT_KINDS.iter() {
+            assert!(
+                f.contains(&format!("?n a ops:{}", k.class)),
+                "filter must exclude {} — got {f}",
+                k.class
+            );
+        }
+        assert!(f.starts_with("FILTER NOT EXISTS"));
+    }
+
+    #[test]
+    fn custom_namespace_is_honoured_both_ways() {
+        let ns = NamespaceConfig { prefix: "mybase".into(), uri: "http://example.com/base#".into() };
+        assert!(is_transient_iri(&ns, "http://example.com/base#ping/x"));
+        assert!(!is_transient_iri(&ns, "http://ops-sys.local/ontology#ping/x"));
+        assert!(sparql_exclude(&ns, "s").contains("?s a mybase:Ping"));
+    }
+}

--- a/tests/analyze_catchall_test.rs
+++ b/tests/analyze_catchall_test.rs
@@ -1,0 +1,109 @@
+//! `base graph analyze` never presents the catchall domain as a core abstraction or as a
+//! community's name (kite F22, vole 2026-09-06).
+//!
+//! After the domain backfill every record no source could file points at `domain/unfiled`,
+//! so on a real store it is the busiest node in the graph by construction: 1,511 edges on
+//! the first migrated copy of Chris's workspace, the #2 god node behind `skyrim-companion`.
+//! A hub that means "nobody filed this" is not an abstraction the operator holds, and a
+//! community named after it describes the pile rather than the subject.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use base::config::{BaseConfig, NamespaceConfig};
+use base::crud;
+use base::graph_analyze::{community_sample, rank_god_nodes};
+use base::graph_query::load_graph;
+use base::migrate::CATCHALL;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+fn workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let base_dir = tmp.path().join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    std::fs::write(base_dir.join("graph.nq"), "").unwrap();
+    std::fs::write(
+        base_dir.join("base.toml"),
+        "[namespace]\nprefix = \"ops\"\nuri = \"http://ops-sys.local/ontology#\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        base_dir.join("domains.toml"),
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = [\"probe\"]\nrules = [\"r\"]\n",
+    )
+    .unwrap();
+    let config = BaseConfig::load(tmp.path());
+    base::domain::sync::sync_domains_to_graph(&config, tmp.path(), None).unwrap();
+    tmp
+}
+
+fn insert(cwd: &Path, triples: &str) {
+    let g = crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd));
+    crud::load_and_mutate(cwd, &ns(), &format!("INSERT DATA {{ GRAPH <{g}> {{\n{triples}\n}} }}")).unwrap();
+}
+
+/// The shape the migration leaves: a typed, named catchall with many records pointing at
+/// it, and a real domain with fewer.
+fn plant_migrated_shape(cwd: &Path) {
+    let unfiled = crud::build_iri(&ns(), "domain", CATCHALL);
+    let probe = crud::build_iri(&ns(), "domain", "probe");
+    insert(cwd, &format!("<{unfiled}> rdf:type ops:Domain ; ops:name \"{CATCHALL}\" .\n"));
+    for n in 0..6 {
+        let d = crud::build_iri(&ns(), "document", &format!("loose-{n}"));
+        insert(cwd, &format!("<{d}> rdf:type ops:Document ; ops:name \"loose {n}\" ; ops:hasDomain <{unfiled}> .\n"));
+    }
+    for n in 0..2 {
+        let d = crud::build_iri(&ns(), "document", &format!("filed-{n}"));
+        insert(cwd, &format!("<{d}> rdf:type ops:Document ; ops:name \"filed {n}\" ; ops:hasDomain <{probe}> .\n"));
+    }
+}
+
+#[test]
+fn the_catchall_is_never_a_god_node_however_busy_it_is() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_migrated_shape(cwd);
+
+    let (nodes, adj) = load_graph(cwd, &ns(), false).unwrap();
+    let degree: HashMap<&String, usize> =
+        nodes.keys().map(|id| (id, adj.get(id).map(|v| v.len()).unwrap_or(0))).collect();
+    let unfiled_key = format!("<{}>", crud::build_iri(&ns(), "domain", CATCHALL));
+    assert!(
+        degree.get(&unfiled_key).copied().unwrap_or(0) >= 6,
+        "the fixture must make the catchall the busiest node, or the test proves nothing: {degree:?}"
+    );
+
+    let ranked = rank_god_nodes(&ns(), &nodes, &degree);
+    assert!(
+        !ranked.iter().any(|(id, _)| id == &unfiled_key),
+        "the catchall ranked as a god node: {ranked:?}"
+    );
+    // The control: a real domain still ranks, and the order is still by degree.
+    let probe_key = format!("<{}>", crud::build_iri(&ns(), "domain", "probe"));
+    assert!(ranked.iter().any(|(id, _)| id == &probe_key), "a real domain must still rank: {ranked:?}");
+    assert!(ranked.windows(2).all(|w| w[0].1 >= w[1].1), "highest degree first: {ranked:?}");
+}
+
+#[test]
+fn a_community_is_never_named_after_the_catchall() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_migrated_shape(cwd);
+
+    let (nodes, _adj) = load_graph(cwd, &ns(), false).unwrap();
+    let members: Vec<&String> = nodes.keys().collect();
+    let sample = community_sample(&ns(), &nodes, &members);
+    assert!(!sample.is_empty(), "the sample must name something");
+    assert!(sample.len() <= 5, "at most five labels: {sample:?}");
+    assert!(
+        !sample.iter().any(|l| l == CATCHALL),
+        "the catchall named a community: {sample:?}"
+    );
+    // Sorted, so the same community carries the same name on every run.
+    let mut sorted = sample.clone();
+    sorted.sort();
+    assert_eq!(sample, sorted);
+}

--- a/tests/creation_domain_link_test.rs
+++ b/tests/creation_domain_link_test.rs
@@ -1,0 +1,273 @@
+//! A covered record takes its domain at CREATION when its parent already knows it.
+//!
+//! kite F7b, vole's ruling (2026-09-06): "every record carries a domain" must stay true
+//! between session starts, not only after the next one. The session-start delta pass
+//! (`migrate.rs`) still files whatever arrives without a link; these paths simply do not
+//! make it wait.
+//!
+//! Task and Milestone take their project's domain. A Handoff (and a fork) takes the
+//! domain of the project it names. An extension ingest source may declare a `domain`
+//! and every record it writes carries it (ruling 3, G0 verdict A3). A parent with no
+//! domain links nothing at creation, and the manual migration then files the record
+//! as the catchall, so the two owners of "where does the domain come from" never
+//! disagree.
+
+use std::path::Path;
+
+use base::config::{BaseConfig, NamespaceConfig};
+use base::crud;
+use base::extension::ingest::ingest_extension;
+use base::extension::{ExtensionDef, ExtensionHooks, IngestSource, SessionStartHook};
+use base::migrate;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+fn workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let base_dir = tmp.path().join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    std::fs::write(base_dir.join("graph.nq"), "").unwrap();
+    std::fs::write(
+        base_dir.join("base.toml"),
+        "[namespace]\nprefix = \"ops\"\nuri = \"http://ops-sys.local/ontology#\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        base_dir.join("domains.toml"),
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = [\"probe\"]\nrules = [\"r\"]\n",
+    )
+    .unwrap();
+    let config = BaseConfig::load(tmp.path());
+    base::domain::sync::sync_domains_to_graph(&config, tmp.path(), None).unwrap();
+    tmp
+}
+
+fn graph_iri(cwd: &Path) -> String {
+    crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd))
+}
+
+fn insert(cwd: &Path, triples: &str) {
+    let sparql = format!("INSERT DATA {{ GRAPH <{}> {{\n{triples}\n}} }}", graph_iri(cwd));
+    crud::load_and_mutate(cwd, &ns(), &sparql).unwrap();
+}
+
+/// A project, with or without a domain, as `base project add` leaves one.
+fn plant_project(cwd: &Path, slug: &str, domain: Option<&str>) -> String {
+    let iri = crud::build_iri(&ns(), "project", slug);
+    let link = domain
+        .map(|d| format!("  ops:hasDomain <{}> ;\n", crud::build_iri(&ns(), "domain", d)))
+        .unwrap_or_default();
+    insert(cwd, &format!("<{iri}> rdf:type ops:Project ;\n{link}  ops:name \"{slug}\" .\n"));
+    iri
+}
+
+/// The domain slugs a record carries under `hasDomain`, sorted.
+fn domains_of(cwd: &Path, iri: &str) -> Vec<String> {
+    let q = format!("SELECT ?d WHERE {{ GRAPH ?g {{ <{iri}> ops:hasDomain ?d }} }}");
+    let oxigraph::sparql::QueryResults::Solutions(sols) =
+        crud::load_and_query(cwd, &ns(), &q).unwrap()
+    else {
+        return Vec::new();
+    };
+    let mut v: Vec<String> = sols
+        .filter_map(|r| r.ok())
+        .filter_map(|row| match row.get("d")? {
+            oxigraph::model::Term::NamedNode(n) => {
+                n.as_str().rsplit_once("domain/").map(|(_, s)| s.to_string())
+            }
+            _ => None,
+        })
+        .collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn a_task_takes_its_projects_domain_at_creation() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "kit", Some("probe"));
+
+    let slug = crud::task::add(cwd, &ns(), "kit", "write the brief", None, None).unwrap();
+    let task = crud::build_iri(&ns(), "task", &slug);
+    assert_eq!(domains_of(cwd, &task), vec!["probe".to_string()], "linked in the same write");
+
+    // Nothing left for the migration to do about it.
+    let out = migrate::migrate_tier(
+        &cwd.join(".base").join("graph.nq"),
+        &graph_iri(cwd),
+        &ns(),
+        migrate::Trigger::Manual,
+    )
+    .unwrap();
+    assert_eq!(out.linked.get("Task"), None, "already linked, not re-filed: {out:?}");
+}
+
+#[test]
+fn a_milestone_takes_its_projects_domain_at_creation() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "kit", Some("probe"));
+
+    let slug = crud::milestone::add(cwd, &ns(), "kit", "phase one", None).unwrap();
+    let ms = crud::build_iri(&ns(), "milestone", &slug);
+    assert_eq!(domains_of(cwd, &ms), vec!["probe".to_string()]);
+}
+
+#[test]
+fn a_handoff_and_a_fork_take_the_domain_of_the_project_they_name() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "kit", Some("probe"));
+
+    let h = crud::handoff::create(cwd, &ns(), "kit", "docs/2026-09-06-kit-handoff.md", None).unwrap();
+    let f = crud::handoff::create_fork(cwd, &ns(), "kit", "docs/kit-side-quest.md", None).unwrap();
+    for slug in [h, f] {
+        let iri = crud::build_iri(&ns(), "handoff", &slug);
+        assert_eq!(domains_of(cwd, &iri), vec!["probe".to_string()], "{slug}");
+    }
+}
+
+#[test]
+fn a_parent_with_no_domain_links_nothing_and_the_migration_files_the_record() {
+    // Two owners of "where does the domain come from" must not disagree: creation
+    // writes a link only when the parent has one, and the catchall stays the
+    // migration's decision alone.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "loose", None);
+
+    let slug = crud::task::add(cwd, &ns(), "loose", "an orphan task", None, None).unwrap();
+    let task = crud::build_iri(&ns(), "task", &slug);
+    assert!(domains_of(cwd, &task).is_empty(), "no domain to inherit, so no link yet");
+
+    let out = migrate::migrate_tier(
+        &cwd.join(".base").join("graph.nq"),
+        &graph_iri(cwd),
+        &ns(),
+        migrate::Trigger::Manual,
+    )
+    .unwrap();
+    assert_eq!(out.linked.get("Task"), Some(&1), "{out:?}");
+    assert_eq!(domains_of(cwd, &task), vec![migrate::CATCHALL.to_string()]);
+}
+
+#[test]
+fn a_task_is_linked_exactly_once_even_though_both_paths_could_link_it() {
+    // Creation links it; a later migration must see the link (either predicate,
+    // `link::domain_index`) and not add a second one.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "kit", Some("probe"));
+    let slug = crud::task::add(cwd, &ns(), "kit", "once", None, None).unwrap();
+    let task = crud::build_iri(&ns(), "task", &slug);
+
+    migrate::migrate_tier(
+        &cwd.join(".base").join("graph.nq"),
+        &graph_iri(cwd),
+        &ns(),
+        migrate::Trigger::Manual,
+    )
+    .unwrap();
+    let raw = std::fs::read_to_string(cwd.join(".base").join("graph.nq")).unwrap();
+    let marker = format!("<{task}> <http://ops-sys.local/ontology#hasDomain>");
+    assert_eq!(raw.matches(&marker).count(), 1, "one link, not two");
+}
+
+#[test]
+fn an_ingest_source_that_declares_a_domain_files_every_record_under_it() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let state_dir = cwd.join(".lore");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::write(
+        state_dir.join("facts.json"),
+        r#"[{"id": "riverwood-mill", "text": "the mill is Gerdur's"}, {"id": "hod", "text": "Hod runs the mill"}]"#,
+    )
+    .unwrap();
+
+    let ext = ExtensionDef {
+        name: "lore".into(),
+        version: "0.1.0".into(),
+        description: "world model".into(),
+        framework_dir: None,
+        state_dir: Some(".lore".into()),
+        hooks: Some(ExtensionHooks {
+            session_start: Some(SessionStartHook {
+                queries: vec![],
+                ingest: vec![IngestSource {
+                    file: "facts.json".into(),
+                    entity: "LoreFact".into(),
+                    strategy: "upsert".into(),
+                    domain: Some("skyrim-companion".into()),
+                }],
+                inject: None,
+            }),
+            user_prompt: None,
+            pre_tool: None,
+            post_tool: None,
+        }),
+        commands: vec![],
+        dist: None,
+        source_path: None,
+    };
+    let config = BaseConfig::load(cwd);
+    let stats = ingest_extension(&ext, cwd, &config).unwrap();
+    assert_eq!(stats.entities, 2);
+
+    for id in ["riverwood-mill", "hod"] {
+        let iri = crud::build_iri(&ns(), "ext/lore/LoreFact", id);
+        assert_eq!(domains_of(cwd, &iri), vec!["skyrim-companion".to_string()], "{id}");
+    }
+}
+
+#[test]
+fn an_ingest_source_with_no_domain_writes_none_and_the_migration_files_it() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let state_dir = cwd.join(".lore");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::write(state_dir.join("facts.json"), r#"[{"id": "one", "text": "a fact"}]"#).unwrap();
+
+    let ext = ExtensionDef {
+        name: "lore".into(),
+        version: "0.1.0".into(),
+        description: "world model".into(),
+        framework_dir: None,
+        state_dir: Some(".lore".into()),
+        hooks: Some(ExtensionHooks {
+            session_start: Some(SessionStartHook {
+                queries: vec![],
+                ingest: vec![IngestSource {
+                    file: "facts.json".into(),
+                    entity: "LoreFact".into(),
+                    strategy: "upsert".into(),
+                    domain: None,
+                }],
+                inject: None,
+            }),
+            user_prompt: None,
+            pre_tool: None,
+            post_tool: None,
+        }),
+        commands: vec![],
+        dist: None,
+        source_path: None,
+    };
+    let config = BaseConfig::load(cwd);
+    ingest_extension(&ext, cwd, &config).unwrap();
+    let iri = crud::build_iri(&ns(), "ext/lore/LoreFact", "one");
+    assert!(domains_of(cwd, &iri).is_empty(), "no declaration, no link at creation");
+
+    let out = migrate::migrate_tier(
+        &cwd.join(".base").join("graph.nq"),
+        &graph_iri(cwd),
+        &ns(),
+        migrate::Trigger::Manual,
+    )
+    .unwrap();
+    assert_eq!(out.by_arm.get("fixed"), Some(&1), "ruling 3's fixed arm files it: {out:?}");
+    assert_eq!(domains_of(cwd, &iri), vec!["skyrim-companion".to_string()]);
+}

--- a/tests/doctor_schema_test.rs
+++ b/tests/doctor_schema_test.rs
@@ -46,7 +46,8 @@ fn insert(cwd: &Path, triples: &str) {
 
 fn migrate(cwd: &Path) -> base::migrate::Outcome {
     let g = crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd));
-    base::migrate::migrate_tier(&graph_path(cwd), &g, &ns()).unwrap()
+    base::migrate::migrate_tier(&graph_path(cwd), &g, &ns(), base::migrate::Trigger::SessionStart)
+        .unwrap()
 }
 
 #[test]

--- a/tests/doctor_schema_test.rs
+++ b/tests/doctor_schema_test.rs
@@ -1,0 +1,155 @@
+//! `base doctor` states the domain schema, always.
+//!
+//! C4: a migration that never ran must not look the same as one that ran and
+//! found nothing. Both cases are quiet at session start by design — the hook says
+//! nothing when it links nothing — so doctor is the only surface where "this store
+//! has not been migrated" is visible at all.
+
+use std::path::Path;
+
+use base::config::{BaseConfig, NamespaceConfig};
+use base::crud;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+fn workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let base_dir = tmp.path().join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    std::fs::write(base_dir.join("graph.nq"), "").unwrap();
+    std::fs::write(
+        base_dir.join("base.toml"),
+        "[namespace]\nprefix = \"ops\"\nuri = \"http://ops-sys.local/ontology#\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        base_dir.join("domains.toml"),
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = []\nrules = [\"r\"]\n",
+    )
+    .unwrap();
+    let config = BaseConfig::load(tmp.path());
+    base::domain::sync::sync_domains_to_graph(&config, tmp.path(), None).unwrap();
+    tmp
+}
+
+fn graph_path(cwd: &Path) -> std::path::PathBuf {
+    cwd.join(".base").join("graph.nq")
+}
+
+fn insert(cwd: &Path, triples: &str) {
+    let g = crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd));
+    crud::load_and_mutate(cwd, &ns(), &format!("INSERT DATA {{ GRAPH <{g}> {{\n{triples}\n}} }}"))
+        .unwrap();
+}
+
+fn migrate(cwd: &Path) -> base::migrate::Outcome {
+    let g = crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd));
+    base::migrate::migrate_tier(&graph_path(cwd), &g, &ns()).unwrap()
+}
+
+#[test]
+fn an_unmigrated_tier_says_so_and_counts_its_orphans() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    for n in 0..3 {
+        let iri = crud::build_iri(&ns(), "goal", &format!("g{n}"));
+        insert(cwd, &format!("<{iri}> rdf:type ops:Goal ; ops:name \"g{n}\" .\n"));
+    }
+    insert(
+        cwd,
+        "<http://ops-sys.local/ontology#ext/lore/LoreFact/1> rdf:type ops:LoreFact .\n",
+    );
+
+    let r = base::doctor::diagnose_tier("workspace", &graph_path(cwd));
+    assert_eq!(r.status, "healthy");
+    assert_eq!(r.schema_version, None, "never migrated");
+    assert_eq!(
+        r.domain_orphans,
+        vec![("Goal".to_string(), 3), ("LoreFact".to_string(), 1)],
+        "highest first, then alphabetical — a stable order to diff between runs"
+    );
+
+    let report = base::doctor::DoctorReport {
+        tiers: vec![r],
+        healthy: true,
+        warnings: vec![],
+        config_errors: vec![],
+    };
+    let human = base::doctor::format_human(&report);
+    assert!(human.contains("schema: not migrated"), "{human}");
+    assert!(human.contains("without a domain: 4 record(s)"), "{human}");
+    assert!(human.contains("Goal=3"), "{human}");
+}
+
+#[test]
+fn a_migrated_tier_reports_its_schema_version_and_no_orphans() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let iri = crud::build_iri(&ns(), "goal", "g0");
+    insert(cwd, &format!("<{iri}> rdf:type ops:Goal ; ops:name \"g0\" .\n"));
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 1);
+
+    let r = base::doctor::diagnose_tier("workspace", &graph_path(cwd));
+    assert_eq!(r.schema_version.as_deref(), Some(base::migrate::SCHEMA_VERSION));
+    assert!(r.domain_orphans.is_empty(), "{:?}", r.domain_orphans);
+
+    let report = base::doctor::DoctorReport {
+        tiers: vec![r],
+        healthy: true,
+        warnings: vec![],
+        config_errors: vec![],
+    };
+    let human = base::doctor::format_human(&report);
+    assert!(human.contains("schema: domain-1"), "{human}");
+    assert!(!human.contains("without a domain"), "nothing to report: {human}");
+}
+
+#[test]
+fn drift_after_a_migration_is_visible_and_is_not_a_fault() {
+    // `base sync` writes a Document with no domain, so the orphan count climbs
+    // again after a migration. That is drift, not damage, and the operator has to
+    // be able to see it — the stamp alone would say "done" forever.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    migrate(cwd);
+    let iri = crud::build_iri(&ns(), "document", "written-later");
+    insert(cwd, &format!("<{iri}> rdf:type ops:Document ; ops:name \"later\" .\n"));
+
+    let r = base::doctor::diagnose_tier("workspace", &graph_path(cwd));
+    assert_eq!(r.schema_version.as_deref(), Some(base::migrate::SCHEMA_VERSION), "still stamped");
+    assert_eq!(r.domain_orphans, vec![("Document".to_string(), 1)], "and the drift is counted");
+    assert_eq!(r.status, "healthy", "drift is not a health fault");
+}
+
+#[test]
+fn an_unhealthy_tier_reports_no_schema_rather_than_a_wrong_one() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    migrate(cwd);
+    let mut raw = std::fs::read_to_string(graph_path(cwd)).unwrap();
+    raw.push_str("this is not a quad\n");
+    std::fs::write(graph_path(cwd), &raw).unwrap();
+
+    let r = base::doctor::diagnose_tier("workspace", &graph_path(cwd));
+    assert_eq!(r.status, "unhealthy");
+    assert_eq!(r.schema_version, None, "a store that will not parse claims nothing");
+    assert!(r.domain_orphans.is_empty());
+}
+
+#[test]
+fn a_ping_is_never_counted_as_an_orphan() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let iri = crud::build_iri(&ns(), "ping", "lark-probe");
+    insert(cwd, &format!("<{iri}> rdf:type ops:Ping ; ops:message \"m\" .\n"));
+
+    let r = base::doctor::diagnose_tier("workspace", &graph_path(cwd));
+    assert!(
+        r.domain_orphans.is_empty(),
+        "session traffic is excluded from the count as well as from the backfill: {:?}",
+        r.domain_orphans
+    );
+}

--- a/tests/domain_link_test.rs
+++ b/tests/domain_link_test.rs
@@ -1,0 +1,181 @@
+//! `base recall --domain` must return the same notes on both sides of the
+//! predicate change, and each note exactly once while both predicates are on disk.
+//!
+//! `crud/note.rs` had five hardcoded `relatedTo <domain_iri>` reads (hawk C11).
+//! Flip the write to `hasDomain` without teaching them both and `recall --domain`
+//! returns nothing — silently, because an empty SPARQL result is indistinguishable
+//! from "that domain has no notes". These tests plant each era's shape directly in
+//! the store so a regression on any one of the five reads fails here.
+
+use std::path::Path;
+
+use base::config::{BaseConfig, NamespaceConfig};
+use base::crud;
+use base::domain::link;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+fn workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let base_dir = tmp.path().join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    std::fs::write(base_dir.join("graph.nq"), "").unwrap();
+    std::fs::write(
+        base_dir.join("base.toml"),
+        "[namespace]\nprefix = \"ops\"\nuri = \"http://ops-sys.local/ontology#\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        base_dir.join("domains.toml"),
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = [\"probe\"]\nrules = [\"a probe rule\"]\n",
+    )
+    .unwrap();
+    let config = BaseConfig::load(tmp.path());
+    base::domain::sync::sync_domains_to_graph(&config, tmp.path(), None).unwrap();
+    tmp
+}
+
+/// A note carrying exactly the predicates given — the era shapes, planted directly.
+fn plant_note(cwd: &Path, slug: &str, text: &str, predicates: &[&str]) {
+    let ns = ns();
+    let p = &ns.prefix;
+    let iri = crud::build_iri(&ns, "note", slug);
+    let dom = crud::build_iri(&ns, "domain", "probe");
+    let graph = crud::workspace_graph_iri(&ns, &crud::workspace_slug(cwd));
+    let edges: String = predicates
+        .iter()
+        .map(|pred| format!("  <{iri}> {p}:{pred} <{dom}> .\n"))
+        .collect();
+    let sparql = format!(
+        "INSERT DATA {{ GRAPH <{graph}> {{\n\
+           <{iri}> rdf:type {p}:Note ;\n\
+             {p}:noteText \"{text}\" ;\n\
+             {p}:noteType \"insight\" ;\n\
+             {p}:status \"active\" ;\n\
+             {p}:createdAt \"2026-09-06T00:00:00-05:00\"^^xsd:dateTime .\n\
+         {edges}\
+         }} }}"
+    );
+    crud::load_and_mutate(cwd, &ns, &sparql).unwrap();
+}
+
+fn hits(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+#[test]
+fn recall_by_domain_finds_a_legacy_only_note() {
+    let tmp = workspace();
+    plant_note(tmp.path(), "legacy-era", "written by 0.13.x", &[link::LEGACY]);
+
+    let out = crud::note::recall_to_string(tmp.path(), &ns(), None, Some("probe"));
+    assert_eq!(
+        hits(&out, "written by 0.13.x"),
+        1,
+        "a note written before the migration must still recall — got {out:?}"
+    );
+}
+
+#[test]
+fn recall_by_domain_finds_a_canonical_only_note() {
+    let tmp = workspace();
+    plant_note(tmp.path(), "canonical-era", "written after the contract", &[link::CANONICAL]);
+
+    let out = crud::note::recall_to_string(tmp.path(), &ns(), None, Some("probe"));
+    assert_eq!(
+        hits(&out, "written after the contract"),
+        1,
+        "a note carrying only the new predicate must recall — got {out:?}"
+    );
+}
+
+#[test]
+fn a_note_carrying_both_predicates_recalls_exactly_once() {
+    // The overlap window's own shape: 0.14.0 writes both, so a naive
+    // `?n (a|b) <dom>` triple pattern yields one solution per matching path and
+    // prints every note twice. The reads use FILTER EXISTS for that reason.
+    let tmp = workspace();
+    plant_note(tmp.path(), "overlap-era", "written during the overlap", &[link::CANONICAL, link::LEGACY]);
+
+    let out = crud::note::recall_to_string(tmp.path(), &ns(), None, Some("probe"));
+    assert_eq!(
+        hits(&out, "written during the overlap"),
+        1,
+        "both predicates on one note is ONE note — got {out:?}"
+    );
+
+    let both = crud::note::recall_to_string(tmp.path(), &ns(), Some("overlap"), Some("probe"));
+    assert_eq!(
+        hits(&both, "written during the overlap"),
+        1,
+        "keyword + domain must not double-count either — got {both:?}"
+    );
+
+    let iris = crud::note::recalled_note_iris(tmp.path(), &ns(), None, Some("probe"));
+    assert_eq!(iris.len(), 1, "the lastRead stamp must see one note, not two — got {iris:?}");
+}
+
+#[test]
+fn learn_writes_both_predicates_and_recalls_once() {
+    // The real write path, end to end: `base learn --domain` during the overlap.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    crud::note::learn(cwd, &ns(), "a note through the write path", "insight", Some("probe"), None, None)
+        .unwrap();
+
+    let ns = ns();
+    let p = &ns.prefix;
+    let dom = crud::build_iri(&ns, "domain", "probe");
+    for pred in [link::CANONICAL, link::LEGACY] {
+        let q = format!("ASK {{ GRAPH ?g {{ ?n a {p}:Note ; {p}:{pred} <{dom}> }} }}");
+        let r = crud::load_and_query(cwd, &ns, &q).unwrap();
+        let oxigraph::sparql::QueryResults::Boolean(yes) = r else { panic!("expected ASK") };
+        assert!(yes, "0.14.0 must write {pred} — a rolled-back 0.13.x binary reads the legacy one");
+    }
+
+    let out = crud::note::recall_to_string(cwd, &ns, None, Some("probe"));
+    assert_eq!(hits(&out, "a note through the write path"), 1, "one note, one row — got {out:?}");
+}
+
+#[test]
+fn list_notes_by_domain_sees_both_eras() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_note(cwd, "legacy-era", "legacy listed", &[link::LEGACY]);
+    plant_note(cwd, "canonical-era", "canonical listed", &[link::CANONICAL]);
+    plant_note(cwd, "overlap-era", "overlap listed", &[link::CANONICAL, link::LEGACY]);
+    // A note in no domain at all — the control the filter must exclude.
+    plant_note(cwd, "unlinked", "unlinked note", &[]);
+
+    // `list_notes` prints; the filter it builds is the fifth read. Exercise it
+    // through the IRI resolver, which builds the same domain clause.
+    let iris = crud::note::recalled_note_iris(cwd, &ns(), None, Some("probe"));
+    let mut slugs: Vec<String> =
+        iris.iter().filter_map(|i| i.rsplit_once("note/").map(|(_, s)| s.to_string())).collect();
+    slugs.sort();
+    assert_eq!(
+        slugs,
+        vec!["canonical-era".to_string(), "legacy-era".to_string(), "overlap-era".to_string()],
+        "both eras in, once each, and the unlinked note out"
+    );
+}
+
+#[test]
+fn a_notes_project_and_entity_links_are_not_domain_links() {
+    // `relatedTo` is generic: 532 document→entity and 30 document→project links in
+    // Chris's store use it (hawk C12). The object IRI kind is the discriminator, so
+    // reading the domain link must never pull a project link in.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    crud::note::learn(cwd, &ns(), "a note about a project", "insight", None, Some("probe"), None)
+        .unwrap();
+
+    // `project/probe` and `domain/probe` differ only in IRI kind.
+    let out = crud::note::recall_to_string(cwd, &ns(), None, Some("probe"));
+    assert!(
+        !out.contains("a note about a project"),
+        "a relatedTo→project link is not a domain link — got {out:?}"
+    );
+}

--- a/tests/migrate_domain_test.rs
+++ b/tests/migrate_domain_test.rs
@@ -50,8 +50,29 @@ fn graph_iri(cwd: &Path) -> String {
     crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd))
 }
 
+/// The session-start path: takes the stamp as a fast path.
 fn migrate(cwd: &Path) -> migrate::Outcome {
-    migrate::migrate_tier(&graph_path(cwd), &graph_iri(cwd), &ns()).unwrap()
+    migrate::migrate_tier(&graph_path(cwd), &graph_iri(cwd), &ns(), migrate::Trigger::SessionStart)
+        .unwrap()
+}
+
+/// `base graph migrate`: always re-plans past the stamp.
+fn migrate_manual(cwd: &Path) -> migrate::Outcome {
+    migrate::migrate_tier(&graph_path(cwd), &graph_iri(cwd), &ns(), migrate::Trigger::Manual)
+        .unwrap()
+}
+
+/// The `.bak-migrate-*` snapshots on disk.
+fn snapshots(cwd: &Path) -> Vec<String> {
+    let dir = cwd.join(".base");
+    let mut v: Vec<String> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n.contains(".bak-migrate-"))
+        .collect();
+    v.sort();
+    v
 }
 
 fn insert(cwd: &Path, triples: &str) {
@@ -201,6 +222,103 @@ fn a_restored_post_migration_backup_does_not_re_migrate() {
 }
 
 // ─── what it must not touch ──────────────────────────────────────────────────
+
+#[test]
+fn a_pass_with_nothing_to_link_takes_no_snapshot() {
+    // The comment, `docs/graph-durability.md` and the outcome's own `backup: None`
+    // all say a no-op takes no snapshot. The code took one anyway, and the test
+    // that looked like it covered this passed only because the STAMP fast path
+    // returned first — so the unstamped-empty-plan case was never exercised
+    // (kite, PR #50). Snapshots share one pool of ten with compact; a pass that
+    // writes nothing but the stamp must not evict a real backup.
+    let tmp = workspace();
+    let cwd = tmp.path();
+
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 0, "nothing to link in a fresh workspace: {out:?}");
+    assert!(out.stamped, "it still stamps, so session start takes the fast path next time");
+    assert_eq!(out.backup, None, "and takes NO snapshot");
+    assert!(snapshots(cwd).is_empty(), "nothing on disk either: {:?}", snapshots(cwd));
+
+    // The control: a pass with work to do DOES snapshot.
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    let out = migrate_manual(cwd);
+    assert_eq!(out.total_linked(), 1);
+    assert!(out.backup.is_some(), "real work is protected: {out:?}");
+    assert_eq!(snapshots(cwd).len(), 1);
+}
+
+#[test]
+fn the_manual_command_re_plans_past_the_stamp() {
+    // `base graph migrate` printed "Nothing to migrate" on a stamped tier while
+    // `base doctor` reported `without a domain: N` on the same tier in the same
+    // second. Both cannot be true (kite, PR #50). The stamp is session start's
+    // fast path and must never answer a question the operator asked directly.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    migrate(cwd);
+
+    // Drift: something writes an unlinked record after the migration ran.
+    plant_orphan(cwd, "goal", "Goal", "written-later");
+
+    let hook = migrate(cwd);
+    assert!(hook.already_migrated, "the hook still takes the fast path: {hook:?}");
+    assert_eq!(hook.total_linked(), 0);
+
+    let manual = migrate_manual(cwd);
+    assert!(!manual.already_migrated, "the operator asked, so it re-planned: {manual:?}");
+    assert_eq!(manual.total_linked(), 1, "and found the drift");
+    let goal = crud::build_iri(&ns(), "goal", "written-later");
+    assert!(ask(cwd, &format!("<{goal}> ops:hasDomain ?d")));
+}
+
+#[test]
+fn the_manual_run_agrees_with_doctor_on_the_same_tier() {
+    // Three surfaces answer one question — doctor, `--dry-run`, and the run —
+    // and they are not allowed to differ.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    migrate(cwd);
+    for n in 0..3 {
+        plant_orphan(cwd, "goal", "Goal", &format!("later-{n}"));
+    }
+
+    let reported: usize = base::doctor::diagnose_tier("workspace", &graph_path(cwd))
+        .domain_orphans
+        .iter()
+        .map(|(_, n)| n)
+        .sum();
+    assert_eq!(reported, 3, "doctor sees the drift");
+
+    let dry = base::migrate::format_dry_run(cwd, &ns());
+    assert!(dry.contains("would link 3 record(s)"), "the dry run agrees: {dry}");
+
+    let manual = migrate_manual(cwd);
+    assert_eq!(manual.total_linked(), reported, "and so does the run: {manual:?}");
+
+    let after: usize = base::doctor::diagnose_tier("workspace", &graph_path(cwd))
+        .domain_orphans
+        .iter()
+        .map(|(_, n)| n)
+        .sum();
+    assert_eq!(after, 0, "doctor is clean afterwards");
+}
+
+#[test]
+fn a_manual_run_with_nothing_to_do_still_writes_nothing() {
+    // Re-planning past the stamp must not cost a 13.4 MB rewrite for no change.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    migrate(cwd);
+
+    let before = bytes(&graph_path(cwd));
+    let out = migrate_manual(cwd);
+    assert!(out.already_migrated, "re-planned, found nothing: {out:?}");
+    assert!(!out.stamped);
+    assert_eq!(out.backup, None);
+    assert_eq!(before, bytes(&graph_path(cwd)), "byte-identical");
+}
 
 #[test]
 fn a_ping_is_never_given_a_domain() {

--- a/tests/migrate_domain_test.rs
+++ b/tests/migrate_domain_test.rs
@@ -62,6 +62,28 @@ fn migrate_manual(cwd: &Path) -> migrate::Outcome {
         .unwrap()
 }
 
+/// Tell the delta gate "this exact store is the one I already looked at".
+///
+/// The marker holds the store's IDENTITY (`len:mtime_nanos`), not a timestamp, so
+/// a literal string no longer pins it — mtime alone let a `.bak` restore land
+/// inside the filesystem's timestamp granularity and silently skip a store that
+/// was no longer migrated.
+fn pin_delta_marker(cwd: &Path) {
+    let g = graph_path(cwd);
+    let m = std::fs::metadata(&g).unwrap();
+    let nanos = m
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::fs::write(
+        cwd.join(".base").join(".last-domain-delta"),
+        format!("{}:{}", m.len(), nanos),
+    )
+    .unwrap();
+}
+
 /// The `.bak-migrate-*` snapshots on disk.
 fn snapshots(cwd: &Path) -> Vec<String> {
     let dir = cwd.join(".base");
@@ -271,8 +293,7 @@ fn the_manual_command_re_plans_past_the_stamp() {
     // about: a stamped tier the hook has no reason to re-plan, and drift that only the
     // operator's own command goes looking for. (With the store newer than the marker the
     // hook would file it itself — `a_record_written_after_the_migration_is_linked_at_the_next_session`.)
-    std::thread::sleep(std::time::Duration::from_millis(20));
-    std::fs::write(cwd.join(".base").join(".last-domain-delta"), "pinned by the test").unwrap();
+    pin_delta_marker(cwd);
 
     let hook = migrate(cwd);
     assert!(hook.already_migrated, "the hook still takes the fast path: {hook:?}");

--- a/tests/migrate_domain_test.rs
+++ b/tests/migrate_domain_test.rs
@@ -321,6 +321,74 @@ fn a_manual_run_with_nothing_to_do_still_writes_nothing() {
 }
 
 #[test]
+fn a_record_written_after_the_migration_is_linked_at_the_next_session() {
+    // "Every record carries a domain" was false one write later (kite F7):
+    // `base sync` and the PAUL ingest manufacture unlinked records every session,
+    // and a stamped tier used to skip them forever.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    let first = migrate(cwd);
+    assert_eq!(first.total_linked(), 1);
+    assert!(!first.delta, "the first pass is a migration, not a delta");
+
+    // Something writes an unlinked record afterwards.
+    plant_orphan(cwd, "document", "Document", "written-later");
+
+    let second = migrate(cwd);
+    assert!(second.delta, "an already-stamped tier does a DELTA pass: {second:?}");
+    assert_eq!(second.total_linked(), 1, "and finds the new record");
+    assert_eq!(second.backup, None, "a delta adds quads only — no snapshot");
+    assert!(snapshots(cwd).len() == 1, "still just the first migration's: {:?}", snapshots(cwd));
+    let doc = crud::build_iri(&ns(), "document", "written-later");
+    assert!(ask(cwd, &format!("<{doc}> ops:hasDomain ?d")));
+
+    // The claim, stated as a test: nothing is left unlinked.
+    let left: usize = base::doctor::diagnose_tier("workspace", &graph_path(cwd))
+        .domain_orphans
+        .iter()
+        .map(|(_, n)| n)
+        .sum();
+    assert_eq!(left, 0);
+}
+
+#[test]
+fn a_session_that_wrote_nothing_costs_no_parse() {
+    // The delta pass must not re-plan a 13.4 MB store every session start. It is
+    // gated on the store's own mtime against a marker — one `stat` — so a session
+    // that changed nothing is skipped outright.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    migrate(cwd);
+
+    let before = bytes(&graph_path(cwd));
+    let out = migrate(cwd);
+    assert!(out.already_migrated, "nothing wrote, so nothing was looked at: {out:?}");
+    assert!(!out.delta);
+    assert_eq!(out.total_linked(), 0);
+    assert_eq!(before, bytes(&graph_path(cwd)), "and the store is byte-identical");
+    assert!(
+        cwd.join(".base").join(".last-domain-delta").exists(),
+        "the marker is what makes the skip possible"
+    );
+}
+
+#[test]
+fn the_delta_pass_reruns_once_the_store_moves_again() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    migrate(cwd);
+    assert!(migrate(cwd).already_migrated, "quiet session, skipped");
+
+    // A write moves the store's mtime past the marker.
+    plant_orphan(cwd, "reminder", "Reminder", "call-someone");
+    let out = migrate(cwd);
+    assert!(out.delta, "the store moved, so the pass ran: {out:?}");
+    assert_eq!(out.total_linked(), 1);
+}
+
+#[test]
 fn a_ping_is_never_given_a_domain() {
     let tmp = workspace();
     let cwd = tmp.path();

--- a/tests/migrate_domain_test.rs
+++ b/tests/migrate_domain_test.rs
@@ -1,0 +1,340 @@
+//! The migration runs once, computes its work from the store, and stamps in the
+//! same write as the data.
+//!
+//! Every assertion here maps to an acceptance line in the fork doc:
+//!
+//! - a store at the old shape, opened by the new binary, migrates once and only once
+//! - a `.bak` restore followed by re-open neither double-migrates nor skips
+//! - the catchall population is NAMED, never "whatever was left"
+//! - session traffic is never given a domain
+//!
+//! The `.bak` pair is the one that decides the design. A file sentinel outside the
+//! store passes "migrates once" and fails "restore re-migrates", silently, forever
+//! — which is why the stamp lives in the graph (G0 verdict A1).
+
+use std::path::Path;
+
+use base::config::{BaseConfig, NamespaceConfig};
+use base::crud;
+use base::migrate;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+fn workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let base_dir = tmp.path().join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    std::fs::write(base_dir.join("graph.nq"), "").unwrap();
+    std::fs::write(
+        base_dir.join("base.toml"),
+        "[namespace]\nprefix = \"ops\"\nuri = \"http://ops-sys.local/ontology#\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        base_dir.join("domains.toml"),
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = [\"probe\"]\nrules = [\"a probe rule\"]\n",
+    )
+    .unwrap();
+    let config = BaseConfig::load(tmp.path());
+    base::domain::sync::sync_domains_to_graph(&config, tmp.path(), None).unwrap();
+    tmp
+}
+
+fn graph_path(cwd: &Path) -> std::path::PathBuf {
+    cwd.join(".base").join("graph.nq")
+}
+
+fn graph_iri(cwd: &Path) -> String {
+    crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd))
+}
+
+fn migrate(cwd: &Path) -> migrate::Outcome {
+    migrate::migrate_tier(&graph_path(cwd), &graph_iri(cwd), &ns()).unwrap()
+}
+
+fn insert(cwd: &Path, triples: &str) {
+    let sparql = format!("INSERT DATA {{ GRAPH <{}> {{\n{triples}\n}} }}", graph_iri(cwd));
+    crud::load_and_mutate(cwd, &ns(), &sparql).unwrap();
+}
+
+/// An orphan of the given class — typed, named, and linked to nothing.
+fn plant_orphan(cwd: &Path, kind: &str, class: &str, slug: &str) -> String {
+    let ns = ns();
+    let p = &ns.prefix;
+    let iri = crud::build_iri(&ns, kind, slug);
+    insert(cwd, &format!("<{iri}> rdf:type {p}:{class} ;\n  {p}:name \"{slug}\" .\n"));
+    iri
+}
+
+fn ask(cwd: &Path, pattern: &str) -> bool {
+    let q = format!("ASK {{ GRAPH ?g {{ {pattern} }} }}");
+    match crud::load_and_query(cwd, &ns(), &q).unwrap() {
+        oxigraph::sparql::QueryResults::Boolean(b) => b,
+        _ => panic!("expected ASK"),
+    }
+}
+
+fn bytes(path: &Path) -> Vec<u8> {
+    std::fs::read(path).unwrap()
+}
+
+// ─── migrates once ───────────────────────────────────────────────────────────
+
+#[test]
+fn an_orphan_gets_the_catchall_and_the_store_gets_the_stamp() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+
+    let out = migrate(cwd);
+    assert!(out.stamped, "the pass must stamp: {out:?}");
+    assert_eq!(out.total_linked(), 1, "one orphan, one link: {out:?}");
+    assert_eq!(out.catchall, 1, "a Goal is in the named catchall set");
+    assert!(out.backup.is_some(), "C1: snapshot before the write");
+    assert!(Path::new(out.backup.as_ref().unwrap()).exists(), "the snapshot is on disk");
+
+    let unfiled = crud::build_iri(&ns(), "domain", migrate::CATCHALL);
+    let goal = crud::build_iri(&ns(), "goal", "ship-the-thing");
+    assert!(ask(cwd, &format!("<{goal}> ops:hasDomain <{unfiled}>")), "the link is on disk");
+    assert!(ask(cwd, &format!("<{unfiled}> a ops:Domain")), "the catchall domain record exists");
+}
+
+#[test]
+fn the_stamp_and_the_data_land_in_the_same_write() {
+    // write_back is temp-plus-rename, so this is really "both or neither". What a
+    // test can check is that no state exists where one is present and the other is
+    // not, at the only point an outside observer can look: the file.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    migrate(cwd);
+
+    let store = base::store::load_graph(&graph_path(cwd)).unwrap();
+    let stamp = migrate::stamp_of(&store, &ns(), &graph_iri(cwd));
+    assert_eq!(stamp.as_deref(), Some(migrate::SCHEMA_VERSION));
+
+    let goal = crud::build_iri(&ns(), "goal", "ship-the-thing");
+    assert!(ask(cwd, &format!("<{goal}> ops:hasDomain ?d")), "data present wherever the stamp is");
+}
+
+#[test]
+fn a_second_run_writes_nothing_at_all() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    migrate(cwd);
+
+    let before = bytes(&graph_path(cwd));
+    let out = migrate(cwd);
+    assert!(out.already_migrated, "the stamp is the fast path: {out:?}");
+    assert!(!out.stamped);
+    assert_eq!(out.total_linked(), 0);
+    assert!(out.backup.is_none(), "a no-op must not evict a compact backup from the pool of 10");
+    assert_eq!(before, bytes(&graph_path(cwd)), "the file must be byte-identical");
+}
+
+#[test]
+fn without_the_stamp_a_re_run_finds_nothing_to_do() {
+    // The stamp is a fast path, not a truth source: strip it and the pass must
+    // still reach the same end state by recomputing from the store, not redo work.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    migrate(cwd);
+
+    let iri = graph_iri(cwd);
+    let del = format!(
+        "DELETE WHERE {{ GRAPH <{iri}> {{ <{iri}> ops:schemaVersion ?v }} }}"
+    );
+    crud::load_and_mutate(cwd, &ns(), &del).unwrap();
+
+    let out = migrate(cwd);
+    assert!(!out.already_migrated, "the stamp is gone, so the pass must run");
+    assert!(out.stamped, "and stamp again");
+    assert_eq!(out.total_linked(), 0, "but find no work — the record is already linked: {out:?}");
+}
+
+// ─── the .bak pair — the acceptance line that decides the design ─────────────
+
+#[test]
+fn a_restored_pre_migration_backup_re_migrates() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    let pre = bytes(&graph_path(cwd));
+
+    let first = migrate(cwd);
+    assert_eq!(first.total_linked(), 1);
+
+    // The operator restores a backup taken before the migration.
+    std::fs::write(graph_path(cwd), &pre).unwrap();
+
+    let second = migrate(cwd);
+    assert!(
+        !second.already_migrated,
+        "a restored PRE-migration store has no stamp and must migrate again. A file \
+         sentinel outside the store would claim it was already done: {second:?}"
+    );
+    assert_eq!(second.total_linked(), 1, "and redo exactly the work the restore undid");
+
+    let goal = crud::build_iri(&ns(), "goal", "ship-the-thing");
+    assert!(ask(cwd, &format!("<{goal}> ops:hasDomain ?d")), "the store ends migrated");
+}
+
+#[test]
+fn a_restored_post_migration_backup_does_not_re_migrate() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    migrate(cwd);
+    let post = bytes(&graph_path(cwd));
+
+    // Something else churns the store, then the operator restores the migrated copy.
+    plant_orphan(cwd, "goal", "Goal", "a-later-goal");
+    std::fs::write(graph_path(cwd), &post).unwrap();
+
+    let out = migrate(cwd);
+    assert!(out.already_migrated, "a restored POST-migration store carries its own stamp: {out:?}");
+    assert_eq!(post, bytes(&graph_path(cwd)), "and is left byte-identical");
+}
+
+// ─── what it must not touch ──────────────────────────────────────────────────
+
+#[test]
+fn a_ping_is_never_given_a_domain() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let ping = plant_orphan(cwd, "ping", "Ping", "lark-probe");
+
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 0, "session traffic is excluded, not catchalled: {out:?}");
+    assert!(!ask(cwd, &format!("<{ping}> ops:hasDomain ?d")), "no domain on a Ping");
+}
+
+#[test]
+fn a_record_that_already_carries_a_legacy_domain_link_is_left_alone() {
+    // The orphan query reads BOTH eras. Reading only `hasDomain` would see all 465
+    // note-domain links in Chris's store as orphans and write 465 duplicates.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    crud::note::learn(cwd, &ns(), "an already linked note", "insight", Some("probe"), None, None)
+        .unwrap();
+    let doc = crud::build_iri(&ns(), "document", "legacy-linked");
+    let dom = crud::build_iri(&ns(), "domain", "probe");
+    insert(
+        cwd,
+        &format!("<{doc}> rdf:type ops:Document ;\n  ops:name \"legacy linked\" ;\n  ops:relatedTo <{dom}> .\n"),
+    );
+
+    let out = migrate(cwd);
+    assert_eq!(
+        out.total_linked(),
+        0,
+        "a record linked under the legacy predicate is not an orphan: {out:?}"
+    );
+    let unfiled = crud::build_iri(&ns(), "domain", migrate::CATCHALL);
+    assert!(!ask(cwd, &format!("<{doc}> ops:hasDomain <{unfiled}>")), "and is not re-filed");
+}
+
+#[test]
+fn a_documents_entity_link_does_not_count_as_a_domain_link() {
+    // `relatedTo` also carries 532 document-entity links in Chris's store. Treating
+    // one as a domain link would leave that document orphaned while reporting it
+    // covered.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let doc = crud::build_iri(&ns(), "document", "entity-linked");
+    let ent = crud::build_iri(&ns(), "entity", "some-entity");
+    insert(
+        cwd,
+        &format!("<{doc}> rdf:type ops:Document ;\n  ops:name \"entity linked\" ;\n  ops:relatedTo <{ent}> .\n"),
+    );
+
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 1, "the object IRI kind is the discriminator: {out:?}");
+    assert!(ask(cwd, &format!("<{doc}> ops:hasDomain ?d")));
+}
+
+#[test]
+fn an_unhealthy_graph_is_skipped_and_not_stamped() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    let mut raw = std::fs::read_to_string(graph_path(cwd)).unwrap();
+    raw.push_str("this is not a quad\n");
+    std::fs::write(graph_path(cwd), &raw).unwrap();
+
+    let out = migrate(cwd);
+    assert!(out.skipped_unhealthy, "defined behaviour, not silence: {out:?}");
+    assert!(!out.stamped, "a skipped migration must not claim it ran");
+    assert!(out.backup.is_none());
+    assert!(
+        migrate::format_outcomes(&[out]).contains("doctor --repair"),
+        "and it must say so, with the next step"
+    );
+}
+
+#[test]
+fn the_migration_never_invents_a_domain() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
+    plant_orphan(cwd, "reminder", "Reminder", "call-someone");
+    migrate(cwd);
+
+    let q = "SELECT DISTINCT ?d WHERE { GRAPH ?g { ?d a ops:Domain } }";
+    let oxigraph::sparql::QueryResults::Solutions(sols) = crud::load_and_query(cwd, &ns(), q).unwrap()
+    else {
+        panic!("expected solutions")
+    };
+    let mut domains: Vec<String> = sols
+        .filter_map(|r| r.ok())
+        .filter_map(|row| match row.get("d")? {
+            oxigraph::model::Term::NamedNode(n) => {
+                n.as_str().rsplit_once("domain/").map(|(_, s)| s.to_string())
+            }
+            _ => None,
+        })
+        .collect();
+    domains.sort();
+    domains.dedup();
+    assert_eq!(
+        domains,
+        vec!["probe".to_string(), migrate::CATCHALL.to_string()],
+        "only the declared domain and the catchall exist — no domain was invented"
+    );
+}
+
+#[test]
+fn the_catchall_record_is_created_once_not_per_record() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    for n in 0..5 {
+        plant_orphan(cwd, "goal", "Goal", &format!("goal-{n}"));
+    }
+    let out = migrate(cwd);
+    assert_eq!(out.catchall, 5);
+
+    let raw = std::fs::read_to_string(graph_path(cwd)).unwrap();
+    let unfiled_type = format!(
+        "<{}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+        crud::build_iri(&ns(), "domain", migrate::CATCHALL)
+    );
+    assert_eq!(
+        raw.matches(&unfiled_type).count(),
+        1,
+        "one catchall domain record, however many records point at it"
+    );
+}
+
+#[test]
+fn a_store_with_nothing_to_do_still_ends_stamped() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 0);
+    assert!(out.stamped, "so the next session takes the fast path instead of re-planning");
+    assert!(!migrate::format_outcomes(&[out]).contains("linked"), "and says nothing about it");
+}

--- a/tests/migrate_domain_test.rs
+++ b/tests/migrate_domain_test.rs
@@ -240,12 +240,18 @@ fn a_pass_with_nothing_to_link_takes_no_snapshot() {
     assert_eq!(out.backup, None, "and takes NO snapshot");
     assert!(snapshots(cwd).is_empty(), "nothing on disk either: {:?}", snapshots(cwd));
 
-    // The control: a pass with work to do DOES snapshot.
-    plant_orphan(cwd, "goal", "Goal", "ship-the-thing");
-    let out = migrate_manual(cwd);
+    // The control: a FIRST migration with work to do does snapshot. On a tier that is
+    // already stamped, later work is a delta pass, which takes none by design: it only
+    // adds quads onto a store already at this schema (e2a5d4d, vole's amendment to
+    // kite F7), so the control has to be a fresh, unstamped tier.
+    let tmp2 = workspace();
+    let cwd2 = tmp2.path();
+    plant_orphan(cwd2, "goal", "Goal", "ship-the-thing");
+    let out = migrate(cwd2);
     assert_eq!(out.total_linked(), 1);
+    assert!(!out.delta, "a first migration is not a delta: {out:?}");
     assert!(out.backup.is_some(), "real work is protected: {out:?}");
-    assert_eq!(snapshots(cwd).len(), 1);
+    assert_eq!(snapshots(cwd2).len(), 1);
 }
 
 #[test]
@@ -260,6 +266,13 @@ fn the_manual_command_re_plans_past_the_stamp() {
 
     // Drift: something writes an unlinked record after the migration ran.
     plant_orphan(cwd, "goal", "Goal", "written-later");
+    // Pin the delta marker newer than the store, so the hook's mtime gate reads "nothing
+    // wrote since I last looked" and takes the fast path. That is the state this test is
+    // about: a stamped tier the hook has no reason to re-plan, and drift that only the
+    // operator's own command goes looking for. (With the store newer than the marker the
+    // hook would file it itself — `a_record_written_after_the_migration_is_linked_at_the_next_session`.)
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    std::fs::write(cwd.join(".base").join(".last-domain-delta"), "pinned by the test").unwrap();
 
     let hook = migrate(cwd);
     assert!(hook.already_migrated, "the hook still takes the fast path: {hook:?}");

--- a/tests/migrate_sources_test.rs
+++ b/tests/migrate_sources_test.rs
@@ -1,0 +1,431 @@
+//! Where each family's domain comes from — one test per arm, plus the precedence
+//! between them.
+//!
+//! Every parent link asserted here was read off Chris's live store with a
+//! read-only probe (lark, 2026-09-06), not inferred from the ontology, which does
+//! not declare half these classes. The shapes:
+//!
+//! ```text
+//! AcceptanceCriteria        <- plan     ops:hasAC          (reverse)
+//! AcceptanceCriteriaResult  <- summary  ops:hasACResult    (reverse)
+//! FileChange                <- summary  ops:hasFileChange  (reverse)
+//! Decision                  <- summary  ops:hasDecision    (reverse)
+//! Task                      <- project  ops:hasTask        (reverse)
+//! Handoff                   ops:project "vintrix"          (literal, not an IRI)
+//! CodeMap                   ops:name    "grazer"           (literal app name)
+//! Lore*                     nothing at all — every property is a literal
+//! ```
+
+use std::path::Path;
+
+use base::config::{BaseConfig, NamespaceConfig};
+use base::crud;
+use base::migrate::{self, Arm};
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+/// A workspace whose domains.toml is given verbatim, so a test can declare path
+/// triggers.
+fn workspace_with(domains_toml: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let base_dir = tmp.path().join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    std::fs::write(base_dir.join("graph.nq"), "").unwrap();
+    std::fs::write(
+        base_dir.join("base.toml"),
+        "[namespace]\nprefix = \"ops\"\nuri = \"http://ops-sys.local/ontology#\"\n",
+    )
+    .unwrap();
+    std::fs::write(base_dir.join("domains.toml"), domains_toml).unwrap();
+    let config = BaseConfig::load(tmp.path());
+    base::domain::sync::sync_domains_to_graph(&config, tmp.path(), None).unwrap();
+    tmp
+}
+
+fn workspace() -> tempfile::TempDir {
+    workspace_with(
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = [\"probe\"]\nrules = [\"r\"]\n",
+    )
+}
+
+fn graph_iri(cwd: &Path) -> String {
+    crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd))
+}
+
+fn insert(cwd: &Path, triples: &str) {
+    let sparql = format!("INSERT DATA {{ GRAPH <{}> {{\n{triples}\n}} }}", graph_iri(cwd));
+    crud::load_and_mutate(cwd, &ns(), &sparql).unwrap();
+}
+
+fn migrate(cwd: &Path) -> migrate::Outcome {
+    migrate::migrate_tier(&cwd.join(".base").join("graph.nq"), &graph_iri(cwd), &ns()).unwrap()
+}
+
+/// The domain slug a record ended up with, read back off disk.
+fn domain_of(cwd: &Path, iri: &str) -> Option<String> {
+    let q = format!("SELECT ?d WHERE {{ GRAPH ?g {{ <{iri}> ops:hasDomain ?d }} }}");
+    let oxigraph::sparql::QueryResults::Solutions(sols) =
+        crud::load_and_query(cwd, &ns(), &q).unwrap()
+    else {
+        return None;
+    };
+    sols.filter_map(|r| r.ok())
+        .filter_map(|row| match row.get("d")? {
+            oxigraph::model::Term::NamedNode(n) => {
+                n.as_str().rsplit_once("domain/").map(|(_, s)| s.to_string())
+            }
+            _ => None,
+        })
+        .next()
+}
+
+/// A project with a domain, as `base project add --domain` writes one.
+fn plant_project(cwd: &Path, slug: &str, domain: &str, path: Option<&str>) -> String {
+    let iri = crud::build_iri(&ns(), "project", slug);
+    let dom = crud::build_iri(&ns(), "domain", domain);
+    let p = path.map(|p| format!("  ops:path \"{p}\" ;\n")).unwrap_or_default();
+    insert(
+        cwd,
+        &format!("<{iri}> rdf:type ops:Project ;\n{p}  ops:name \"{slug}\" ;\n  ops:hasDomain <{dom}> .\n"),
+    );
+    iri
+}
+
+/// A markdown file on disk plus its record, the shape `base sync` writes. `class`
+/// is `Document`, `PaulPlan` or `PaulSummary` — the Paul pair share the
+/// `document/` IRI space and carry `ops:path` the same way, and no subject in
+/// Chris's store carries two rdf:types (measured, 2026-09-06).
+fn plant_doclike(cwd: &Path, class: &str, rel: &str, frontmatter: &str) -> String {
+    let full = cwd.join(rel);
+    std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+    std::fs::write(&full, format!("---\n{frontmatter}---\n\n# body\n")).unwrap();
+    let slug = crud::slugify(rel);
+    let iri = crud::build_iri(&ns(), "document", &slug);
+    insert(
+        cwd,
+        &format!("<{iri}> rdf:type ops:{class} ;\n  ops:name \"{slug}\" ;\n  ops:path \"{rel}\" .\n"),
+    );
+    iri
+}
+
+fn plant_document(cwd: &Path, rel: &str, frontmatter: &str) -> String {
+    plant_doclike(cwd, "Document", rel, frontmatter)
+}
+
+// ─── ruling 3: the Lore family ───────────────────────────────────────────────
+
+#[test]
+fn the_lore_family_takes_skyrim_companion_and_the_domain_is_created_if_absent() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let mut iris = Vec::new();
+    for (n, class) in [
+        (0, "LoreKnowledge"),
+        (1, "LoreFact"),
+        (2, "LoreRelationship"),
+        (3, "LoreItem"),
+        (4, "LoreBelief"),
+    ] {
+        let iri = format!("http://ops-sys.local/ontology#ext/lore/{class}/{n}");
+        // Exactly the shape the extension writes: every property a literal, no
+        // IRI edges at all, so nothing but a fixed assignment can reach these.
+        insert(cwd, &format!("<{iri}> rdf:type ops:{class} ;\n  ops:source \"ext:lore\" .\n"));
+        iris.push(iri);
+    }
+
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 5, "{out:?}");
+    assert_eq!(out.by_arm.get("fixed"), Some(&5), "all five by the fixed arm");
+    assert_eq!(out.catchall, 0, "ruling 3 is a real domain, not the catchall");
+    for iri in &iris {
+        assert_eq!(domain_of(cwd, iri).as_deref(), Some("skyrim-companion"), "{iri}");
+    }
+    // G0 verdict A3: created once, not invented per record.
+    let raw = std::fs::read_to_string(cwd.join(".base").join("graph.nq")).unwrap();
+    let marker = "<http://ops-sys.local/ontology#domain/skyrim-companion> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>";
+    assert_eq!(raw.matches(marker).count(), 1, "one skyrim-companion domain record");
+}
+
+// ─── parent walks, all reverse ───────────────────────────────────────────────
+
+#[test]
+fn paul_artefacts_inherit_the_plan_or_summary_that_owns_them() {
+    let tmp = workspace_with(
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"phases\"]\nrules = [\"r\"]\n",
+    );
+    let cwd = tmp.path();
+
+    // A plan and a summary, both filed by the path-trigger arm in stage 1.
+    let plan = plant_doclike(cwd, "PaulPlan", "phases/01-01-PLAN.md", "");
+    let summary = plant_doclike(cwd, "PaulSummary", "phases/01-01-SUMMARY.md", "");
+
+    let ac = crud::build_iri(&ns(), "acceptance-criteria", "01-01-ac-1");
+    let acr = crud::build_iri(&ns(), "ac-result", "01-01-ac-1");
+    let fc = crud::build_iri(&ns(), "file-change", "01-01-src-lib-rs");
+    let dec = crud::build_iri(&ns(), "decision", "01-01-a-choice");
+    insert(
+        cwd,
+        &format!(
+            "<{ac}> rdf:type ops:AcceptanceCriteria ; ops:name \"AC-1\" .\n\
+             <{acr}> rdf:type ops:AcceptanceCriteriaResult ; ops:criterion \"AC-1\" .\n\
+             <{fc}> rdf:type ops:FileChange ; ops:filePath \"src/lib.rs\" .\n\
+             <{dec}> rdf:type ops:Decision ; ops:rationale \"because\" .\n\
+             <{plan}> ops:hasAC <{ac}> .\n\
+             <{summary}> ops:hasACResult <{acr}> .\n\
+             <{summary}> ops:hasFileChange <{fc}> .\n\
+             <{summary}> ops:hasDecision <{dec}> .\n"
+        ),
+    );
+
+    let out = migrate(cwd);
+    for (iri, what) in [(&ac, "AC"), (&acr, "AC result"), (&fc, "file change"), (&dec, "decision")] {
+        assert_eq!(
+            domain_of(cwd, iri).as_deref(),
+            Some("probe"),
+            "{what} must inherit the document that owns it, filed in the same pass: {out:?}"
+        );
+    }
+    assert_eq!(out.by_arm.get("parent"), Some(&4));
+    assert_eq!(out.by_arm.get("path-trigger"), Some(&2), "the plan and the summary");
+    assert_eq!(out.catchall, 0);
+}
+
+#[test]
+fn a_task_inherits_its_project() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let proj = plant_project(cwd, "meet-caddy", "probe", None);
+    let task = crud::build_iri(&ns(), "task", "meet-caddy.do-the-thing");
+    insert(cwd, &format!("<{task}> rdf:type ops:Task ; ops:name \"do the thing\" .\n"));
+    insert(cwd, &format!("<{proj}> ops:hasTask <{task}> .\n"));
+
+    migrate(cwd);
+    assert_eq!(domain_of(cwd, &task).as_deref(), Some("probe"));
+}
+
+#[test]
+fn a_decision_a_domain_already_points_at_is_not_an_orphan() {
+    // `crud/decision.rs:47` writes `<domain> ops:hasDecision <decision>`. A
+    // subject-side-only orphan test reads all 420 of Chris's decisions as orphans
+    // and files them under `unfiled` on top of the domain they already have.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let dec = crud::build_iri(&ns(), "decision", "probe.a-real-decision");
+    let dom = crud::build_iri(&ns(), "domain", "probe");
+    insert(cwd, &format!("<{dec}> rdf:type ops:Decision ; ops:rationale \"r\" .\n"));
+    insert(cwd, &format!("<{dom}> ops:hasDecision <{dec}> .\n"));
+
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 0, "already linked, the other way round: {out:?}");
+    assert_eq!(domain_of(cwd, &dec), None, "and not given a second, wrong link");
+}
+
+// ─── literal-named parents ───────────────────────────────────────────────────
+
+#[test]
+fn a_handoff_takes_the_domain_of_the_project_named_in_its_literal() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "vintrix", "probe", None);
+    let h = crud::build_iri(&ns(), "handoff", "2026-09-05-0642-egret-vintrix");
+    insert(
+        cwd,
+        &format!("<{h}> rdf:type ops:Handoff ; ops:name \"vintrix\" ; ops:project \"vintrix\" .\n"),
+    );
+
+    migrate(cwd);
+    assert_eq!(domain_of(cwd, &h).as_deref(), Some("probe"));
+}
+
+#[test]
+fn a_codemap_takes_the_domain_of_the_app_it_maps() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "grazer", "probe", None);
+    let c = crud::build_iri(&ns(), "codemap", "grazer");
+    insert(cwd, &format!("<{c}> rdf:type ops:CodeMap ; ops:name \"grazer\" .\n"));
+
+    migrate(cwd);
+    assert_eq!(domain_of(cwd, &c).as_deref(), Some("probe"));
+}
+
+#[test]
+fn a_handoff_naming_an_unknown_project_takes_the_catchall() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let h = crud::build_iri(&ns(), "handoff", "2026-09-05-nobody");
+    insert(cwd, &format!("<{h}> rdf:type ops:Handoff ; ops:project \"no-such-project\" .\n"));
+
+    let out = migrate(cwd);
+    assert_eq!(domain_of(cwd, &h).as_deref(), Some(migrate::CATCHALL));
+    assert_eq!(out.by_arm.get(migrate::CATCHALL), Some(&1), "counted as a catchall, not hidden");
+}
+
+// ─── ruling 2: the document arms, and their order ───────────────────────────
+
+#[test]
+fn frontmatter_wins_when_it_names_a_domain_that_exists() {
+    let tmp = workspace_with(
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"notes\"]\nrules = [\"r\"]\n\n\
+         [[domain]]\nname = \"declared\"\nmode = \"triggered\"\nkeywords = []\nrules = [\"r\"]\n",
+    );
+    let cwd = tmp.path();
+    let d = plant_document(cwd, "notes/a.md", "domain: declared\n");
+
+    let out = migrate(cwd);
+    assert_eq!(
+        domain_of(cwd, &d).as_deref(),
+        Some("declared"),
+        "frontmatter is the first arm, ahead of the path trigger that also matches"
+    );
+    assert_eq!(out.by_arm.get("frontmatter"), Some(&1));
+}
+
+#[test]
+fn frontmatter_naming_a_domain_that_does_not_exist_falls_through() {
+    // "Never invent a domain record" — a typo in a doc's frontmatter must not
+    // create a domain, and must not stop the next arm working.
+    let tmp = workspace_with(
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"notes\"]\nrules = [\"r\"]\n",
+    );
+    let cwd = tmp.path();
+    let d = plant_document(cwd, "notes/a.md", "domain: not-a-real-domain\n");
+
+    migrate(cwd);
+    assert_eq!(domain_of(cwd, &d).as_deref(), Some("probe"), "falls through to the path trigger");
+    let raw = std::fs::read_to_string(cwd.join(".base").join("graph.nq")).unwrap();
+    assert!(!raw.contains("domain/not-a-real-domain"), "and invents nothing");
+}
+
+#[test]
+fn a_path_trigger_files_a_document_with_no_frontmatter_domain() {
+    let tmp = workspace_with(
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"Documents/video-gen\"]\nrules = [\"r\"]\n",
+    );
+    let cwd = tmp.path();
+    let hit = plant_document(cwd, "Documents/video-gen/a.md", "title: A\n");
+    let miss = plant_document(cwd, "Documents/elsewhere/b.md", "title: B\n");
+
+    let out = migrate(cwd);
+    assert_eq!(domain_of(cwd, &hit).as_deref(), Some("probe"));
+    assert_eq!(domain_of(cwd, &miss).as_deref(), Some(migrate::CATCHALL));
+    assert_eq!(out.by_arm.get("path-trigger"), Some(&1));
+    assert_eq!(out.by_arm.get(migrate::CATCHALL), Some(&1));
+}
+
+#[test]
+fn the_longest_path_trigger_wins_and_a_tie_is_deterministic() {
+    // Chris's workspace declares `tools` twice — skyrim-companion and
+    // asset-inventory — so something must decide it, and decide it the same way
+    // on every run. Longest trigger first; a tie keeps `load_domains` order.
+    let tmp = workspace_with(
+        "[[domain]]\nname = \"broad\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"tools\"]\nrules = [\"r\"]\n\n\
+         [[domain]]\nname = \"narrow\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"tools/stt\"]\nrules = [\"r\"]\n\n\
+         [[domain]]\nname = \"alsobroad\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"tools\"]\nrules = [\"r\"]\n",
+    );
+    let cwd = tmp.path();
+    let deep = plant_document(cwd, "tools/stt/a.md", "title: A\n");
+    let shallow = plant_document(cwd, "tools/other/b.md", "title: B\n");
+
+    migrate(cwd);
+    assert_eq!(domain_of(cwd, &deep).as_deref(), Some("narrow"), "longest trigger wins");
+    let tie = domain_of(cwd, &shallow);
+    assert_eq!(tie.as_deref(), Some("broad"), "a tie keeps declaration order, first wins");
+
+    // Determinism: the same store migrated again from scratch agrees.
+    let tmp2 = workspace_with(
+        "[[domain]]\nname = \"broad\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"tools\"]\nrules = [\"r\"]\n\n\
+         [[domain]]\nname = \"narrow\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"tools/stt\"]\nrules = [\"r\"]\n\n\
+         [[domain]]\nname = \"alsobroad\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"tools\"]\nrules = [\"r\"]\n",
+    );
+    let cwd2 = tmp2.path();
+    let shallow2 = plant_document(cwd2, "tools/other/b.md", "title: B\n");
+    migrate(cwd2);
+    assert_eq!(domain_of(cwd2, &shallow2), tie, "two runs, same answer");
+}
+
+#[test]
+fn a_project_path_files_a_document_no_trigger_reached() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "renda", "probe", Some("Documents/Meet Caddy/Renda Group"));
+    let d = plant_document(cwd, "Documents/Meet Caddy/Renda Group/BRIEF.md", "title: Brief\n");
+
+    let out = migrate(cwd);
+    assert_eq!(domain_of(cwd, &d).as_deref(), Some("probe"));
+    assert_eq!(out.by_arm.get("project-path"), Some(&1));
+}
+
+#[test]
+fn a_project_whose_path_is_one_top_level_folder_claims_nothing() {
+    // `vintrix` has path "Documents" and `asset-inventory` has "tools" in Chris's
+    // store. Honouring those as prefixes files 377 unrelated documents under them.
+    let tmp = workspace();
+    let cwd = tmp.path();
+    plant_project(cwd, "vintrix", "probe", Some("Documents"));
+    let d = plant_document(cwd, "Documents/something-unrelated/x.md", "title: X\n");
+
+    let out = migrate(cwd);
+    assert_eq!(
+        domain_of(cwd, &d).as_deref(),
+        Some(migrate::CATCHALL),
+        "a bare top-level project path is mis-filing, not coverage: {out:?}"
+    );
+}
+
+// ─── the log ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_log_names_every_arm_including_the_catchall() {
+    let tmp = workspace_with(
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"notes\"]\nrules = [\"r\"]\n",
+    );
+    let cwd = tmp.path();
+    plant_document(cwd, "notes/a.md", "title: A\n");
+    plant_document(cwd, "elsewhere/b.md", "title: B\n");
+    insert(cwd, "<http://ops-sys.local/ontology#ext/lore/LoreFact/1> rdf:type ops:LoreFact .\n");
+
+    let out = migrate(cwd);
+    let line = migrate::format_outcomes(std::slice::from_ref(&out));
+    assert!(line.contains("by source:"), "{line}");
+    assert!(line.contains("path-trigger 1"), "{line}");
+    assert!(line.contains("fixed 1"), "{line}");
+    assert!(
+        line.contains(&format!("{} 1", migrate::CATCHALL)),
+        "the catchall is one arm among the others, never a silent remainder: {line}"
+    );
+    assert!(line.contains("by kind:"), "{line}");
+    assert_eq!(out.by_arm.values().sum::<usize>(), out.total_linked(), "arms account for every record");
+}
+
+#[test]
+fn a_record_carrying_two_covered_types_is_filed_once() {
+    // Legal RDF, absent from Chris's store today, and a double-file would double
+    // every number in the migration log — which is the operator's only view of
+    // what happened.
+    let tmp = workspace_with(
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = []\npaths = [\"notes\"]\nrules = [\"r\"]\n",
+    );
+    let cwd = tmp.path();
+    let d = plant_document(cwd, "notes/a.md", "title: A\n");
+    insert(cwd, &format!("<{d}> rdf:type ops:PaulPlan .\n"));
+
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 1, "one record, one assignment: {out:?}");
+    assert_eq!(out.by_arm.values().sum::<usize>(), 1);
+    assert_eq!(domain_of(cwd, &d).as_deref(), Some("probe"));
+}
+
+#[test]
+fn arm_labels_are_stable() {
+    // The migration log is the operator's only view of why a record landed where
+    // it did; renaming an arm silently changes what a past log meant.
+    assert_eq!(Arm::Frontmatter.label(), "frontmatter");
+    assert_eq!(Arm::PathTrigger.label(), "path-trigger");
+    assert_eq!(Arm::ProjectPath.label(), "project-path");
+    assert_eq!(Arm::Fixed.label(), "fixed");
+    assert_eq!(Arm::Parent.label(), "parent");
+    assert_eq!(Arm::Catchall.label(), migrate::CATCHALL);
+}

--- a/tests/migrate_sources_test.rs
+++ b/tests/migrate_sources_test.rs
@@ -60,7 +60,13 @@ fn insert(cwd: &Path, triples: &str) {
 }
 
 fn migrate(cwd: &Path) -> migrate::Outcome {
-    migrate::migrate_tier(&cwd.join(".base").join("graph.nq"), &graph_iri(cwd), &ns()).unwrap()
+    migrate::migrate_tier(
+        &cwd.join(".base").join("graph.nq"),
+        &graph_iri(cwd),
+        &ns(),
+        migrate::Trigger::SessionStart,
+    )
+    .unwrap()
 }
 
 /// The domain slug a record ended up with, read back off disk.

--- a/tests/migrate_sources_test.rs
+++ b/tests/migrate_sources_test.rs
@@ -419,6 +419,84 @@ fn a_record_carrying_two_covered_types_is_filed_once() {
 }
 
 #[test]
+fn a_domain_that_already_has_a_name_does_not_get_a_second_one() {
+    // A domain's DECLARED name need not equal its slug — `domains.toml` says
+    // `name = "Probe Domain"`, the IRI is `domain/probe-domain`. Writing the slug
+    // unconditionally therefore adds a SECOND `ops:name`, and a record with two
+    // names is one every reader answers about differently depending on which it
+    // binds. It happened twice on Chris's real store, to `content` and
+    // `development`.
+    let tmp = workspace_with(
+        "[[domain]]\nname = \"Probe Domain\"\nmode = \"triggered\"\nkeywords = []\nrules = [\"r\"]\n",
+    );
+    let cwd = tmp.path();
+    let dom = crud::build_iri(&ns(), "domain", "probe-domain");
+    assert_eq!(count_names(cwd, &dom), 1, "the fixture starts with exactly one name");
+    assert_eq!(
+        name_values(cwd, &dom),
+        vec!["Probe Domain".to_string()],
+        "and it is the DECLARED name, not the slug"
+    );
+
+    // Route a record at it so `ensure_domain` runs on an existing domain.
+    plant_project(cwd, "p", "probe-domain", None);
+    let t = crud::build_iri(&ns(), "task", "p.a-task");
+    insert(cwd, &format!("<{t}> rdf:type ops:Task ; ops:name \"a task\" .\n"));
+    insert(cwd, &format!("<{}> ops:hasTask <{t}> .\n", crud::build_iri(&ns(), "project", "p")));
+
+    let out = migrate(cwd);
+    assert_eq!(out.total_linked(), 1, "{out:?}");
+    assert_eq!(
+        name_values(cwd, &dom),
+        vec!["Probe Domain".to_string()],
+        "still one name, still the declared one"
+    );
+
+    // A domain the migration DOES create is named once, from its slug.
+    let unfiled = crud::build_iri(&ns(), "domain", migrate::CATCHALL);
+    assert_eq!(count_names(cwd, &unfiled), 0, "nothing needed the catchall here");
+    let g = crud::build_iri(&ns(), "goal", "g0");
+    insert(cwd, &format!("<{g}> rdf:type ops:Goal ; ops:name \"g0\" .\n"));
+    let iri = graph_iri(cwd);
+    crud::load_and_mutate(
+        cwd,
+        &ns(),
+        &format!("DELETE WHERE {{ GRAPH <{iri}> {{ <{iri}> ops:schemaVersion ?v }} }}"),
+    )
+    .unwrap();
+    migrate(cwd);
+    assert_eq!(name_values(cwd, &unfiled), vec![migrate::CATCHALL.to_string()]);
+}
+
+/// The `ops:name` literals a record carries, sorted.
+fn name_values(cwd: &Path, iri: &str) -> Vec<String> {
+    let q = format!("SELECT ?n WHERE {{ GRAPH ?g {{ <{iri}> ops:name ?n }} }}");
+    let oxigraph::sparql::QueryResults::Solutions(sols) =
+        crud::load_and_query(cwd, &ns(), &q).unwrap()
+    else {
+        return Vec::new();
+    };
+    let mut v: Vec<String> = sols
+        .filter_map(|r| r.ok())
+        .filter_map(|row| match row.get("n")? {
+            oxigraph::model::Term::Literal(l) => Some(l.value().to_string()),
+            _ => None,
+        })
+        .collect();
+    v.sort();
+    v
+}
+
+/// How many `ops:name` literals a record carries.
+fn count_names(cwd: &Path, iri: &str) -> usize {
+    let q = format!("SELECT ?n WHERE {{ GRAPH ?g {{ <{iri}> ops:name ?n }} }}");
+    match crud::load_and_query(cwd, &ns(), &q).unwrap() {
+        oxigraph::sparql::QueryResults::Solutions(s) => s.filter_map(|r| r.ok()).count(),
+        _ => 0,
+    }
+}
+
+#[test]
 fn arm_labels_are_stable() {
     // The migration log is the operator's only view of why a record landed where
     // it did; renaming an arm silently changes what a past log meant.

--- a/tests/transient_kinds_test.rs
+++ b/tests/transient_kinds_test.rs
@@ -1,0 +1,291 @@
+//! One list, four readers.
+//!
+//! Chris's ruling 4 (2026-09-06): relay pings are excluded from analyze AND from
+//! every other read surface by ONE shared rule — *"make sure the tool as a whole is
+//! built to exclude pings in the same way"*. So the thing worth testing is not that
+//! `graph analyze` happens to skip pings; it is that **every** reader consults
+//! `ontology::transient::TRANSIENT_KINDS`, and that adding a kind to that list is
+//! all it takes.
+//!
+//! Each test below plants a fixture record that WOULD match the reader's query on
+//! every count except its transient class, and asserts the reader drops it. Where a
+//! reader's query is class-constrained today (the note reads, the domain
+//! neighbourhood), the fixture carries both classes — that is contrived data on
+//! purpose: it is the minimal record that makes a `FILTER NOT EXISTS` load-bearing,
+//! so a future widening of those queries cannot leak pings without failing here.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use base::config::{BaseConfig, NamespaceConfig};
+use base::crud;
+use base::ontology::transient;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+/// A workspace with one domain (`probe`) synced into the graph.
+fn workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let base_dir = tmp.path().join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    std::fs::write(base_dir.join("graph.nq"), "").unwrap();
+    std::fs::write(
+        base_dir.join("base.toml"),
+        "[namespace]\nprefix = \"ops\"\nuri = \"http://ops-sys.local/ontology#\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        base_dir.join("domains.toml"),
+        "[[domain]]\nname = \"probe\"\nmode = \"triggered\"\nkeywords = [\"probe\"]\nrules = [\"a probe rule\"]\n",
+    )
+    .unwrap();
+    let config = BaseConfig::load(tmp.path());
+    base::domain::sync::sync_domains_to_graph(&config, tmp.path(), None).unwrap();
+    tmp
+}
+
+fn graph_iri(cwd: &Path) -> String {
+    crud::workspace_graph_iri(&ns(), &crud::workspace_slug(cwd))
+}
+
+fn insert(cwd: &Path, triples: &str) {
+    let sparql = format!("INSERT DATA {{ GRAPH <{}> {{\n{triples}\n}} }}", graph_iri(cwd));
+    crud::load_and_mutate(cwd, &ns(), &sparql).unwrap();
+}
+
+/// The IRI of the fixture ping, as `crud::build_iri` writes one.
+fn ping_iri() -> String {
+    crud::build_iri(&ns(), "ping", "lark-transient-probe")
+}
+
+fn domain_iri() -> String {
+    crud::build_iri(&ns(), "domain", "probe")
+}
+
+// ── the list itself ──────────────────────────────────────────────────────────
+
+#[test]
+fn the_list_names_ping_and_is_the_only_place_that_does() {
+    assert!(
+        transient::TRANSIENT_KINDS.iter().any(|k| k.class == "Ping" && k.iri_kind == "ping"),
+        "ruling 4: relay pings are transient"
+    );
+}
+
+// ── reader 1: graph_query::load_graph — every `base graph` command ───────────
+
+#[test]
+fn load_graph_drops_a_ping_node_and_its_edges() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let p = &ns().prefix;
+    let ping = ping_iri();
+    let dom = domain_iri();
+
+    // A ping exactly as `relay/task_inbox.rs` writes one, plus an IRI-object edge
+    // it does not carry today — so this proves the edge guard, not just the node
+    // guard, and stays honest if a future ping ever links to a record.
+    insert(
+        cwd,
+        &format!(
+            "<{ping}> rdf:type {p}:Ping ;\n\
+               {p}:name \"lark transient probe\" ;\n\
+               {p}:message \"lark transient probe\" ;\n\
+               {p}:relatedTo <{dom}> .\n"
+        ),
+    );
+
+    let (nodes, adj) = base::graph_query::load_graph(cwd, &ns(), false).unwrap();
+
+    let ping_key = format!("<{ping}>");
+    assert!(
+        !nodes.contains_key(&ping_key),
+        "a Ping must not be a node in the analysed graph — got {:?}",
+        nodes.keys().collect::<Vec<_>>()
+    );
+    assert!(!adj.contains_key(&ping_key), "a Ping must have no adjacency");
+    assert!(
+        !adj.get(&format!("<{dom}>")).is_some_and(|v| v.iter().any(|(b, _)| b == &ping_key)),
+        "the domain must not gain a neighbour that is a Ping"
+    );
+    // The control: a non-transient record on the same edge shape still loads.
+    assert!(
+        nodes.keys().any(|k| k.contains("#domain/probe")),
+        "the domain itself must still be a node"
+    );
+}
+
+#[test]
+fn load_graph_keeps_a_note_whose_slug_merely_contains_ping() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    crud::note::learn(cwd, &ns(), "ping hub latency is the thing to watch", "insight", Some("probe"), None, None)
+        .unwrap();
+
+    let (nodes, _) = base::graph_query::load_graph(cwd, &ns(), false).unwrap();
+    assert!(
+        nodes.keys().any(|k| k.contains("#note/ping-hub-latency")),
+        "exclusion is by kind segment, never by substring — got {:?}",
+        nodes.keys().collect::<Vec<_>>()
+    );
+}
+
+// ── reader 2: domain::query::query_domain_from_graph — prompt-time injection ─
+
+#[test]
+fn domain_injection_drops_a_transient_neighbour() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let p = &ns().prefix;
+    let ping = ping_iri();
+    let dom = domain_iri();
+
+    // Dual-typed on purpose (see the module comment): a record that satisfies the
+    // neighbourhood query's Project arm in every respect except being a Ping.
+    insert(
+        cwd,
+        &format!(
+            "<{ping}> rdf:type {p}:Ping ;\n\
+               rdf:type {p}:Project ;\n\
+               {p}:name \"lark transient probe\" ;\n\
+               {p}:hasDomain <{dom}> .\n"
+        ),
+    );
+    // The control: a real project on the same edge.
+    let real = crud::build_iri(&ns(), "project", "real-probe-project");
+    insert(
+        cwd,
+        &format!(
+            "<{real}> rdf:type {p}:Project ;\n\
+               {p}:name \"real probe project\" ;\n\
+               {p}:hasDomain <{dom}> .\n"
+        ),
+    );
+
+    let config = BaseConfig::load(cwd);
+    let store = base::store::load_graph(&cwd.join(".base").join("graph.nq")).unwrap();
+    let def = base::domain::load_domains(cwd).into_iter().find(|d| d.name == "probe").unwrap();
+    let (_rules, neighbourhood) = base::domain::query::query_domain_from_graph(&store, &config, &def);
+
+    assert!(
+        neighbourhood.contains("real probe project"),
+        "the control must still inject — got {neighbourhood:?}"
+    );
+    assert!(
+        !neighbourhood.contains("lark transient probe"),
+        "a Ping must never reach prompt-time injection — got {neighbourhood:?}"
+    );
+}
+
+// ── reader 3: crud::note recall reads ────────────────────────────────────────
+
+#[test]
+fn recall_by_domain_drops_a_transient_note() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let p = &ns().prefix;
+    let ping = ping_iri();
+    let dom = domain_iri();
+
+    crud::note::learn(cwd, &ns(), "a real note in probe", "insight", Some("probe"), None, None).unwrap();
+    // Dual-typed: satisfies the note read in every respect except being a Ping.
+    insert(
+        cwd,
+        &format!(
+            "<{ping}> rdf:type {p}:Ping ;\n\
+               rdf:type {p}:Note ;\n\
+               {p}:noteText \"lark transient probe\" ;\n\
+               {p}:noteType \"insight\" ;\n\
+               {p}:status \"active\" ;\n\
+               {p}:relatedTo <{dom}> .\n"
+        ),
+    );
+
+    let by_domain = crud::note::recall_to_string(cwd, &ns(), None, Some("probe"));
+    assert!(by_domain.contains("a real note in probe"), "the control must still recall — got {by_domain:?}");
+    assert!(
+        !by_domain.contains("lark transient probe"),
+        "`recall --domain` must drop a Ping — got {by_domain:?}"
+    );
+
+    let by_both = crud::note::recall_to_string(cwd, &ns(), Some("probe"), Some("probe"));
+    assert!(
+        !by_both.contains("lark transient probe"),
+        "`recall --keyword --domain` must drop a Ping too — got {by_both:?}"
+    );
+
+    let iris = crud::note::recalled_note_iris(cwd, &ns(), None, Some("probe"));
+    assert!(
+        !iris.iter().any(|i| i.contains("#ping/")),
+        "the lastRead stamp must never touch a Ping — got {iris:?}"
+    );
+    assert!(iris.iter().any(|i| i.contains("#note/")), "the control note is still stamped");
+}
+
+// ── reader 4: dashboard::api nodes + edges ───────────────────────────────────
+
+/// The dashboard handlers are `async fn` with no `.await` inside, so one poll
+/// completes them. Done by hand rather than pulling tokio into dev-dependencies
+/// for two calls.
+fn poll_once<F: std::future::Future>(fut: F) -> F::Output {
+    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    unsafe fn clone(_: *const ()) -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    unsafe fn noop(_: *const ()) {}
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+    let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = Box::pin(fut);
+    match fut.as_mut().poll(&mut cx) {
+        Poll::Ready(v) => v,
+        Poll::Pending => panic!("dashboard handler awaited something — this harness cannot drive it"),
+    }
+}
+
+#[test]
+fn dashboard_graph_view_drops_ping_nodes_and_edges() {
+    let tmp = workspace();
+    let cwd = tmp.path();
+    let p = &ns().prefix;
+    let ping = ping_iri();
+    let dom = domain_iri();
+
+    insert(
+        cwd,
+        &format!(
+            "<{ping}> rdf:type {p}:Ping ;\n\
+               {p}:name \"lark transient probe\" ;\n\
+               {p}:relatedTo <{dom}> .\n"
+        ),
+    );
+    crud::note::learn(cwd, &ns(), "a real note in probe", "insight", Some("probe"), None, None).unwrap();
+
+    let trig_path = cwd.join(".base").join("graph.nq");
+    let state = std::sync::Arc::new(base::dashboard::server::AppState {
+        store: Mutex::new(base::store::load_graph(&trig_path).unwrap()),
+        config: BaseConfig::load(cwd),
+        cwd: cwd.to_path_buf(),
+        trig_path,
+    });
+
+    let nodes = poll_once(base::dashboard::api::nodes(axum::extract::State(state.clone()))).0;
+    assert!(
+        !nodes.iter().any(|n| n.iri.contains("#ping/")),
+        "the dashboard must not render a Ping node — got {:?}",
+        nodes.iter().map(|n| n.iri.as_str()).collect::<Vec<_>>()
+    );
+    assert!(nodes.iter().any(|n| n.iri.contains("#note/")), "the control note still renders");
+
+    let edges = poll_once(base::dashboard::api::edges(axum::extract::State(state))).0;
+    assert!(
+        !edges.iter().any(|e| e.source.contains("#ping/") || e.target.contains("#ping/")),
+        "the dashboard must not render an edge touching a Ping"
+    );
+    assert!(
+        edges.iter().any(|e| e.source.contains("#note/") && e.target.contains("#domain/probe")),
+        "the control note→domain edge still renders"
+    );
+}

--- a/tests/transient_kinds_test.rs
+++ b/tests/transient_kinds_test.rs
@@ -216,6 +216,18 @@ fn recall_by_domain_drops_a_transient_note() {
         "`recall --keyword --domain` must drop a Ping too — got {by_both:?}"
     );
 
+    // `recall --keyword` with no `--domain` is a DIFFERENT query — five UNION arms
+    // over Note, Decision, FileChange and AcceptanceCriteriaResult — and it
+    // consulted the list nowhere (kite F16). "Four readers, one list" was true of
+    // `recall --domain` and false of the surface right beside it.
+    let by_keyword = crud::note::recall_to_string(cwd, &ns(), Some("transient"), None);
+    assert!(
+        !by_keyword.contains("lark transient probe"),
+        "`recall --keyword` must drop a Ping too — got {by_keyword:?}"
+    );
+    let control = crud::note::recall_to_string(cwd, &ns(), Some("real note"), None);
+    assert!(control.contains("a real note in probe"), "the control still recalls: {control:?}");
+
     let iris = crud::note::recalled_note_iris(cwd, &ns(), None, Some("probe"));
     assert!(
         !iris.iter().any(|i| i.contains("#ping/")),


### PR DESCRIPTION
Every record carries a domain link, migrated safely for existing users.

Fork: `~/.base-gbl/forks/base-domain-normalisation.md` (G0 verdict + BUILD RECORD).
Built in the order that verdict gives; a commit per step.

## What lands

- **One `TRANSIENT_KINDS` list, four readers.** Relay pings are excluded from
  `graph_query::load_graph`, prompt-time domain injection, the `crud::note` recall
  reads and the dashboard's node/edge queries by one constant, not four filters.
  5,012 of the global tier's typed records are pings; left in, they are what every
  community and count is about.
- **`hasDomain` is the domain link, and every read sees both eras.** 0.14.0 writes
  both predicates and reads both; N+1 stops writing `relatedTo`, N+2 drops it. The
  five hardcoded `relatedTo <domain>` reads in `crud/note.rs` become
  `domain::link::links_to` — flipping the write without them is how `base recall
  --domain` goes silently empty.
- **A one-time, idempotent migration**, run from session start per tier, with the
  schema stamp written **inside the same `write_back` as the data**.
- **Backfill sources per family**, with every arm counted in the log so `unfiled`
  is a visible decision and never a silent remainder.
- **`base doctor` reports** each tier's `schema:` and `without a domain: N`.
- **`base graph migrate [--dry-run]`** as the operator's manual trigger.

## Two design decisions, each shown failing first

**The stamp must live in the graph, not in a file.** Building the rejected design
and running the suite against it:

```
LARK_SENTINEL=1 cargo test --test migrate_domain_test
  a_restored_pre_migration_backup_re_migrates     FAILED
     already_migrated: true, linked: {} — on a store whose links the restore removed
  the_stamp_and_the_data_land_in_the_same_write   FAILED
  without_the_stamp_a_re_run_finds_nothing_to_do  FAILED
in-graph stamp restored: 13 passed, 0 failed
```

A file sentinel passes "migrates once" and fails "a restore re-migrates" —
silently, forever.

**The four readers really do consult one list.** With the seam neutered, all four
leak a fixture ping (dashboard renders the node, `recall --domain` returns it,
injection lists it as a Project, `load_graph` keeps it); restored, 6/6 green.

## What the real store said that the spec did not

Probed on a read-only copy before writing any resolver:

- **The orphan test was subject-side only.** `crud/decision.rs:47` writes
  `<domain> ops:hasDecision <decision>` — the domain is the subject — and
  `domain sync` writes `hasRule` the same way. A subject-side test reads all 420
  decisions and 79 rules as orphans and files them under `unfiled` on top of the
  domain they already have. `link::domain_index` now reads both directions.
- **Every PAUL parent link is reverse, and `fromPlan` is a literal** (`"01-01"`),
  so it cannot be walked at all. The real edges are `<plan> hasAC <ac>`,
  `<summary> hasACResult|hasFileChange|hasDecision`, `<project> hasTask`.
- **Ruling 2's "registered workspace's project domain" has no data behind it** —
  zero `[[workspace]]` entries in `~/.base-gbl/base.toml`, zero `ops:Workspace`
  records. Of 1,372 doc-like records: frontmatter resolves 8, a `domains.toml`
  path trigger 510, a project path prefix 92. Escalated rather than guessed; the
  path-trigger arm was added on that measurement.

## Fixed in passing

- `recall --keyword X --domain Y` returned a matching note twice — the two UNION
  arms have never been disjoint or deduped. Pre-existing in 0.13.x.
- No `ORDER BY` on any recall branch, so results followed store order and any
  rewrite reshuffled them. Found by the acceptance line itself: the same 80 rows
  before and after, in a different order. `load_graph` already sorts its adjacency
  for this reason; these reads never did.
- `dashboard/api.rs`'s two hardcoded edge allowlists omitted `hasDomain`, so the
  graph view has never drawn the project→domain edges.
- Doctor's orphan count ran one SPARQL per covered class: 11.2s → 0.06s as one
  typed-subject scan. That path is session-start on a 13.4 MB store.

## Real-store acceptance (copies only; live stores never written)

```
workspace  4323 linked in 11.2s   fixed 1434 · path-trigger 505 · parent 925
                                  · frontmatter 6 · unfiled 1453
global      184 linked            parent 9 · unfiled 175
second run                        byte-identical, "nothing to migrate"
doctor                            "not migrated" → "schema: domain-1", both tiers
recall --domain base              80 rows, BYTE-IDENTICAL before/after
recall --domain skyrim-companion  73 rows, BYTE-IDENTICAL before/after
.bak restore + re-open            re-migrated, identical counts, did not skip
C10 kit (v0.12.0, 105 back)       read AND wrote the migrated store, HEALTHY both
                                  times, stamp and all 4380 links preserved
LOGOS export on the migrated copy   see the correction below
```

## Correction to an earlier version of this description

It claimed the LOGOS export showed *"0 nodes lost, 0 edges lost, +1875 edges"*.
The edge half was an artifact of the diff, not a fact about the graph, and the
review held on it — correctly.

LOGOS edge objects are `{s, t, rel}` where `s` and `t` are INTEGER INDICES into
the nodes array. The diff keyed on `e.get("source")`, which is always `None`, so
10,632 edges collapsed into 11 per-relation buckets and "0 lost" measured nothing.

Keyed correctly, on `(node id, node id, rel)` with indices resolved per file:

```
edges before 10632, after 12507
LOST 3590    domain 3229, related 349, references 12
GAINED 5465  domain 5104, related 349, references 12
```

Every lost edge is one LOGOS *derives*. It scopes a record by an explicit domain
edge first, then slug prefix, then nearest scoped neighbour, and draws a `domain`
edge from that decision — so explicit links make the inference defer, and 3,229
inferred edges re-point. `related` is 349 lost and 349 gained: the same edges
moved, not removed.

**The test that decides "additive" is at the quad level, and it is clean.**
Pre-migration snapshot against the migrated store, compared as line sets:

```
workspace  pre 60340 / post 64670   in PRE but not POST: 0   gained 4330
           = 4323 hasDomain + 4 ops:name + 2 rdf:type + 1 schemaVersion
global     pre 46967 / post 47154   in PRE but not POST: 0   gained  187
           = 184 hasDomain + 1 ops:name + 1 rdf:type + 1 schemaVersion
```

Zero loss on both tiers, every gain itemised.

**Standing claim: the migration is additive at the quad level with zero data
loss; LOGOS's render re-points 3,229 inferred domain edges onto explicit ones and
its non-derived topology is identical.** Explicit beating inferred is the intended
outcome, not a regression.

The run still closes the SINGLE-SOURCE left on C11: `REL_FOLD`'s raw-name fallback
holds, measured rather than read.

Two more things this pass found, both fixed on the branch:

- `ensure_domain` wrote `ops:name` unconditionally, so a domain whose declared
  name differs from its slug ended up with TWO name literals — it happened to
  `domain/content` and `domain/development`. A record with two names is one every
  reader answers about differently depending on which it binds.
- The evidence harness re-copied from the LIVE store on every run. That store took
  245 writes that day and *shrank* mid-measurement, so two runs of identical code
  reported different arm splits. It is now pinned to one frozen snapshot, and
  anyone reproducing this evidence has to pin the same way.

## Verification

Rebased onto `main` (#49) with no conflicts. Two consecutive full suites: **44
binaries, 714 passed, 0 failed, 3 ignored**, plus `cargo clippy --all-targets --
-D warnings` clean.

## Not in this PR

- Ruling 2's write-path half. `src/extract/frontmatter.rs` has no `domain` key at
  all, so markdown sync has never written a domain link even when the file
  declared one. Held pending an operator ruling.
- N+1 (stop writing `relatedTo`) and N+2 (drop the triples).
- A guard on naming a community `unfiled` — noted in `base-analyze-demo-grade.md`.

https://claude.ai/code/session_01E2eHJ4Qk2BDq8QYjVfzhbK
