### PR TITLE
Test and lint on Windows (#108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: cargo test
+      # --no-fail-fast because cargo test ABORTS at the first failing target and
+      # runs the rest of them never. This job's first run proved the cost: it
+      # stopped at ast_automap_test (4th of the suite, alphabetically) and so
+      # tests/hook_log_tier_test.rs -- the failure #108 was FILED for -- did not
+      # execute at all, and #108's own claim went unmeasured by the job built to
+      # measure it. A first-ever Windows job that reveals one failure per 8-minute
+      # round trip is worth little; this one reports every Windows failure at once.
+      - run: cargo test --no-fail-fast
 
   # Required, not advisory. It was `continue-on-error: true` "until the three
   # pre-existing never_loop denies in src/crud are cleared" -- they are: a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
   # TEMPORARY. REMOVED BEFORE G2. Do not merge with it.
   #
   # R1 EXTENSION. The first experiment measured the release profile against ONE
-  # of the four targets #129 covers (hook_log_tier_test). R1's action gates only
+  # of the spawning targets #129 covers (hook_log_tier_test). R1's action gates only
   # the 2 ast_automap tests and moves the Windows job to --release, which leaves
   # 14 tests ungated on one target's evidence. If the other three still overflow
   # in release, that job's first full run turns main RED for every later PR.
@@ -309,7 +309,7 @@ jobs:
   # overflows" is established only for hook_log_tier_test, and assuming it for
   # the rest would be the same unmeasured leap in the opposite direction.
   #
-  # The job-level verdict is the STRICTEST of the four, never a majority.
+  # The job-level verdict is the STRICTEST of the set, never a majority.
   # ==========================================================================
   windows-release-all-targets-EXPERIMENT:
     runs-on: windows-latest
@@ -333,12 +333,12 @@ jobs:
           ls -l target/debug/base.exe   2>&1 || echo "NO DEBUG BINARY"
           ls -l target/release/base.exe 2>&1 || echo "NO RELEASE BINARY"
 
-      - name: Four targets x two profiles, rc captured to files before any reporting
+      - name: Five targets x two profiles, rc captured to files before any reporting
         if: always()
         shell: bash
         run: |
           set +e
-          for t in hook_log_tier_test hook_output_channel_test outside_workspace_test served_count_coach_test; do
+          for t in hook_log_tier_test hook_output_channel_test outside_workspace_test served_count_coach_test ast_relation_query_test; do
             cargo test --test "$t" -- --nocapture > "dbg_$t.log" 2>&1
             echo "$?" > "dbg_$t.rc"
             cargo test --release --test "$t" -- --nocapture > "rel_$t.log" 2>&1
@@ -347,7 +347,7 @@ jobs:
           done
           set -e
 
-      - name: PER-TARGET VERDICT (same pre-registered ladder, applied four times)
+      - name: PER-TARGET VERDICT (same pre-registered ladder, applied per target)
         if: always()
         shell: bash
         run: |
@@ -359,7 +359,7 @@ jobs:
           rank () { case "$1" in V1) echo 5;; V2) echo 4;; R2) echo 3;; R3) echo 2;; R1) echo 1;; esac; }
 
           echo "=================== PER-TARGET FACTS ==================="
-          for t in hook_log_tier_test hook_output_channel_test outside_workspace_test served_count_coach_test; do
+          for t in hook_log_tier_test hook_output_channel_test outside_workspace_test served_count_coach_test ast_relation_query_test; do
             tr -d '\r' < "dbg_$t.log" > "dbg_$t.clean" 2>/dev/null || : > "dbg_$t.clean"
             tr -d '\r' < "rel_$t.log" > "rel_$t.clean" 2>/dev/null || : > "rel_$t.clean"
             d_rc=$(cat "dbg_$t.rc" 2>/dev/null || echo NO_RC)
@@ -382,9 +382,9 @@ jobs:
           done
 
           echo "=================== JOB VERDICT ==================="
