### PR TITLE
fix(verification): silent_no_ops_0142.sh could pass on a control it never read

### DIFF
--- a/verification/base-0.14.2/silent_no_ops_0142.sh
+++ b/verification/base-0.14.2/silent_no_ops_0142.sh
@@ -21,8 +21,23 @@ ok()      { pass=$((pass+1)); printf '  PASS  %s\n' "$1"; }
 bad()     { fail=$((fail+1)); printf '  FAIL  %s\n' "$1"; }
 skipped() { skip=$((skip+1)); printf '  SKIP  %s\n' "$1"; }
 
+# A tool that is ABSENT produces the same empty output as a binary that genuinely lacks the
+# symbol. Assert the tool first, or the diagnosis below blames the binary for the toolchain.
+need_tool() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "ABORT: '$1' is not on PATH. Its empty output is indistinguishable from a binary"
+        echo "       that lacks the symbol, so every provenance check below would be void."
+        exit 3
+    }
+}
+need_tool strings; need_tool md5sum
+
+# ONE trap, set ONCE, covering everything it must clean. `trap ... EXIT` does not accumulate:
+# a second one REPLACES the first. This script had two — the tempfile trap here and a WORK trap
+# further down — so the two symbol dumps leaked on every single run.
+WORK=$(mktemp -d)
 WORK_SYMS_NEW=$(mktemp); WORK_SYMS_OLD=$(mktemp)
-trap 'rm -f "$WORK_SYMS_NEW" "$WORK_SYMS_OLD"' EXIT
+trap 'rm -rf "$WORK"; rm -f "$WORK_SYMS_NEW" "$WORK_SYMS_OLD"' EXIT
 echo "═══ provenance ═══"
 for b in "$BASE_BIN" "$OLD_BIN"; do
     [ -x "$b" ] || { echo "ABORT: not executable: $b"; exit 2; }
@@ -38,8 +53,26 @@ fi
 # FAILED when it MATCHES: grep -q exits at the first hit, strings takes SIGPIPE, and
 # pipefail publishes that. This check therefore inverted and refused a correct binary
 # whose symbol the build had just counted twice. Dump once, grep the file.
-strings "$BASE_BIN" > "$WORK_SYMS_NEW" 2>/dev/null || true
-strings "$OLD_BIN"  > "$WORK_SYMS_OLD" 2>/dev/null || true
+# The `|| true` that used to sit on both of these lines swallowed the failure, and the swallow
+# was ONE-SIDED in effect. On the BRANCH an empty dump makes the check below find no symbol and
+# ABORT — closed. On the CONTROL an empty dump makes its check find no symbol and PASS, and the
+# script then prints "both binaries are what they claim". A CONTROL THAT WAS NEVER READ PASSED
+# THE CONTROL CHECK. Same shape as a missing baseline reading as zero differing files.
+dump_syms() { # dump_syms <binary> <outfile> <which>
+    if ! strings "$1" > "$2" 2>/dev/null; then
+        echo "ABORT: strings failed on the $3 binary ($1); its symbol dump is not evidence."; exit 3
+    fi
+    # An empty dump is not a result. Asserted on BOTH arms, because the control is the arm
+    # where emptiness reads as success.
+    [ -s "$2" ] || {
+        echo "ABORT: strings produced an EMPTY dump for the $3 binary ($1)."
+        echo "       Every symbol check below would be meaningless, and the CONTROL check"
+        echo "       would PASS on it — emptiness is indistinguishable from absence there."
+        exit 3
+    }
+}
+dump_syms "$BASE_BIN" "$WORK_SYMS_NEW" branch
+dump_syms "$OLD_BIN"  "$WORK_SYMS_OLD" control
 if ! grep -q "$SYMBOL" "$WORK_SYMS_NEW"; then
     echo "ABORT: branch binary has no '$SYMBOL' — it is not this branch's build."; exit 2
 fi
@@ -48,7 +81,7 @@ if grep -q "$SYMBOL" "$WORK_SYMS_OLD"; then
 fi
 echo "  symbol '$SYMBOL': present in branch, absent in control — both binaries are what they claim"
 
-WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+# WORK and its cleanup are established with the single trap at the top of this script.
 HOME_DIR="$WORK/home"; mkdir -p "$HOME_DIR/.base-gbl/.base"
 
 hook() { # hook <bin> <event> <cwd> <payload>
@@ -179,4 +212,15 @@ echo
 echo "═══════════════════════════════════════════"
 echo "  $pass PASS / $fail FAIL / $skip SKIP"
 echo "  branch $MD5_NEW   control $MD5_OLD"
-[ "$fail" -eq 0 ] || exit 1
+# The verdict used to read the FAIL counter alone, so a run in which every control arm SKIPPED
+# — the move nudge not firing, the #86 race not firing, #95 with REPO_DIR unset — exited 0 and
+# read as acceptance. A row that never ran is neither a pass nor a failure, and collapsing it
+# into either is how an instrument reports coverage it does not have. Three exits, three states.
+if [ "$fail" -ne 0 ]; then echo "  ACCEPTANCE FAIL — $fail failing row(s)"; exit 1; fi
+if [ "$skip" -ne 0 ]; then
+    echo "  ACCEPTANCE INCOMPLETE — $skip skipped row(s); a SKIP is not a PASS."
+    echo "  (set REPO_DIR to the branch worktree to run the #95 row here)"
+    exit 5
+fi
+echo "  ACCEPTANCE PASS"
+exit 0   # explicit: the last statement of this script is never a bare test again

--- a/verification/base-0.14.2/silent_no_ops_0142.sh
+++ b/verification/base-0.14.2/silent_no_ops_0142.sh
@@ -30,7 +30,10 @@ need_tool() {
         exit 3
     }
 }
