### PR TITLE
The paul ingest rewrote the whole store on every session start, and the cause was a duplicate scan

### DIFF
--- a/src/extract/paul_toml.rs
+++ b/src/extract/paul_toml.rs
@@ -103,7 +103,48 @@ pub fn scan_all_workspaces(config: &crate::config::BaseConfig) -> Vec<(PathBuf, 
         }
     }
 
-    results
+    // ONE PROJECT, ONE ENTRY. A `paul.toml` reachable by two paths was returned twice
+    // -- Chris's `My Documents` junction sitting beside `Documents` is the live case --
+    // and the ingest loop then ran twice for one IRI. The two passes overwrote each
+    // other's `path` quad, so `managed_quads` reported a REAL difference on both passes,
+    // both restamped `updatedAt`, `registered` counted two, and every session start
+    // rewrote the whole store to change two timestamps (F25).
+    //
+    // It left no trace in the delta because the second pass put `path` back where the
+    // first found it, so the store ended each session on the value it started with.
+    // That is why three separate whole-quad between-session diffs all reported "only
+    // `updatedAt` moved" and three hypotheses were aimed one level too high; only an
+    // in-process instrument could see the churn.
+    //
+    // Two shapes are dropped, and they are different defects. The same FILE reached by
+    // two paths is caught by `canonicalize`, which resolves the junction or symlink.
+    // Two DIFFERENT directories whose `paul.toml` declare the same name are caught by
+    // the slug, because the IRI is built from the name and one IRI is one project
+    // whatever the disk says. First hit wins; `workspace_roots` is ordered by config
+    // and then cwd, so the survivor is the same on every run of the same machine.
+    let mut seen_file = std::collections::HashSet::new();
+    let mut seen_slug = std::collections::HashSet::new();
+    let mut deduped: Vec<(PathBuf, PaulToml)> = Vec::with_capacity(results.len());
+    for (toml_path, paul) in results {
+        // A path that cannot be canonicalised (a race, a permission) falls back to
+        // itself rather than being dropped: an un-resolvable duplicate is a smaller
+        // problem than a project that silently stops being ingested.
+        let real = std::fs::canonicalize(&toml_path).unwrap_or_else(|_| toml_path.clone());
+        let slug = crud::slugify(&paul.name);
+        if !seen_file.insert(real) || !seen_slug.insert(slug) {
+            if config.devmode.enabled {
+                eprintln!(
+                    "[paul] duplicate of project '{}' ignored: {}",
+                    paul.name,
+                    toml_path.display()
+                );
+            }
+            continue;
+        }
+        deduped.push((toml_path, paul));
+    }
+
+    deduped
 }
 
 fn try_load_paul_toml(project_dir: &Path) -> Option<(PathBuf, PaulToml)> {
@@ -290,7 +331,8 @@ pub fn ingest_paul_projects(
         // store untouched, which is what keeps `migrate_tiers`' delta gate closed: the
         // old unconditional refresh moved the store's identity every session, re-opened
         // that gate, and bought a full re-plan that was then discarded (F25).
-        if managed_quads(&store, ns, &iri, &graph) != managed_before {
+        let managed_after = managed_quads(&store, ns, &iri, &graph);
+        if managed_after != managed_before {
             let touch = format!(
                 "{pfx}\n\
                  DELETE {{ GRAPH <{graph}> {{ <{iri}> {p}:updatedAt ?o }} }}\n\

--- a/src/extract/paul_toml.rs
+++ b/src/extract/paul_toml.rs
@@ -3,6 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use oxigraph::model::{GraphNameRef, NamedNodeRef, Quad};
+use oxigraph::store::Store;
+
 use crate::config::BaseConfig;
 use crate::changelog::Change;
 use crate::crud;
@@ -115,6 +118,29 @@ fn try_load_paul_toml(project_dir: &Path) -> Option<(PathBuf, PaulToml)> {
 
 // ─── Graph ingestion ────────────────────────────────────────
 
+/// Every quad the ingest manages for one project, `updatedAt` EXCLUDED.
+///
+/// `updatedAt` is left out on purpose: it is the field the ingest refuses to
+/// refresh when nothing else moved, so counting it would make every project look
+/// changed forever and defeat the whole guard. Scoped to the project's own home
+/// graph, which is the only graph this writer touches for that IRI.
+fn managed_quads(
+    store: &Store,
+    ns: &crate::config::NamespaceConfig,
+    iri: &str,
+    graph_iri: &str,
+) -> std::collections::HashSet<Quad> {
+    let (Ok(subject), Ok(graph)) = (NamedNodeRef::new(iri), NamedNodeRef::new(graph_iri)) else {
+        return std::collections::HashSet::new();
+    };
+    let updated_at = format!("{}updatedAt", ns.uri);
+    store
+        .quads_for_pattern(Some(subject.into()), None, None, Some(GraphNameRef::NamedNode(graph)))
+        .filter_map(|q| q.ok())
+        .filter(|q| q.predicate.as_str() != updated_at)
+        .collect()
+}
+
 pub struct IngestStats {
     pub scanned: usize,
     pub registered: usize,
@@ -184,8 +210,13 @@ pub fn ingest_paul_projects(
              WHERE {{ GRAPH <{graph}> {{ <{iri}> ?pp ?oo .\n\
                FILTER(?pp NOT IN (\
                  rdf:type, {p}:status, {p}:lastActive, {p}:deferredReason, \
-                 {p}:resurfaceAt, {p}:createdAt)) }} }}"
+                 {p}:resurfaceAt, {p}:createdAt, {p}:updatedAt)) }} }}"
         );
+        // F25: what the store already holds for this project, `updatedAt` excluded.
+        // Compared against the same set after the re-ingest, it decides whether this
+        // project really changed — and so whether the store is touched at all.
+        let managed_before = managed_quads(&store, ns, &iri, &graph);
+
         let _ = store.update(&delete);
 
         // Build milestone/phase/loop description
@@ -229,8 +260,7 @@ pub fn ingest_paul_projects(
              INSERT DATA {{\n\
                GRAPH <{graph}> {{\n\
                  <{iri}> rdf:type {p}:Project ;\n\
-                   {p}:name \"{}\" ;\n\
-                   {p}:updatedAt \"{now}\"^^xsd:dateTime .\n\
+                   {p}:name \"{}\" .\n\
              {extra_triples}\
                }}\n\
              }}",
@@ -254,10 +284,39 @@ pub fn ingest_paul_projects(
             escape(&paul.status),
         );
         let _ = store.update(&seed);
-        registered += 1;
+
+        // Only a project whose managed set actually moved gets a fresh `updatedAt`,
+        // and only such a project counts as ingested. An unchanged project leaves the
+        // store untouched, which is what keeps `migrate_tiers`' delta gate closed: the
+        // old unconditional refresh moved the store's identity every session, re-opened
+        // that gate, and bought a full re-plan that was then discarded (F25).
+        if managed_quads(&store, ns, &iri, &graph) != managed_before {
+            let touch = format!(
+                "{pfx}\n\
+                 DELETE {{ GRAPH <{graph}> {{ <{iri}> {p}:updatedAt ?o }} }}\n\
+                 WHERE {{ GRAPH <{graph}> {{ <{iri}> {p}:updatedAt ?o }} }};\n\
+                 INSERT DATA {{ GRAPH <{graph}> {{\n\
+                   <{iri}> {p}:updatedAt \"{now}\"^^xsd:dateTime .\n\
+                 }} }}"
+            );
+            let _ = store.update(&touch);
+            registered += 1;
+        }
     }
 
     let delta = crate::store::delta_since(&store, &[], before);
+
+    // F25: nothing moved, so do not rewrite the whole store to change nothing. The
+    // rewrite was unconditional, it moved the store's identity, and
+    // `changed_since_last_delta` (src/migrate.rs) therefore re-opened the delta gate on
+    // every single session. Measured on Chris's frozen copy: 18 session-starts, 18
+    // `extract.paul_toml` entries carrying the same 4 timestamp quads, 0
+    // `migrate.domain-1.delta` entries. This is the call site only; `write_back_inner`
+    // still writes whatever it is asked to write.
+    if delta.is_empty() {
+        return Ok(IngestStats { scanned: projects.len(), registered });
+    }
+
     let ops = delta.to_ops();
     crate::store::write_back(&store, &trig_path, Change::OpWithDelta("extract.paul_toml", &ops))?;
 

--- a/tests/paul_ingest_idempotent_test.rs
+++ b/tests/paul_ingest_idempotent_test.rs
@@ -1,0 +1,127 @@
+//! F25 — re-ingesting an unchanged `paul.toml` must not touch the store.
+//!
+//! The ingest used to refresh `updatedAt` on every scanned project and then call
+//! `write_back` unconditionally, so a 15 MB `graph.nq` was rewritten on every
+//! session start to change four timestamps. That moved the store's identity, which
+//! re-opened `migrate_tiers`' delta gate (`changed_since_last_delta` compares
+//! `len:mtime_nanos` against `.last-domain-delta`), which bought a full re-plan of
+//! the whole store that was then discarded because the plan was empty. Measured on
+//! Chris's frozen copy: 18 session-starts produced 18 `extract.paul_toml` changelog
+//! entries and 0 `migrate.domain-1.delta` entries.
+//!
+//! Both assertions below fail on the pre-fix ingest: the changelog grows on every
+//! call and the bytes differ every time.
+
+use std::fs;
+use std::path::Path;
+
+use base::config::{BaseConfig, NamespaceConfig, WorkspaceEntry};
+use base::extract::paul_toml::{ingest_paul_projects, scan_all_workspaces};
+
+fn workspace_with_project(root: &Path, milestone: Option<&str>) -> BaseConfig {
+    let ws = root.join("ws");
+    fs::create_dir_all(ws.join(".base")).unwrap();
+    fs::write(ws.join(".base").join("graph.nq"), "").unwrap();
+
+    let proj = ws.join("demo");
+    fs::create_dir_all(proj.join(".paul")).unwrap();
+    let mut toml = "name = \"Demo\"\nstatus = \"active\"\npath = \"demo\"\n".to_string();
+    if let Some(m) = milestone {
+        toml.push_str(&format!(
+            "\n[milestone]\nname = \"{m}\"\nversion = \"v1\"\nstatus = \"active\"\n"
+        ));
+    }
+    fs::write(proj.join(".paul").join("paul.toml"), toml).unwrap();
+
+    BaseConfig {
+        namespace: NamespaceConfig::default(),
+        workspace: vec![WorkspaceEntry { path: ws.to_string_lossy().into() }],
+        ..Default::default()
+    }
+}
+
+fn changelog_lines(ws: &Path) -> usize {
+    match fs::read_to_string(ws.join(".base").join("changes.jsonl")) {
+        Ok(s) => s.lines().filter(|l| !l.trim().is_empty()).count(),
+        Err(_) => 0,
+    }
+}
+
+fn ingest(config: &BaseConfig, ws: &Path) -> usize {
+    let projects = scan_all_workspaces(config);
+    assert!(!projects.is_empty(), "the scan must find the project");
+    ingest_paul_projects(ws, config, &projects).unwrap().registered
+}
+
+#[test]
+fn a_second_ingest_of_an_unchanged_paul_toml_touches_nothing() {
+    let root = tempfile::tempdir().unwrap();
+    let config = workspace_with_project(root.path(), None);
+    let ws = root.path().join("ws");
+    let graph = ws.join(".base").join("graph.nq");
+
+    // First ingest: the project is new, so it is written and counted.
+    assert_eq!(ingest(&config, &ws), 1, "a new project is ingested");
+    let after_first = fs::read(&graph).unwrap();
+    let log_after_first = changelog_lines(&ws);
+    assert!(!after_first.is_empty(), "the first ingest writes the project");
+    assert_eq!(log_after_first, 1, "one changelog entry for the first ingest");
+
+    // Second ingest, nothing changed on disk. Not one byte may move, and the
+    // changelog must not gain an entry — a no-op write is still a write.
+    assert_eq!(ingest(&config, &ws), 0, "an unchanged project is not re-ingested");
+    assert_eq!(
+        fs::read(&graph).unwrap(),
+        after_first,
+        "graph.nq must be byte-identical after a no-op ingest"
+    );
+    assert_eq!(
+        changelog_lines(&ws),
+        log_after_first,
+        "a no-op ingest must not append a changelog entry"
+    );
+
+    // A third, also unchanged: the guard must hold across repeats, not just once.
+    assert_eq!(ingest(&config, &ws), 0);
+    assert_eq!(fs::read(&graph).unwrap(), after_first);
+    assert_eq!(changelog_lines(&ws), log_after_first);
+}
+
+#[test]
+fn a_changed_paul_toml_is_still_ingested_and_restamped() {
+    let root = tempfile::tempdir().unwrap();
+    let config = workspace_with_project(root.path(), None);
+    let ws = root.path().join("ws");
+    let graph = ws.join(".base").join("graph.nq");
+
+    assert_eq!(ingest(&config, &ws), 1);
+    let before = fs::read_to_string(&graph).unwrap();
+    let log_before = changelog_lines(&ws);
+    let updated_before = updated_at(&before);
+
+    // Add a milestone: a real change, so the store moves and `updatedAt` is
+    // restamped. The guard must not have turned the ingest into a no-op writer.
+    let proj = ws.join("demo");
+    fs::write(
+        proj.join(".paul").join("paul.toml"),
+        "name = \"Demo\"\nstatus = \"active\"\npath = \"demo\"\n\
+         \n[milestone]\nname = \"Ship\"\nversion = \"v1\"\nstatus = \"active\"\n",
+    )
+    .unwrap();
+
+    assert_eq!(ingest(&config, &ws), 1, "a changed project is re-ingested");
+    let after = fs::read_to_string(&graph).unwrap();
+    assert_ne!(after, before, "a real change must reach the store");
+    assert!(after.contains("Milestone: Ship"), "the new milestone is in the store");
+    assert_eq!(changelog_lines(&ws), log_before + 1, "one entry for one real change");
+    assert_ne!(updated_at(&after), updated_before, "a real change restamps updatedAt");
+}
+
+/// The `updatedAt` literal for `project/demo`, or empty when absent.
+fn updated_at(graph: &str) -> String {
+    graph
+        .lines()
+        .find(|l| l.contains("project/demo>") && l.contains("updatedAt>"))
+        .unwrap_or_default()
+        .to_string()
+}

--- a/tests/paul_ingest_idempotent_test.rs
+++ b/tests/paul_ingest_idempotent_test.rs
@@ -87,6 +87,55 @@ fn a_second_ingest_of_an_unchanged_paul_toml_touches_nothing() {
     assert_eq!(changelog_lines(&ws), log_after_first);
 }
 
+/// F25's actual cause, found 2026-09-07 with the in-process instrument.
+///
+/// Chris's `My Documents` junction sits beside `Documents`, so `scan_all_workspaces`
+/// returned the same `paul.toml` twice under two paths. The ingest loop ran twice for
+/// one IRI and the two passes overwrote each other's `path` quad, so the guard saw a
+/// real difference on BOTH passes, both restamped, and every session start rewrote the
+/// store. The second pass put `path` back where the first found it, which is why every
+/// between-session diff reported "only `updatedAt` moved" and the cause survived three
+/// refuted hypotheses.
+///
+/// unix-only because the reproduction needs a second path to one directory and creating
+/// one on Windows needs a privilege a test cannot assume. The defect is not unix-only.
+#[cfg(unix)]
+#[test]
+fn a_project_reachable_by_two_paths_is_ingested_once() {
+    let root = tempfile::tempdir().unwrap();
+    let config = workspace_with_project(root.path(), None);
+    let ws = root.path().join("ws");
+    // A second directory in the same workspace reaching the same project, exactly what
+    // the junction does on Chris's machine.
+    std::os::unix::fs::symlink(ws.join("demo"), ws.join("demo-link")).unwrap();
+
+    let projects = scan_all_workspaces(&config);
+    assert_eq!(
+        projects.len(),
+        1,
+        "one paul.toml was scanned twice: {:?}",
+        projects.iter().map(|(p, _)| p.display().to_string()).collect::<Vec<_>>()
+    );
+
+    let graph = ws.join(".base").join("graph.nq");
+    assert_eq!(ingest(&config, &ws), 1, "one project is one registration, not two");
+    let after_first = fs::read(&graph).unwrap();
+    let log_after_first = changelog_lines(&ws);
+
+    // The whole point: with the duplicate gone the second ingest is a no-op again.
+    assert_eq!(ingest(&config, &ws), 0, "the second ingest must touch nothing");
+    assert_eq!(
+        fs::read(&graph).unwrap(),
+        after_first,
+        "graph.nq moved on a no-op ingest of a duplicated project"
+    );
+    assert_eq!(
+        changelog_lines(&ws),
+        log_after_first,
+        "a no-op ingest appended a changelog entry"
+    );
+}
+
 #[test]
 fn a_changed_paul_toml_is_still_ingested_and_restamped() {
     let root = tempfile::tempdir().unwrap();
@@ -108,6 +157,14 @@ fn a_changed_paul_toml_is_still_ingested_and_restamped() {
          \n[milestone]\nname = \"Ship\"\nversion = \"v1\"\nstatus = \"active\"\n",
     )
     .unwrap();
+
+    // `updatedAt` is written at second resolution (`crud::now_iso` uses
+    // `SecondsFormat::Secs`) and this test runs in ~10 ms, so both ingests would
+    // otherwise stamp the SAME literal and the restamp assertion below would fail
+    // even though the restamp fired. Cross a real second boundary so the assertion
+    // measures the restamp and not the clock resolution; 1100 ms crosses at least
+    // one tick from any starting offset.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
 
     assert_eq!(ingest(&config, &ws), 1, "a changed project is re-ingested");
     let after = fs::read_to_string(&graph).unwrap();


### PR DESCRIPTION
# The paul ingest rewrote the whole store on every session start, and the cause was a duplicate scan

Fork: `C:/Users/Chris/.base-gbl/forks/base-f25-ingest-idempotence.md` (defect, three refuted hypotheses, the instrument run that named the field, and auk's ruling).

Measured on a frozen copy of Chris's store: **18 session starts, 18 `extract.paul_toml` changelog entries carrying the same four timestamp quads, 0 `migrate.domain-1.delta` entries.** Rewriting a 14 MB store to change two timestamps moves the store's identity, which re-opens `migrate_tiers`' delta gate (`changed_since_last_delta`), which buys a full re-plan that is then discarded because the plan is empty.

## The cause, and why it survived three hypotheses

`scan_all_workspaces` returned the same `paul.toml` **twice**, reached by two paths: Chris's `My Documents` junction sits beside `Documents`, and the walk descends both. One IRI, two `discovered_dir` values, so the ingest loop ran twice for one project and each pass overwrote the other's `path` quad.

`managed_quads` therefore saw a genuine difference on **both** passes, both restamped `updatedAt`, `registered` counted two, and `write_back` fired.

It left no trace in the delta because the second pass put `path` back where the first found it, so the store ended each session on the value it started with. That is why three separate whole-quad between-session diffs all reported "only `updatedAt` moved", and why the three hypotheses in the fork doc were all aimed a level too high. The churn is entirely inside one ingest; only an in-process instrument saw it.

Verbatim from that instrument, session 2, `project/grazer`:

```
F25 …project/grazer: before=12 after=12
  only-before: …path "/mnt/c/Users/Chris/My Documents/grazer"
  only-after:  …path "/mnt/c/Users/Chris/Documents/grazer"
F25 …project/grazer: before=12 after=12
  only-before: …path "/mnt/c/Users/Chris/Documents/grazer"
  only-after:  …path "/mnt/c/Users/Chris/My Documents/grazer"
```

The set size never moves. Only that one member does.

## What changed

**`1c453d9`** is the guard: `managed_quads` compares a project's own quads with `updatedAt` excluded, the DELETE preserves `updatedAt`, and only a project whose managed set actually moved gets a fresh stamp. The call site skips `write_back` when the delta is empty. That guard was correct all along and was reporting a real difference.

**`408790f`** fixes the scan, which is where the defect was. Two shapes are dropped, and they are different defects:

- the same **file** reached by two paths, caught by `fs::canonicalize`;
- two different **directories** whose `paul.toml` declare the same name, caught by the slug, because the IRI is built from the name and one IRI is one project whatever the disk says.

First hit wins, and the drop is logged once in devmode. A path that cannot be canonicalised falls back to itself rather than being dropped: an unresolvable duplicate is a smaller problem than a project that silently stops being ingested.

It also fixes a test that was measuring the clock. `crud::now_iso` is `SecondsFormat::Secs` and the test runs in ~10 ms, so both ingests stamped an identical literal and the restamp assertion failed even though the restamp had fired. It now crosses a real second boundary.

## Verification on `408790f`'s pre-rebase content (`f204f34`)

| leg | result |
|---|---|
| chain | **8/8 PASS** |
| binary provenance | md5 `3bc47ec2831e4132f5dfa33a951db037`, distinct from main `9e953cbd`; carries `managed_quads` |
| suite | 756 passed, 0 failed |
| clippy `--all-targets -D warnings` | exit 0 |
| acceptance leg 1 | `tests/paul_ingest_idempotent_test.rs`: a second and third ingest of an unchanged `paul.toml` register nothing, leave `graph.nq` byte-identical and append no changelog entry |
| acceptance leg 2, on the frozen copy | **PASS, for the first time** — no `extract.paul_toml` entry in session 2, and the delta marker equals the store identity, so the gate stays closed |
| acceptance leg 3 (0.20 s B-vs-A pairs) | **UNMEASURED, deliberately.** A timing leg needs a quiet box and other cargo lanes were live. It is gated behind `F25_TIMING=1` and prints "This is NOT a pass"; it runs on the release head, serial, with the other owed timing legs. |

Red-first, with the dedupe bypassed:

```
one paul.toml was scanned twice:
["/tmp/.tmpzHpU1R/ws/demo-link/.paul/paul.toml", "/tmp/.tmpzHpU1R/ws/demo/.paul/paul.toml"]
```

The suite number on the rebased head belongs to CI on this sha, not to the pre-rebase run above.

Harness: `~/.base-gbl/verification/base-0.14.0/shrike_f25_accept.sh`, driven by `shrike_chain.sh` with `BRANCH=f25`. It aborts rather than reports when the binary's md5 matches main's or `managed_quads` is absent, and the accept stage prints the script's own md5 beside the binary's.

https://claude.ai/code/session_01L1148BxNwL2Kp4SFFYUsJY