-          echo "STRICTEST_ACROSS_FOUR_TARGETS=$worst"
+          echo "STRICTEST_ACROSS_TARGETS=$worst"
           if [ "$worst" = "R1" ]; then
-            echo "All four targets read R1. The release profile is clean on every target"
+            echo "All targets read R1. The release profile is clean on every target"
             echo "the R1 action decides the fate of. Merging on it is now a measurement."
           else
             echo "NOT R1 across the set. One or more targets denies it, so the R1 action"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,48 @@ jobs:
       # this runner is ubuntu — so the check reads `git check-attr`, not the checkout.
       - run: ./scripts/test-crlf-attributes.sh
 
+  # base publishes base-windows-x86_64.zip on every release and, until 0.14.3, no
+  # test and no lint had ever run on Windows (#108). release.yml's Windows leg is a
+  # plain `cargo build --release`: compiled once, zipped, shipped, and nothing else
+  # on that platform ever checked.
+  #
+  # Its own job rather than a matrix leg on `test`. That job's second step is
+  # ./scripts/test-release-rehearsal.sh, a bash release rehearsal that is
+  # Linux-shaped, so a Windows leg would need an `if:` skipping it -- and a leg
+  # called `test` that quietly runs half of what the name says is worse than no
+  # leg at all, because it reports a name it did not earn.
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # ast_extension_registry.rs, ast_automap_test.rs and
+      # ast_extractor_notices_test.rs shell `python` on Windows and FAIL rather
+      # than skip when it is absent (ast_extension_registry.rs:14-15, :33 -- "a
+      # skip here is indistinguishable from a pass"). Pinned rather than trusted
+      # to whatever the image happens to ship.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: cargo test
+
   # Required, not advisory. It was `continue-on-error: true` "until the three
   # pre-existing never_loop denies in src/crud are cleared" -- they are: a
   # repo-wide grep for never_loop matches zero lines, and the step itself has been
   # `success` on main (run 34200195605, job clippy, step 5). An advisory lint job
   # reports the RUN green whether the step passed or failed, which is how a real
   # Windows failure sat on main unnoticed (#97, #108).
+  # …and since 0.14.3 it runs on both platforms. A Linux-only lint is how
+  # doorbell.rs's BUDGET -- dead on Windows and only on Windows -- passed every
+  # check base had, for months (#97). fail-fast is off so a failure on one
+  # platform never hides the other's result: telling the two apart is the point.
   clippy:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,3 +155,142 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
