### PR TITLE
The Windows lint gate: three cfg-dead items, and clippy becomes a required check (#97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,14 @@ jobs:
       # this runner is ubuntu — so the check reads `git check-attr`, not the checkout.
       - run: ./scripts/test-crlf-attributes.sh
 
-  # Advisory until the three pre-existing never_loop denies in src/crud are
-  # cleared; then drop continue-on-error and it becomes a required check.
+  # Required, not advisory. It was `continue-on-error: true` "until the three
+  # pre-existing never_loop denies in src/crud are cleared" -- they are: a
+  # repo-wide grep for never_loop matches zero lines, and the step itself has been
+  # `success` on main (run 34200195605, job clippy, step 5). An advisory lint job
+  # reports the RUN green whether the step passed or failed, which is how a real
+  # Windows failure sat on main unnoticed (#97, #108).
   clippy:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/scripts/build-base-windows.ps1
+++ b/scripts/build-base-windows.ps1
@@ -125,6 +125,28 @@ cargo not found. Install the Rust toolchain (MSVC ABI) and re-run:
 }
 Write-Ok ((cargo --version) -join '')
 
+# ── 3b. clippy ─ the lint gate this build cannot otherwise run ─────────────
+# clippy is NOT installed by default with the msvc toolchain, so a from-source
+# Windows build had no way to run base's own lint gate (#97). Reported, never
+# installed: this script's job is to produce a binary, and a missing lint
+# component is not a reason to refuse one.
+#
+# Asked of cargo rather than looked for on PATH. The component is per-toolchain,
+# and a cargo-clippy.exe belonging to a DIFFERENT toolchain on PATH is exactly
+# the state that made `clippy -D warnings` and `clippy` both exit non-zero and
+# read as a confirmed lint failure when the tool was simply absent.
+Write-Step "Checking clippy (lint gate)"
+$clippyVersion = $null
+try { $clippyVersion = (cargo clippy --version 2>$null) -join '' } catch { }
+if ($clippyVersion) {
+    Write-Ok $clippyVersion
+} else {
+    Write-Warn2 "clippy is not installed for this toolchain. The build below will still"
+    Write-Warn2 "work, but you cannot run base's lint gate. To install it:"
+    Write-Warn2 "  rustup component add clippy"
+    Write-Warn2 "Then: cargo clippy --all-targets -- -D warnings"
+}
+
 # ── 4. Build / install ─────────────────────────────────────────────────────
 if ($SkipInstall) {
     Write-Step "Building base (cargo build --release)"

--- a/src/doorbell.rs
+++ b/src/doorbell.rs
@@ -22,10 +22,18 @@
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
+// Unix only, like the constant it types: the Windows `poke` has no write
+// timeout to spend, so importing this there is dead too.
+#[cfg(unix)]
 use std::time::Duration;
 
 /// The longest base will spend telling the app. A write must never wait on a
 /// listener that has stopped reading.
+///
+/// Unix only. `set_write_timeout` is what enforces it, and the Windows `poke`
+/// below has no equivalent for a `File` — so on Windows there is no budget to
+/// declare rather than a budget that is declared and ignored.
+#[cfg(unix)]
 const BUDGET: Duration = Duration::from_millis(50);
 
 /// Where the app publishes the socket/pipe it is listening on — one line.
@@ -88,9 +96,9 @@ fn poke(addr: &str, payload: &str) -> std::io::Result<()> {
     // away rather than blocking, because blocking would require an explicit
     // WaitNamedPipe this deliberately does not call.
     //
-    // std exposes no write timeout for a File, so the BUDGET is not enforced on
-    // this side: the app's pipe server must read promptly. Documented rather
-    // than papered over with a thread that could outlive the process.
+    // std exposes no write timeout for a File, so the unix side's write budget has
+    // no equivalent here: the app's pipe server must read promptly. Documented
+    // rather than papered over with a thread that could outlive the process.
     let mut pipe = std::fs::OpenOptions::new().write(true).open(addr)?;
     pipe.write_all(payload.as_bytes())?;
     pipe.write_all(b"\n")

--- a/tests/ast_extractor_notices_test.rs
+++ b/tests/ast_extractor_notices_test.rs
@@ -12,7 +12,13 @@
 //! The stub extractor here writes notice lines and exits 0. The real python is
 //! not involved: this pins the plumbing, not the count.
 
+// Both consumers are `#[cfg(unix)]` — `stub_python` below and the one test that
+// spawns the binary — so on Windows these imports are dead and
+// `clippy --all-targets -- -D warnings` fails on them (#97). Gated with what
+// uses them rather than allowed, so the cfg story reads the same in both places.
+#[cfg(unix)]
 use std::path::Path;
+#[cfg(unix)]
 use std::process::Command;
 
 /// A fake `python3`/`python` earlier on PATH than the real one. It ignores its


### PR DESCRIPTION
Closes #97.

`cargo clippy --all-targets -- -D warnings` cannot pass on the
`stable-x86_64-pc-windows-msvc` toolchain, and CI cannot see it: the `clippy` job runs on
Linux, and it carried `continue-on-error: true`, so even a Linux failure reported the job as
`success`.

## The pair, on one toolchain and one tree

Both legs, every time (a gate whose *failing* state and whose *cannot-run* state share an exit
code is not a gate). Leg B is the control, and it is what makes leg A believable: a real
`dead_code` warning cannot fail permissive clippy, so `A=101, B=0` isolates the failure to the
`-D warnings` promotion and to nothing else. An earlier run of this same pair returned `rc 1` on
**both** legs, which looked like a confirmed failure and was a missing `cargo-clippy.exe`.

| | LEG A `-- -D warnings` | LEG B permissive | warning lines | `BUDGET` mentions |
|---|---|---|---|---|
| **before**, `main` @ `610636e8` | **101** | **0** | 6 | 2 |
| **after**, this branch @ `96ac2cf` | **0** | **0** | **0** | **0** |

`clippy 0.1.97 (8bab26f4f6 2026-07-14)`, `cargo 1.97.1`, MSVC 2022 BuildTools, dedicated
`CARGO_TARGET_DIR`, `git status --porcelain` empty on both sides.

**What leg B's zero actually proves, and what it does not.** It proves the fix did not
*relocate* the defect: gating the constant without its `Duration` import would have traded a
dead-const warning for an unused-import warning one line up, and leg B would have shown it.
That is a real trap and this pair catches it.

It does **not** separate *repaired* from *silenced*. `#[cfg_attr(windows, allow(dead_code))]`
suppresses the lint, so under that fix leg A exits 0, leg B exits 0, and the word `BUDGET`
appears zero times in both logs — **an output identical to this one, at every number in the
table**. No clippy leg can tell the two apart, because clippy is exactly what `allow` is
addressed to. The choice between them was made by reading the code, not by measuring it, and
the reasoning is in the section below rather than dressed up as a measurement it is not.

## Correction to #97: the issue's completeness claim is false as measured

#97 says the doorbell constant is *"the only one standing between this build and a clean
`-D warnings` run on Windows"*. **It is not.** There are **three** Windows-dead items, and
fixing the constant alone moves leg A from **101 to 101** with a different error:

```
src/doorbell.rs:29                      constant `BUDGET` is never used
tests/ast_extractor_notices_test.rs:15  unused import: `std::path::Path`
tests/ast_extractor_notices_test.rs:16  unused import: `std::process::Command`
```

**Why nobody saw the other two**, which is the part worth carrying:

1. **Leg A halts at the first error.** Its last line is `error: could not compile `base` (lib)
   due to 1 previous error`, so it never reaches the test targets at all. An instrument that
   stops on the first failure cannot enumerate what else is broken — the count it reports is a
   floor, never a total.
2. **The corroborating measurement used a different invocation than the gate.** #108's Windows
   comment is a `cargo build --release`, which compiles the **lib only** and reported *"one
   warning in the whole build"*. The gate runs `--all-targets`. A measurement taken under a
   different invocation than the gate uses is not a measurement of the gate.

Both are visible only in the **permissive** leg, which is the second thing the law-24 control
earns beyond telling a failure from an absent tool: it is the only leg that enumerates.

## The fix — one class, three instances

The class is *an unconditional item whose only consumers sit behind `#[cfg(unix)]`*:

- `BUDGET` (`doorbell.rs:29`) is read only at `:78`, inside `#[cfg(unix)] fn poke`.
- `Path` is used only at `:22`, inside `#[cfg(unix)] fn stub_python`.
- `Command` is used only at `:86`, inside a `#[cfg(unix)]` test.

Each moves under the same `cfg` as what uses it. **The `Duration` import moves with the constant
it types**: `grep -n Duration src/doorbell.rs` returns exactly two lines, the import and the
constant, so gating the constant alone would leave the import with no user and trade a
dead-const warning for an unused-import warning one line up — the same defect, relocated.

Rejected, and why. Both alternatives produce clippy output identical to this fix's, so this is a
reading, not a measurement, and is stated as one:

- `#[cfg_attr(windows, allow(dead_code))]` — one line shorter, and it **silences rather than
  repairs**. The constant stays in the Windows source, compiled and unread, and the next reader
  finds an `allow` where the code should have said which platform the value belongs to. `cfg`
  makes the source state the same thing the comment states; `allow` makes the source contradict
  it quietly.
- `#[expect(dead_code)]` — fires `unfulfilled_lint_expectation` on unix, where the constant is
  used. This one is measurable and it fails.

The Windows comment in `poke` no longer names `BUDGET`, because that symbol is not compiled on
the platform the comment describes.

## The gate itself

**`ci.yml` — `continue-on-error: true` is dropped from the `clippy` job.**

Its justification read *"Advisory until the three pre-existing `never_loop` denies in `src/crud`
are cleared"*. They are cleared: a repo-wide grep for `never_loop` matches **zero lines** at
`610636e8`. The comment described a state that no longer existed, so it goes with the flag
rather than being left to justify it forever.

Dropping it costs nothing today, read at **step** level rather than assumed — CI run
[34200195605](https://github.com/ChristopherKahler/base/actions/runs/34200195605), job `clippy`,
step 5 `cargo clippy --all-targets -- -D warnings`, `conclusion: success`. Genuinely run, not
skipped and not masked.

Reading it that way is the whole point: `continue-on-error` makes GitHub report the job — and
the commit's check-run — as `success` whether the step passed or failed. An advisory lint job is
a green light over a red step, which is the shape that let a Windows lint failure sit on `main`.

**`scripts/build-base-windows.ps1` — a clippy check**, in the same form as the MSVC, libclang
and cargo checks above it: present → report the version; absent → print the exact
`rustup component add clippy` line and carry on. It reports and never installs — this script's
job is to produce a binary, and a missing lint component is not a reason to refuse one. clippy
is not installed by default with the msvc toolchain, which is why a from-source Windows build
had no gate of its own.

It asks `cargo clippy --version` rather than looking for `cargo-clippy.exe` on PATH: the
component is per-toolchain, and a `cargo-clippy.exe` belonging to a *different* toolchain on
PATH is exactly the state that made both invocations exit non-zero and read as a confirmed lint
failure when the tool was simply absent.

## Not in this PR

No Windows CI job — that is #108, and it lands next, on top of this one. This PR is the **bar
change**, which goes first so that in-flight branches build against the final bar throughout
rather than going red at merge time.

`.gitattributes` / CRLF is #95 and untouched. Checked rather than assumed, since this was
authored on Windows: all four committed blobs carry **0 CR bytes**.

<sub>Built by Claude Code (session `tern`) on the maintainer's behalf.</sub>

https://claude.ai/code/session_01GMwJzqANGZ4XD64aFqRPpX