-need_tool strings; need_tool md5sum
+# python3 too (shrike, #109 review): the #75 and #76 rows pipe into `python3 -c … 2>/dev/null` inside an
+# elif, so a MISSING python3 makes the condition silently false, the control falls through, and the row
+# reports FAIL against the PRODUCT — the same tool-absence misdiagnosis as strings, two rows further down.
+need_tool strings; need_tool md5sum; need_tool python3
 
 # ONE trap, set ONCE, covering everything it must clean. `trap ... EXIT` does not accumulate:
 # a second one REPLACES the first. This script had two — the tempfile trap here and a WORK trap


### PR DESCRIPTION
## The instrument could pass on a control it never read

Four defects in `verification/base-0.14.2/silent_no_ops_0142.sh` — the acceptance harness itself,
not the product. Each is demonstrated **failing** on the parent revision before being trusted.

**Rig: 11 PASS / 0 FAIL / 0 NOTE.** Every case runs the real script — parent copy and this copy —
against identical fixtures (stub `base` binaries, a stub `strings` on `PATH`). Neither script is
edited, so a mutant cannot die of a parse error. The rig lives at
`C:\Users\Chris\.cache\merlin-0142\gate\rig_instrument.sh`; upstreaming it is a follow-up.

| # | defect | parent | this PR |
|---|---|---|---|
| **a** | one-sided `strings` swallow | rc 0, *"both binaries are what they claim"* | rc 3, names the control |
| **a3** | control dump empty, `strings` exits 0 | rc 0, same false claim | rc 3, `EMPTY dump for the control binary` |
| **a2** | `strings` fails on the branch | rc 2, *"it is not this branch's build"* | rc 3, names the **tool** |
| **b** | `strings` absent from `PATH` | rc 2, blames the binary | rc 3, `'strings' is not on PATH` |
| **c** | SKIP never reached the exit code | `10 PASS / 0 FAIL / 2 SKIP` → **exit 0** | same fixtures → **exit 5 INCOMPLETE** |
| **d** | two `trap … EXIT` don't accumulate | leaves **2** files in a private `TMPDIR` | leaves **0** |

### (a) is the worst, and the open side is the control

Both dumps ended in `|| true`. The swallow is symmetric in the source and **one-sided in effect**:

- **branch** binary, empty dump → the symbol check finds nothing → **ABORT**. Fails closed.
- **control** binary, empty dump → its check finds nothing → **PASSES**, because "control lacks the
  symbol" is the success condition. The script then printed *"both binaries are what they claim"*.

**A control that was never read passed the control check.** That is the same family as a missing
baseline reading as zero differing files — this round's signature defect, one level in.

Both arms now go through `dump_syms()`, which asserts the exit status **and** that the dump is
non-empty, on both sides.

### (c) changes the default outcome, deliberately

With `REPO_DIR` unset the `#95` row skips, so a normal run now exits **5 INCOMPLETE** rather than 0.

The compatibility question has an empirical answer rather than a judgement one: code search across
`main` finds `silent_no_ops_0142` in **exactly one file — itself**, `REPO_DIR` in only this script
and an unrelated `src/install.rs`, and none of the three workflows reference it. **There are zero
automated callers**, so no caller changes behaviour. Set `REPO_DIR` to reach a clean pass.

### (d) measured, not argued

`trap … EXIT` does not accumulate — a second one replaces the first. The tempfile trap at the top was
replaced by the `WORK` trap further down, so both `mktemp` symbol dumps leaked on every completed
run. One trap now, set once, before anything it must clean.

The rig's first attempt at this case reported **UNPROVEN-HERE rather than a pass**, because it tested
an abort path that returns *before* the replacing trap — so nothing leaked and there was nothing to
have fixed. Fixed to use a full run in a private `TMPDIR`; the numbers above are from that.

## What I did not do

No build, no `cargo`, no product test execution — another lane holds the build box. This is a change
to a verification script only, exercised by its own rig with stub binaries. Both revisions
`bash -n` clean under Git Bash 5.2.37 and WSL 5.2.21.

---

https://claude.ai/code/session_01S6r6FPqdimm3BwCYRJeYBd