+
+  # ==========================================================================
+  # TEMPORARY. REMOVED BEFORE THIS PR IS PUT UP FOR G2. Do not merge with it.
+  #
+  # Pre-registered experiment for #129, settling whether base.exe's Windows
+  # stack overflow is a debug-profile artefact or reaches the shipped binary.
+  # Every observation behind #129 so far is from a DEBUG build; the artifact
+  # base actually publishes is `cargo build --release`, which has different
+  # stack usage and different inlining. #124's design depends on the answer:
+  # release clean means the Windows job can run --release and cover 14 of the
+  # 16 failures for real; release broken means the job ignores all 16 and the
+  # finding leaves #124 entirely.
+  #
+  # The decision rule was written, hashed and handed to the orchestrator
+  # BEFORE this job existed on the branch:
+  #   scratchpad/EXPERIMENT-RULE.md
+  #   sha256 A41245A64992CD0A732F01347349F5F4FAB9FA421E8E35A4385B4BAB9740A553
+  #   6730 bytes, 2026-09-08T13:30:08Z
+  #
+  # TWO ARMS, ONE RUNNER, ONE COMMIT, DIFFERING IN EXACTLY ONE VARIABLE: the
+  # cargo profile. Arm A (debug) is the CONTROL and is REQUIRED TO FAIL -- if
+  # it passes, the experiment is VOID and arm B proves nothing, because the
+  # profile is then no longer the only thing that changed. Yesterday's red run
+  # on 703dca6 is deliberately NOT used as the control: different commit,
+  # different day, different runner. A control has to be the change, not the
+  # calendar.
+  #
+  # `cargo test --release --test <name>` builds the `base` bin target in
+  # release and hands the test `CARGO_BIN_EXE_base` pointing at it, so the
+  # spawned process IS the release binary. The artifact-probe step below reads
+  # that file's size off disk rather than assuming the build produced it.
+  #
+  # Neither arm's STEP CONCLUSION is evidence for anything. `continue-on-error`
+  # makes a failing step report `conclusion: success` -- law 28's trap in the
+  # mirror -- so each arm captures its own rc into a file BEFORE printing
+  # anything, and the verdict is computed from those files and the log text.
+  # ==========================================================================
+  windows-release-vs-debug-EXPERIMENT:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: ARM A -- DEBUG (control; this arm is REQUIRED to fail)
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          cargo test --test hook_log_tier_test -- --nocapture > arm_debug.log 2>&1
+          rc=$?
+          set -e
+          echo "$rc" > arm_debug.rc
+          echo "ARM_A_DEBUG_RC=$rc"
+          echo "----- arm A (debug) log -----"
+          cat arm_debug.log
+
+      - name: Artifact probe -- prove a RELEASE base.exe exists before believing arm B
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          cargo build --release --bin base > relbuild.log 2>&1
+          rc=$?
+          set -e
+          echo "$rc" > relbuild.rc
+          echo "RELEASE_BUILD_RC=$rc"
+          tail -20 relbuild.log
+          echo "----- target/release listing -----"
+          ls -l target/release/base.exe 2>&1 || echo "NO RELEASE BINARY ON DISK"
+
+      - name: ARM B -- RELEASE (subject)
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          cargo test --release --test hook_log_tier_test -- --nocapture > arm_release.log 2>&1
+          rc=$?
+          set -e
+          echo "$rc" > arm_release.rc
+          echo "ARM_B_RELEASE_RC=$rc"
+          echo "----- arm B (release) log -----"
+          cat arm_release.log
+
+      - name: VERDICT (branch letters are pre-registered; see hash above)
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          for f in arm_debug arm_release; do
+            tr -d '\r' < "$f.log" > "$f.clean" 2>/dev/null || : > "$f.clean"
+          done
+
+          rc_of () { cat "$1.rc" 2>/dev/null || echo "NO_RC"; }
+          # grep -c exits 1 on ABSENCE (law 27), so the count is captured and the
+          # status is deliberately discarded -- an honest zero must not read as a
+          # tool failure.
+          ovf_of () { grep -c -e "has overflowed its stack" -e "1073741571" "$1.clean" 2>/dev/null || true; }
+          # law 23: print what was COUNTED. passed+failed==0 is a failure, never a pass.
+          ran_of () { awk '/^test result:/ { for (i=1;i<=NF;i++) { if ($i=="passed;") p+=$(i-1); if ($i=="failed;") f+=$(i-1) } } END { print (p+0)+(f+0) }' "$1.clean"; }
+
+          A_RC=$(rc_of arm_debug);   B_RC=$(rc_of arm_release)
+          A_OVF=$(ovf_of arm_debug); B_OVF=$(ovf_of arm_release)
+          A_RAN=$(ran_of arm_debug); B_RAN=$(ran_of arm_release)
+
+          echo "=================== RAW FACTS ==================="
+          echo "arm A debug   rc=$A_RC  tests_run=$A_RAN  overflow_lines=$A_OVF"
+          echo "arm B release rc=$B_RC  tests_run=$B_RAN  overflow_lines=$B_OVF"
+          echo "release build rc=$(rc_of relbuild)"
+          echo "--- test result lines, arm A ---"; grep "^test result:" arm_debug.clean   || echo "(none)"
+          echo "--- test result lines, arm B ---"; grep "^test result:" arm_release.clean || echo "(none)"
+          echo "--- assertion text, arm A ---"; grep -e "left" -e "right" -e "panicked" arm_debug.clean   | head -20 || echo "(none)"
+          echo "--- assertion text, arm B ---"; grep -e "left" -e "right" -e "panicked" arm_release.clean | head -20 || echo "(none)"
+
+          echo "=================== VERDICT ==================="
+          if [ "$A_RAN" = "0" ] || [ "$B_RAN" = "0" ]; then
+            echo "BRANCH=V1  VOID -- an arm executed ZERO tests. This experiment proved NOTHING."
+          elif [ "$A_OVF" = "0" ]; then
+            echo "BRANCH=V2  VOID -- the DEBUG CONTROL did not reproduce the overflow."
+            echo "           A green subject beside a green control is not a result."
+          elif [ "$B_OVF" != "0" ]; then
+            echo "BRANCH=R2  RELEASE ALSO OVERFLOWS -- #129 reaches the shipped binary."
+          elif [ "$B_RC" = "0" ]; then
+            echo "BRANCH=R1  RELEASE IS CLEAN -- overflow is debug-only on this evidence."
+          else
+            echo "BRANCH=R3  AMBIGUOUS -- release does NOT overflow but still fails."
+            echo "           This is NOT R1. Read the arm B assertion text above."
+          fi
+          echo "==============================================="
+          echo "This job is TEMPORARY and is removed before G2."
+          # law 27: this step is a REPORTER, not a gate. Its exit code is
+          # ASSIGNED here deliberately rather than inherited from whatever it
+          # happened to run last -- an unmarked trailing `echo` swallows every
+          # status silently, which is the worse of the two polarities. The
+          # arms' rcs are the evidence and they live in arm_*.rc.
+          exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,3 +294,101 @@ jobs:
           # status silently, which is the worse of the two polarities. The
           # arms' rcs are the evidence and they live in arm_*.rc.
           exit 0
+
+  # ==========================================================================
+  # TEMPORARY. REMOVED BEFORE G2. Do not merge with it.
+  #
+  # R1 EXTENSION. The first experiment measured the release profile against ONE
+  # of the four targets #129 covers (hook_log_tier_test). R1's action gates only
+  # the 2 ast_automap tests and moves the Windows job to --release, which leaves
+  # 14 tests ungated on one target's evidence. If the other three still overflow
+  # in release, that job's first full run turns main RED for every later PR.
+  #
+  # Deferring a measurement onto the trunk is not measuring. So each of the four
+  # targets is measured here, and each gets its OWN debug control -- "debug
+  # overflows" is established only for hook_log_tier_test, and assuming it for
+  # the rest would be the same unmeasured leap in the opposite direction.
+  #
+  # The job-level verdict is the STRICTEST of the four, never a majority.
+  # ==========================================================================
+  windows-release-all-targets-EXPERIMENT:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build both profiles once, so the arms differ only in profile
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          cargo build --bin base > build_debug.log 2>&1;    echo "$?" > build_debug.rc
+          cargo build --release --bin base > build_rel.log 2>&1; echo "$?" > build_rel.rc
+          set -e
+          echo "BUILD_DEBUG_RC=$(cat build_debug.rc)  BUILD_RELEASE_RC=$(cat build_rel.rc)"
+          ls -l target/debug/base.exe   2>&1 || echo "NO DEBUG BINARY"
+          ls -l target/release/base.exe 2>&1 || echo "NO RELEASE BINARY"
+
+      - name: Four targets x two profiles, rc captured to files before any reporting
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          for t in hook_log_tier_test hook_output_channel_test outside_workspace_test served_count_coach_test; do
+            cargo test --test "$t" -- --nocapture > "dbg_$t.log" 2>&1
+            echo "$?" > "dbg_$t.rc"
+            cargo test --release --test "$t" -- --nocapture > "rel_$t.log" 2>&1
+            echo "$?" > "rel_$t.rc"
+            echo "TARGET=$t DEBUG_RC=$(cat dbg_$t.rc) RELEASE_RC=$(cat rel_$t.rc)"
+          done
+          set -e
+
+      - name: PER-TARGET VERDICT (same pre-registered ladder, applied four times)
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          ovf_of () { grep -c -e "has overflowed its stack" -e "1073741571" "$1" 2>/dev/null || true; }
+          ran_of () { awk '/^test result:/ { for (i=1;i<=NF;i++) { if ($i=="passed;") p+=$(i-1); if ($i=="failed;") f+=$(i-1) } } END { print (p+0)+(f+0) }' "$1"; }
+
+          worst=R1
+          rank () { case "$1" in V1) echo 5;; V2) echo 4;; R2) echo 3;; R3) echo 2;; R1) echo 1;; esac; }
+
+          echo "=================== PER-TARGET FACTS ==================="
+          for t in hook_log_tier_test hook_output_channel_test outside_workspace_test served_count_coach_test; do
+            tr -d '\r' < "dbg_$t.log" > "dbg_$t.clean" 2>/dev/null || : > "dbg_$t.clean"
+            tr -d '\r' < "rel_$t.log" > "rel_$t.clean" 2>/dev/null || : > "rel_$t.clean"
+            d_rc=$(cat "dbg_$t.rc" 2>/dev/null || echo NO_RC)
+            r_rc=$(cat "rel_$t.rc" 2>/dev/null || echo NO_RC)
+            d_ovf=$(ovf_of "dbg_$t.clean"); r_ovf=$(ovf_of "rel_$t.clean")
+            d_ran=$(ran_of "dbg_$t.clean"); r_ran=$(ran_of "rel_$t.clean")
+
+            if [ "$d_ran" = "0" ] || [ "$r_ran" = "0" ]; then b=V1
+            elif [ "$d_ovf" = "0" ];                        then b=V2
+            elif [ "$r_ovf" != "0" ];                        then b=R2
+            elif [ "$r_rc" = "0" ];                          then b=R1
+            else                                                  b=R3
+            fi
+            echo "TARGET_VERDICT $t = $b"
+            echo "   debug   rc=$d_rc ran=$d_ran ovf=$d_ovf"
+            echo "   release rc=$r_rc ran=$r_ran ovf=$r_ovf"
+            grep "^test result:" "rel_$t.clean" | sed 's/^/   release result: /' || echo "   release result: (none)"
+            grep -e "panicked" -e "left:" -e "right:" "rel_$t.clean" | head -6 | sed 's/^/   release fail: /' || true
+            if [ "$(rank $b)" -gt "$(rank $worst)" ]; then worst=$b; fi
+          done
+
+          echo "=================== JOB VERDICT ==================="
+          echo "STRICTEST_ACROSS_FOUR_TARGETS=$worst"
+          if [ "$worst" = "R1" ]; then
+            echo "All four targets read R1. The release profile is clean on every target"
+            echo "the R1 action decides the fate of. Merging on it is now a measurement."
+          else
+            echo "NOT R1 across the set. One or more targets denies it, so the R1 action"
+            echo "(gate only 2, move the job to --release) MUST NOT be taken."
+          fi
+          echo "This job is TEMPORARY and is removed before G2."
+          exit 0


### PR DESCRIPTION
Closes #108.

base publishes `base-windows-x86_64.zip` on every release. **No test and no lint has ever run on
Windows.** `release.yml`'s Windows matrix leg is a plain `cargo build --release` (`:60`) — compiled
once, zipped, shipped. The only `cargo test` in that workflow is the ubuntu docs gate at `:22`, and
`ci.yml` had no `windows-latest` anywhere.

## Two jobs, separate on purpose

**`test-windows`** runs `cargo test` on `windows-latest`. Not a matrix leg on `test`: that job's
second step is `./scripts/test-release-rehearsal.sh`, a bash release rehearsal that is Linux-shaped,
so a Windows leg would need an `if:` skipping it. A job named `test` that quietly runs half of what
its name says is worse than no job, because it reports a name it did not earn.

It pins Python. `ast_extension_registry.rs`, `ast_automap_test.rs` and
`ast_extractor_notices_test.rs` shell `python` on Windows and **fail rather than skip** when it is
absent, by their own design — *"a skip here is indistinguishable from a pass"*. Trusting the image
to ship an interpreter would make a real failure and a missing interpreter look alike.

**`clippy` gains an os matrix**, `fail-fast: false`. A Linux-only lint is how `doorbell.rs`'s
`BUDGET` — dead on Windows and only on Windows — passed every check base had for months (#97, fixed
in #119). `fail-fast` off so a failure on one platform never hides the other's result; telling the
two apart is the entire point of adding the second platform.

## This PR opened RED deliberately, and the measurement corrected the prediction

#108 reports `tests/hook_log_tier_test.rs` failing **4 of 4** on Windows while passing on ubuntu,
and says plainly that its author did not re-run it and that *"the root cause is not established in
this issue"*. This PR landed the job first and measured it on GitHub's own runner rather than
designing a fix by reading `cfg` attributes.

**The measurement did not find what the issue predicted.**

### Run `34223265443`, at step level

| job | conclusion | what the **log** says |
|---|---|---|
| `clippy (ubuntu-latest)` | success | |
| `clippy (windows-latest)` | **success** | 248 `Checking`/`Compiling` crate lines; `Checking base v0.14.2` present as the **final** crate; `Finished dev profile in 8m 00s`; **0** `warning:` lines |
| `test` | success | |
| `release-invocations` | success | |
| `test-windows` | **failure** | `ast_automap_test` — 12 passed, **2 failed** |

### `hook_log_tier_test` never ran, so #108's own claim is still unmeasured

Occurrences of `hook_log_tier` in the entire 1468-line job log: **zero**.

`cargo test` aborts at the first failing target. It reached four binaries — `src/lib.rs`,
`src/main.rs`, `tests/analyze_catchall_test.rs`, `tests/ast_automap_test.rs` — and stopped there:

```
error: test failed, to rerun pass `--test ast_automap_test`
```

`ast_…` sorts before `hook_…`, so the file the issue was filed about never executed. Neither
confirmed nor refuted; **nobody has measured it yet**, including this run.

### The failure that is actually blocking, in `tests/ast_automap_test.rs`

```
---- the_temp_rule_stands_down_only_inside_a_redirected_home ----
tests\ast_automap_test.rs:281:9
assertion `left == right` failed: a fixture inside the sandbox home is mappable
  left: Some("a Windows AppData directory")
 right: None

---- the_sandbox_exemption_covers_the_segments_the_sandbox_itself_sits_under ----
tests\ast_automap_test.rs:318:9
assertion `left == right` failed
  left: Some("a Windows AppData directory")
 right: Some("a node_modules tree")
```

Both return the same reason, which means `sandbox_home()` did not recognise the sandbox and
`never_map_reason` read the whole path instead of the fixture-relative part.

Note what these two tests are: `ast_automap_test.rs:296-301` records that this exact shape was
**already measured once** — *"5 of 13 tests in this file failed on the Windows mirror at `b72703a`
for exactly this reason (2026-09-03); Linux never saw it"* — and `automap.rs:746-752` documents the
Windows behaviour as intended. Root cause is being established by direct instrumentation before any
fix is written or any scope call is made.

### `--no-fail-fast`, added in this PR

The first run is the argument for it: it stopped at the fourth binary and never executed the file
#108 was filed about, so **the job built to measure #108's claim did not measure it**. A first-ever
Windows job that reveals one failure per eight-minute round trip is worth little. The job now
reports every Windows failure in one run.

### `clippy (windows-latest)`: #119's undischarged MSVC leg is discharged

#119's merge comment recorded its MSVC corroboration as **undischarged** — it could not be run
locally at 2.0 GB free RAM. This leg is that instrument, and it was read at step level from the
**log**, not from the conclusion: a green exit alone cannot exclude a lint that ran on nothing.
It compiled 248 crates and linted `base` itself, last of the 248, with zero warnings.

<sub>Built by Claude Code (session `tern`) on the maintainer's behalf.</sub>

https://claude.ai/code/session_011VSEdejdH235vTHgN3g6Rz
