### PR TITLE
test(lock): widen the tripwire to filesystem primitives, red-first (#104)

### DIFF
--- a/tests/lock_tripwire_test.rs
+++ b/tests/lock_tripwire_test.rs
@@ -274,9 +274,10 @@ fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
 /// filesystem primitives in scope, because **626 of the 1,903 functions in
 /// `src/` are test code** and fixtures legitimately write graph files directly.
 /// `src/graph_move.rs` alone carries 8 `fs::write` calls past its
-/// `#[cfg(test)]`, and `src/hook/session_start.rs` — the sentinel — writes a
-/// `graph.nq` fixture. The cheap way to green that would be to re-add files to
-/// an allow-list, which re-blinds the exact files under repair.
+/// `#[cfg(test)]`, and `src/hook/session_start.rs` writes a `graph.nq` fixture
+/// which is that file's only filesystem primitive. The cheap way to green that
+/// would be to re-add files to an allow-list, which re-blinds the exact files
+/// under repair.
 fn functions(src: &str) -> Vec<Func> {
     let lines: Vec<&str> = src.lines().collect();
     let cfg_test_at = lines

--- a/tests/lock_tripwire_test.rs
+++ b/tests/lock_tripwire_test.rs
@@ -35,7 +35,8 @@
 //!   here: `src/dashboard/api.rs` is one deliberate entry covering 17 sites.
 //! * **Rule 2 — filesystem primitives.** A function that puts bytes over a path
 //!   it names as a graph must hold the lock, unless the (FILE, FUNCTION) pair is
-//!   on [`ALLOW_FNS`].
+//!   on [`ALLOW_FNS`]. Measured on `610636e`: 157 primitive sites in non-test
+//!   functions, 9 of them in a function that names a graph and takes no lock.
 //!
 //! **Rule 2's exemptions are function-scoped and that is load-bearing.** A
 //! file-scoped exemption is precisely what would have let `restore_tier` ship
@@ -377,10 +378,6 @@ fn scan_file(
 
         // Rule 2 — filesystem primitives over a path the function names as a
         // graph, exempted by (FILE, FUNCTION).
-        //
-        // NOT YET ENFORCED in this commit. The candidates are measured and
-        // PRINTED so the red-first run shows the detector naming the very sites
-        // it then fails to report as findings — the widening lands next.
         let sites = code
             .lines()
             .filter(|l| first_match(l, &FS_PRIMITIVES).is_some())
@@ -391,7 +388,11 @@ fn scan_file(
                 counts.fs_primitive_graph_functions += 1;
                 if !allow_fns.contains(&(rel, f.name.as_str())) {
                     counts.fs_primitive_functions_flagged += 1;
-                    println!("  rule 2 candidate (not yet enforced): {site}  [{sig}]");
+                    found.push(Finding {
+                        site,
+                        rule: Rule::FsPrimitive,
+                        token: sig.to_string(),
+                    });
                 }
             }
         }

--- a/tests/lock_tripwire_test.rs
+++ b/tests/lock_tripwire_test.rs
@@ -13,15 +13,55 @@
 //! writer with no test would sail through. Reading the source catches it whether
 //! or not anything calls it.
 //!
-//! Adding a site to the allow-list is a deliberate act that shows up in review.
-//! The list is PRINTED on every run, so an exemption is visible rather than
+//! Adding a site to an allow-list is a deliberate act that shows up in review.
+//! Both lists are PRINTED on every run, so an exemption is visible rather than
 //! assumed.
+//!
+//! # Two rules, because matching call NAMES was itself the blind spot (#104)
+//!
+//! The first version of this test recognised three write calls and nothing else.
+//! `src/graph_move.rs` uses none of them — it has its own `fs::write` →
+//! `fs::rename` path — so the tripwire **never opened that file**. Not "opened it
+//! and passed it": the file-level filter skipped it before any function was
+//! examined. `doctor::restore_tier` is the same shape behind a file-scoped
+//! exemption. Measured on `610636e`, the unwidened test scanned 99 files, checked
+//! 10 functions and reported all-clear while TWELVE unlocked whole-file graph
+//! writers sat in the tree.
+//!
+//! So:
+//!
+//! * **Rule 1 — write calls.** A function reaching the store seam's write must
+//!   hold the lock, unless its FILE is on [`ALLOW_FILES`]. File scope is right
+//!   here: `src/dashboard/api.rs` is one deliberate entry covering 17 sites.
+//! * **Rule 2 — filesystem primitives.** A function that puts bytes over a path
+//!   it names as a graph must hold the lock, unless the (FILE, FUNCTION) pair is
+//!   on [`ALLOW_FNS`].
+//!
+//! **Rule 2's exemptions are function-scoped and that is load-bearing.** A
+//! file-scoped exemption is precisely what would have let `restore_tier` ship
+//! unlocked inside `doctor.rs` while the tripwire certified that same file green.
+//! Repeating file scope in the wider rule would rebuild the hole one level up.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-/// Calls that write a graph file back to disk.
+/// Calls that write a graph file back to disk through the store seam.
 const WRITE_CALLS: [&str; 3] = ["write_back(", "update_and_write(", "mutate_and_write("];
+
+/// Filesystem primitives that can put bytes over a graph file WITHOUT touching
+/// the seam. Enumerated from the codebase, not from imagination: these are the
+/// primitives the #104 route sweep counted across `src/` (211 call-site lines at
+/// `610636e`), plus `fs::remove_file`, because deleting a graph is a whole-file
+/// write of zero bytes.
+const FS_PRIMITIVES: [&str; 7] = [
+    "fs::write(",
+    "fs::rename(",
+    "fs::copy(",
+    "fs::remove_file(",
+    "File::create(",
+    "OpenOptions",
+    "BufWriter::new(",
+];
 
 /// Anything that puts the graph lock in scope for the enclosing function.
 const LOCK_TOKENS: [&str; 5] = [
@@ -32,9 +72,34 @@ const LOCK_TOKENS: [&str; 5] = [
     "mutate_file_if_holds(",
 ];
 
-/// Files allowed to write a graph without holding the lock, each with the reason.
+/// Spellings by which a function names a graph FILE, for Rule 2.
+///
+/// `".nq"` covers every path literal (`graph.nq`, `dest.nq`). `"\"nq."` covers
+/// the temp-file spelling `with_extension("nq.tmp")` — and that one is not
+/// decoration: **`doctor::restore_tier`, 4B in #104, is reached by NO other
+/// signal.** Its only tell is `path.with_extension("nq.tmp")`; it names no
+/// graph-path variable and calls no graph function. Drop that entry and the
+/// widened rule goes blind to the exact site it was widened for.
+///
+/// The rest are the resolvers a graph path arrives through. `lock_path(`
+/// deliberately is NOT here: the relay has a `lock_path` of its own over its
+/// spool, and including it flagged `relay::with_lock`, which touches no graph.
+const GRAPH_SIGNALS: [&str; 10] = [
+    ".nq",
+    "\"nq.",
+    "graph_path",
+    "dest_path",
+    "source_path",
+    "all_tier_files",
+    "tier_paths(",
+    "graph_health(",
+    "load_graph(",
+    "load_or_empty(",
+];
+
+/// Rule 1: files allowed to reach the seam's write without holding the lock.
 /// Every entry is a deliberate exemption, not an oversight.
-const ALLOW: [(&str, &str); 12] = [
+const ALLOW_FILES: [(&str, &str); 12] = [
     ("src/store.rs", "the seam itself: it defines the lock and the write"),
     (
         "src/dashboard/api.rs",
@@ -54,6 +119,134 @@ const ALLOW: [(&str, &str); 12] = [
     ("src/hook/session_start.rs", "no graph write; listed if a call appears"),
 ];
 
+/// Rule 2: (file, function) pairs allowed to call a filesystem primitive while
+/// naming a graph path. **Every reason names the file the function actually
+/// writes** — an exemption that cannot say what it writes is not an exemption,
+/// it is a hole.
+const ALLOW_FNS: [(&str, &str, &str); 9] = [
+    (
+        "src/store.rs",
+        "write_back_inner",
+        "the seam itself: this IS the atomic temp+rename that every locked write ends in",
+    ),
+    (
+        "src/graph_move.rs",
+        "write_validated",
+        "#87: writes the graph by its own fs::write + fs::rename path. Takes the lock when the \
+         nine Tier C sites migrate; this entry is removed then",
+    ),
+    (
+        "src/graph_move.rs",
+        "commit",
+        "#87: rollback copies snapshots over BOTH graphs. Takes the lock with the migration; \
+         this entry is removed then",
+    ),
+    (
+        "src/doctor.rs",
+        "restore_tier",
+        "#87: fs::copy + fs::rename straight over the graph. Takes the lock with the migration; \
+         this entry is removed then",
+    ),
+    (
+        "src/doctor.rs",
+        "repair_tier",
+        "writes the .quarantine-<stamp> sidecar, NOT the graph. Its graph write is write_back \
+         at :793 and is Rule 1's (#87)",
+    ),
+    (
+        "src/graph.rs",
+        "auto_compact_tiers",
+        "writes the .last-auto-compact cooldown marker, NOT the graph. Its graph write is \
+         compact_tier → write_back at :45 and is Rule 1's (#87)",
+    ),
+    (
+        "src/install.rs",
+        "create_global_tier",
+        "writes base.toml, standards.toml and the seed docs. Writes no graph",
+    ),
+    (
+        "src/relay/mod.rs",
+        "export_nq",
+        "writes inbox.nq, an ephemeral read-only export of the relay spool — never a tier graph",
+    ),
+    (
+        "src/scaffold.rs",
+        "run",
+        "writes domains.toml and base.toml into a new workspace. Writes no graph",
+    ),
+];
+
+/// The three unlocked filesystem-primitive graph writers on the tree #104 was
+/// filed against, by name.
+///
+/// This list is #104's acceptance leg and it is the reason the instrument had to
+/// be fixed before #87: it is derived from a census of the tree, independently of
+/// the detector, so a detector that quietly exempts everything cannot satisfy it.
+/// **It expires when #87 lands** — those three take the lock, and this test
+/// inverts to asserting they are no longer offenders.
+const KNOWN_UNLOCKED_FS_WRITERS: [&str; 3] = [
+    "src/graph_move.rs::write_validated",
+    "src/graph_move.rs::commit",
+    "src/doctor.rs::restore_tier",
+];
+
+/// One realistic usage per primitive in [`FS_PRIMITIVES`], for the reach test.
+/// Law 31: a guard's own suite cannot supply the list of shapes it must reach —
+/// these come from the primitives measured across `src/`, and the reach test
+/// asserts this table's keys ARE `FS_PRIMITIVES`, so the two cannot drift apart.
+const FS_PRIMITIVE_SHAPES: [(&str, &str); 7] = [
+    ("fs::write(", "std::fs::write(&tmp, bytes)?;"),
+    ("fs::rename(", "std::fs::rename(&tmp, path)?;"),
+    ("fs::copy(", "std::fs::copy(backup, &tmp)?;"),
+    ("fs::remove_file(", "let _ = std::fs::remove_file(path);"),
+    ("File::create(", "let f = std::fs::File::create(&tmp)?;"),
+    ("OpenOptions", "let f = std::fs::OpenOptions::new().write(true).open(path)?;"),
+    ("BufWriter::new(", "let w = std::io::BufWriter::new(f);"),
+];
+
+// ─── the scan ────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Rule {
+    WriteCall,
+    FsPrimitive,
+}
+
+impl Rule {
+    fn label(self) -> &'static str {
+        match self {
+            Rule::WriteCall => "rule 1, write call",
+            Rule::FsPrimitive => "rule 2, fs primitive",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Finding {
+    site: String,
+    rule: Rule,
+    token: String,
+}
+
+/// What the scan actually visited. Printed every run, and asserted non-zero:
+/// a count of zero means the scan proved NOTHING and is a failure, never a pass.
+#[derive(Debug, Default, Clone, Copy)]
+struct Counts {
+    files_scanned: usize,
+    functions_visited: usize,
+    test_functions_skipped: usize,
+    write_call_functions_checked: usize,
+    fs_primitive_sites_seen: usize,
+    fs_primitive_graph_functions: usize,
+    fs_primitive_functions_flagged: usize,
+}
+
+struct Func {
+    name: String,
+    body: String,
+    is_test: bool,
+}
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -70,50 +263,153 @@ fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-/// Split a file into (function name, body) pairs. Deliberately crude: it splits
-/// on top-level `fn` lines, which is enough to ask "does the function containing
-/// this write also take the lock?" without carrying a parser.
-fn functions(src: &str) -> Vec<(String, String)> {
-    let mut out: Vec<(String, String)> = Vec::new();
+/// Split a file into functions. Deliberately crude: it splits on `fn` lines,
+/// which is enough to ask "does the function containing this write also take the
+/// lock?" without carrying a parser.
+///
+/// It also marks test code, which the previous version's comment CLAIMED to do
+/// and did not — the code beneath that comment skipped comment LINES, not test
+/// modules. Harmless while only three named calls were matched; fatal with
+/// filesystem primitives in scope, because **626 of the 1,903 functions in
+/// `src/` are test code** and fixtures legitimately write graph files directly.
+/// `src/graph_move.rs` alone carries 8 `fs::write` calls past its
+/// `#[cfg(test)]`, and `src/hook/session_start.rs` — the sentinel — writes a
+/// `graph.nq` fixture. The cheap way to green that would be to re-add files to
+/// an allow-list, which re-blinds the exact files under repair.
+fn functions(src: &str) -> Vec<Func> {
+    let lines: Vec<&str> = src.lines().collect();
+    let cfg_test_at = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with("#[cfg(test)]"));
+
+    let mut out: Vec<Func> = Vec::new();
     let mut name = String::from("<file scope>");
     let mut body = String::new();
-    for line in src.lines() {
+    let mut is_test = false;
+    let mut pending_test_attr = false;
+
+    for (i, line) in lines.iter().enumerate() {
         let t = line.trim_start();
-        let is_fn = t.starts_with("fn ") || t.starts_with("pub fn ") || t.starts_with("pub(crate) fn ");
+        let is_fn =
+            t.starts_with("fn ") || t.starts_with("pub fn ") || t.starts_with("pub(crate) fn ");
         if is_fn {
-            out.push((name.clone(), std::mem::take(&mut body)));
+            out.push(Func {
+                name: name.clone(),
+                body: std::mem::take(&mut body),
+                is_test,
+            });
             name = t
                 .split("fn ")
                 .nth(1)
                 .and_then(|r| r.split(['(', '<']).next())
                 .unwrap_or("?")
                 .to_string();
+            // Everything after a `#[cfg(test)]` line is test code, as is anything
+            // directly under a `#[test]` / `#[tokio::test]` attribute run.
+            is_test = pending_test_attr || cfg_test_at.is_some_and(|c| i > c);
+            pending_test_attr = false;
+        } else if t.starts_with("#[") {
+            if t.contains("test]") {
+                pending_test_attr = true;
+            }
+        } else if !t.is_empty() && !t.starts_with("//") {
+            pending_test_attr = false;
         }
         body.push('\n');
         body.push_str(line);
     }
-    out.push((name, body));
+    out.push(Func { name, body, is_test });
     out
 }
 
-#[test]
-fn every_graph_writer_outside_the_allow_list_takes_the_lock() {
+/// The body's non-comment lines.
+///
+/// Dropping comment lines is not tidiness: in this round's route sweep, three
+/// DOC COMMENTS naming a primitive in prose were the entire difference between
+/// two counts of the same tree (214 vs 211) — one of them inside
+/// `with_graph_lock`'s own documentation.
+fn code_only(body: &str) -> String {
+    body.lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn first_match<'a>(hay: &str, needles: &[&'a str]) -> Option<&'a str> {
+    needles.iter().copied().find(|n| hay.contains(n))
+}
+
+/// Scan one file. `allow_files` and `allow_fns` are parameters rather than
+/// constants so the acceptance leg can run the same detector with them EMPTY —
+/// a detector that can only be run with its own exemptions applied cannot be
+/// asked whether it sees anything.
+fn scan_file(
+    rel: &str,
+    src: &str,
+    allow_files: &BTreeSet<&str>,
+    allow_fns: &BTreeSet<(&str, &str)>,
+    counts: &mut Counts,
+) -> Vec<Finding> {
+    let mut found = Vec::new();
+    for f in functions(src) {
+        if f.is_test {
+            counts.test_functions_skipped += 1;
+            continue;
+        }
+        counts.functions_visited += 1;
+        let code = code_only(&f.body);
+        let locked = first_match(&code, &LOCK_TOKENS).is_some();
+        let site = format!("{rel}::{}", f.name);
+
+        // Rule 1 — the seam's write calls, exempted by FILE.
+        if let Some(tok) = first_match(&code, &WRITE_CALLS) {
+            if !allow_files.contains(rel) {
+                counts.write_call_functions_checked += 1;
+                if !locked {
+                    found.push(Finding {
+                        site: site.clone(),
+                        rule: Rule::WriteCall,
+                        token: tok.to_string(),
+                    });
+                }
+            }
+        }
+
+        // Rule 2 — filesystem primitives over a path the function names as a
+        // graph, exempted by (FILE, FUNCTION).
+        //
+        // NOT YET ENFORCED in this commit. The candidates are measured and
+        // PRINTED so the red-first run shows the detector naming the very sites
+        // it then fails to report as findings — the widening lands next.
+        let sites = code
+            .lines()
+            .filter(|l| first_match(l, &FS_PRIMITIVES).is_some())
+            .count();
+        counts.fs_primitive_sites_seen += sites;
+        if sites > 0 && !locked {
+            if let Some(sig) = first_match(&code, &GRAPH_SIGNALS) {
+                counts.fs_primitive_graph_functions += 1;
+                if !allow_fns.contains(&(rel, f.name.as_str())) {
+                    counts.fs_primitive_functions_flagged += 1;
+                    println!("  rule 2 candidate (not yet enforced): {site}  [{sig}]");
+                }
+            }
+        }
+    }
+    found
+}
+
+fn scan_tree(
+    allow_files: &BTreeSet<&str>,
+    allow_fns: &BTreeSet<(&str, &str)>,
+) -> (Vec<Finding>, Counts) {
     let root = repo_root();
     let mut files = Vec::new();
     rust_files(&root.join("src"), &mut files);
     files.sort();
-    assert!(!files.is_empty(), "no source files scanned — the tripwire measured nothing");
 
-    let allowed: BTreeSet<&str> = ALLOW.iter().map(|(f, _)| *f).collect();
-
-    println!("tripwire: scanned {} files under src/", files.len());
-    println!("allow-list ({} entries), each an explicit exemption:", ALLOW.len());
-    for (f, why) in ALLOW {
-        println!("  {f}\n      {why}");
-    }
-
-    let mut offenders: Vec<String> = Vec::new();
-    let mut checked = 0usize;
+    let mut counts = Counts::default();
+    let mut found = Vec::new();
     for path in &files {
         let rel = path
             .strip_prefix(&root)
@@ -121,41 +417,200 @@ fn every_graph_writer_outside_the_allow_list_takes_the_lock() {
             .to_string_lossy()
             .replace('\\', "/");
         let src = std::fs::read_to_string(path).unwrap_or_default();
-        if !WRITE_CALLS.iter().any(|c| src.contains(c)) {
-            continue;
-        }
-        if allowed.contains(rel.as_str()) {
-            continue;
-        }
-        for (fname, body) in functions(&src) {
-            // Skip the test modules: fixtures legitimately write graphs directly.
-            let writes = WRITE_CALLS.iter().any(|c| {
-                body.lines().any(|l| {
-                    let t = l.trim_start();
-                    l.contains(c) && !t.starts_with("//") && !t.starts_with("///")
-                })
-            });
-            if !writes {
-                continue;
-            }
-            checked += 1;
-            let locked = LOCK_TOKENS.iter().any(|t| body.contains(t));
-            if !locked {
-                offenders.push(format!("{rel}::{fname}"));
-            }
-        }
+        counts.files_scanned += 1;
+        found.extend(scan_file(&rel, &src, allow_files, allow_fns, &mut counts));
+    }
+    (found, counts)
+}
+
+fn allow_file_set() -> BTreeSet<&'static str> {
+    ALLOW_FILES.iter().map(|(f, _)| *f).collect()
+}
+
+fn allow_fn_set() -> BTreeSet<(&'static str, &'static str)> {
+    ALLOW_FNS.iter().map(|(f, n, _)| (*f, *n)).collect()
+}
+
+fn report(found: &[Finding]) -> String {
+    found
+        .iter()
+        .map(|f| format!("{}  [{}: {}]", f.site, f.rule.label(), f.token))
+        .collect::<Vec<_>>()
+        .join("\n  ")
+}
+
+// ─── the tests ───────────────────────────────────────────────
+
+#[test]
+fn every_graph_writer_outside_the_allow_list_takes_the_lock() {
+    let allow_files = allow_file_set();
+    let allow_fns = allow_fn_set();
+
+    println!("rule 1 allow-list — {} FILES, each an explicit exemption:", ALLOW_FILES.len());
+    for (f, why) in ALLOW_FILES {
+        println!("  {f}\n      {why}");
+    }
+    println!(
+        "rule 2 allow-list — {} (FILE, FUNCTION) pairs, each naming what it actually writes:",
+        ALLOW_FNS.len()
+    );
+    for (f, n, why) in ALLOW_FNS {
+        println!("  {f}::{n}\n      {why}");
     }
 
-    println!("tripwire: {checked} graph-writing function(s) required to hold the lock");
+    let (found, counts) = scan_tree(&allow_files, &allow_fns);
+
+    println!("tripwire: {} files scanned under src/", counts.files_scanned);
+    println!("tripwire: {} non-test functions visited", counts.functions_visited);
+    println!("tripwire: {} test functions skipped", counts.test_functions_skipped);
+    println!(
+        "tripwire: {} write-call function(s) required to hold the lock",
+        counts.write_call_functions_checked
+    );
+    println!(
+        "tripwire: {} fs write-primitive site(s) seen in non-test functions",
+        counts.fs_primitive_sites_seen
+    );
+    println!(
+        "tripwire: {} unlocked function(s) name a graph path and call a primitive; {} outside the rule 2 allow-list",
+        counts.fs_primitive_graph_functions, counts.fs_primitive_functions_flagged
+    );
+
+    // Control legs. A zero here means this run proved NOTHING; it is a failure,
+    // never a pass. (An earlier isolation tripwire in this project printed PASS
+    // having opened zero files.)
     assert!(
-        checked > 0,
-        "the tripwire found no locked writers to check — it would pass on an empty scan"
+        counts.files_scanned > 0,
+        "scanned 0 files — this run proved NOTHING about the tree"
     );
     assert!(
-        offenders.is_empty(),
-        "these write a graph without taking the lock, and are not on the allow-list:\n  {}\n\
+        counts.functions_visited > 0,
+        "visited 0 non-test functions — this run proved NOTHING about the tree"
+    );
+    assert!(
+        counts.write_call_functions_checked > 0,
+        "checked 0 write-call functions — rule 1 proved NOTHING"
+    );
+    assert!(
+        counts.fs_primitive_sites_seen > 0,
+        "saw 0 fs write-primitive sites — rule 2 proved NOTHING"
+    );
+
+    assert!(
+        found.is_empty(),
+        "these write a graph without taking the lock, and are not on an allow-list:\n  {}\n\
          Either take the lock (store::with_graph_lock / lock_graph / crud::lock_and_load) or add \
-         the file to ALLOW in this test with the reason.",
-        offenders.join("\n  ")
+         the entry to ALLOW_FILES (rule 1) or ALLOW_FNS (rule 2) in this test, with a reason that \
+         names what it writes.",
+        report(&found)
+    );
+}
+
+/// #104's acceptance leg: the widened rule must actually SEE the unlocked
+/// filesystem-primitive writers, by name.
+///
+/// Run with both allow-lists EMPTY, because the question is what the detector can
+/// see, not what it has been told to ignore. A rule too loose (exempts
+/// everything) and a rule too narrow (never fires) are both GREEN in the main
+/// test — this is the leg that separates them.
+#[test]
+fn the_widened_rule_sees_the_unlocked_fs_writers() {
+    let no_files: BTreeSet<&str> = BTreeSet::new();
+    let no_fns: BTreeSet<(&str, &str)> = BTreeSet::new();
+    let (found, counts) = scan_tree(&no_files, &no_fns);
+
+    assert!(
+        counts.functions_visited > 0,
+        "visited 0 non-test functions — this leg proved NOTHING"
+    );
+
+    let seen: BTreeSet<&str> = found
+        .iter()
+        .filter(|f| f.rule == Rule::FsPrimitive)
+        .map(|f| f.site.as_str())
+        .collect();
+
+    let missed: Vec<&str> = KNOWN_UNLOCKED_FS_WRITERS
+        .iter()
+        .copied()
+        .filter(|w| !seen.contains(w))
+        .collect();
+
+    assert!(
+        missed.is_empty(),
+        "the widened rule does not see {} of the {} known unlocked fs-primitive graph writers:\n  \
+         {}\nIt saw {} fs-primitive site(s) in total. A rule that cannot name these is not \
+         widened, whatever the suite says.",
+        missed.len(),
+        KNOWN_UNLOCKED_FS_WRITERS.len(),
+        missed.join("\n  "),
+        seen.len()
+    );
+}
+
+/// Law 31: prove the rule REACHES every shape of the thing it claims to guard,
+/// with the shapes enumerated from the codebase rather than from this test.
+///
+/// Law 26's other half is here too: the negative controls. A rule that flagged
+/// everything would pass the positive half of this test identically.
+#[test]
+fn every_fs_primitive_shape_reaches_the_rule() {
+    // The shape table cannot drift away from the constant it claims to cover.
+    let shape_keys: Vec<&str> = FS_PRIMITIVE_SHAPES.iter().map(|(k, _)| *k).collect();
+    assert_eq!(
+        shape_keys,
+        FS_PRIMITIVES.to_vec(),
+        "FS_PRIMITIVE_SHAPES no longer covers FS_PRIMITIVES — a primitive was added to the rule \
+         without a shape proving the rule reaches it"
+    );
+
+    let no_files: BTreeSet<&str> = BTreeSet::new();
+    let no_fns: BTreeSet<(&str, &str)> = BTreeSet::new();
+
+    let scan = |src: &str| -> Vec<Finding> {
+        let mut c = Counts::default();
+        scan_file("src/probe.rs", src, &no_files, &no_fns, &mut c)
+    };
+
+    // Positive: every primitive, in a function that names a graph path.
+    for (prim, usage) in FS_PRIMITIVE_SHAPES {
+        let src = format!(
+            "fn writes_a_graph(path: &Path) -> Result<()> {{\n    \
+             let tmp = path.with_extension(\"nq.tmp\");\n    {usage}\n    Ok(())\n}}\n"
+        );
+        let found = scan(&src);
+        assert!(
+            found.iter().any(|f| f.rule == Rule::FsPrimitive),
+            "rule 2 does not reach the {prim} shape:\n{src}"
+        );
+    }
+
+    // Negative 1 — a primitive with no graph path in sight is NOT a graph write.
+    let unrelated = "fn writes_a_log(p: &Path) -> Result<()> {\n    \
+                     std::fs::write(p, \"hello\")?;\n    Ok(())\n}\n";
+    assert!(
+        scan(unrelated).is_empty(),
+        "rule 2 flags a primitive that names no graph path — it is flagging everything, \
+         which is indistinguishable from working"
+    );
+
+    // Negative 2 — holding the lock is the whole point; it must clear the flag.
+    let locked = "fn writes_a_graph(path: &Path) -> Result<()> {\n    \
+                  let _g = store::lock_graph(path)?;\n    \
+                  let tmp = path.with_extension(\"nq.tmp\");\n    \
+                  std::fs::rename(&tmp, path)?;\n    Ok(())\n}\n";
+    assert!(
+        scan(locked).is_empty(),
+        "rule 2 flags a function that DOES hold the lock"
+    );
+
+    // Negative 3 — test fixtures legitimately write graph files directly.
+    let fixture = "#[cfg(test)]\nmod tests {\n    \
+                   fn seed(dir: &Path) {\n        \
+                   std::fs::write(dir.join(\"graph.nq\"), \"\").unwrap();\n    }\n}\n";
+    assert!(
+        scan(fixture).is_empty(),
+        "rule 2 flags a #[cfg(test)] fixture — every test module in src/ becomes an offender \
+         and the cheap fix re-blinds the files under repair"
     );
 }

--- a/tests/lock_tripwire_test.rs
+++ b/tests/lock_tripwire_test.rs
@@ -364,16 +364,16 @@ fn scan_file(
         let site = format!("{rel}::{}", f.name);
 
         // Rule 1 — the seam's write calls, exempted by FILE.
-        if let Some(tok) = first_match(&code, &WRITE_CALLS) {
-            if !allow_files.contains(rel) {
-                counts.write_call_functions_checked += 1;
-                if !locked {
-                    found.push(Finding {
-                        site: site.clone(),
-                        rule: Rule::WriteCall,
-                        token: tok.to_string(),
-                    });
-                }
+        if let Some(tok) = first_match(&code, &WRITE_CALLS)
+            && !allow_files.contains(rel)
+        {
+            counts.write_call_functions_checked += 1;
+            if !locked {
+                found.push(Finding {
+                    site: site.clone(),
+                    rule: Rule::WriteCall,
+                    token: tok.to_string(),
+                });
             }
         }
 
@@ -384,17 +384,18 @@ fn scan_file(
             .filter(|l| first_match(l, &FS_PRIMITIVES).is_some())
             .count();
         counts.fs_primitive_sites_seen += sites;
-        if sites > 0 && !locked {
-            if let Some(sig) = first_match(&code, &GRAPH_SIGNALS) {
-                counts.fs_primitive_graph_functions += 1;
-                if !allow_fns.contains(&(rel, f.name.as_str())) {
-                    counts.fs_primitive_functions_flagged += 1;
-                    found.push(Finding {
-                        site,
-                        rule: Rule::FsPrimitive,
-                        token: sig.to_string(),
-                    });
-                }
+        if sites > 0
+            && !locked
+            && let Some(sig) = first_match(&code, &GRAPH_SIGNALS)
+        {
+            counts.fs_primitive_graph_functions += 1;
+            if !allow_fns.contains(&(rel, f.name.as_str())) {
+                counts.fs_primitive_functions_flagged += 1;
+                found.push(Finding {
+                    site,
+                    rule: Rule::FsPrimitive,
+                    token: sig.to_string(),
+                });
             }
         }
     }


### PR DESCRIPTION
## What

The lock tripwire stops matching write CALL NAMES. A function that puts bytes over a path it names
as a graph must hold the graph lock, whatever filesystem primitive it reaches for.

Closes #104. **Instrument only, no production code moves here.** Locking the writers it now sees is
#87, next in this lane.

## Why the instrument had to be fixed before #87

`tests/lock_tripwire_test.rs` recognised three tokens, `write_back(`, `update_and_write(` and
`mutate_and_write(`, and skipped any file containing none of them *before examining a single
function*. `src/graph_move.rs` has its own complete write path (`fs::write` then `graph_health` then
`fs::rename`, plus rollback `fs::copy` over **both** graph files) and uses none of the three, so
**the tripwire had never opened that file.** Not "opened it and passed it". `doctor::restore_tier`
(`fs::copy` plus `fs::rename` straight over the graph) is the same shape behind a file-scoped
exemption.

Measured on `610636e` with the instrument unchanged:

```
tripwire: scanned 99 files under src/
tripwire: 10 graph-writing function(s) required to hold the lock
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

Green, while **twelve** unlocked whole-file graph writers sat in that tree: the nine `write_back`
sites behind file-scoped exemptions, and three fs-primitive routes it never opened a file to find.

That green is why #87 cannot be verified through the old instrument. #87 removes `doctor.rs`'s
exemption and locks `repair_tier`; the tripwire would then go green **on `doctor.rs`** while
`restore_tier` still overwrote the graph unlocked, and #87 would ship with a worthless certificate.

## Red-first (law 25)

The three legs land in the first commit against the **unwidened** detector, so their RED run is real
and reproducible rather than asserted afterwards. The second commit turns on exactly the enforcement
and nothing else.

Both arms below were re-run on **this** branch, on today's base `de01d7b`, after it was rebased
forward. The shas in the header are the ones the runner checked out and recorded in each log, and it
derives them from `git log` rather than taking them as arguments. The script that
opens this PR refuses if a log's recorded sha is not the commit it is about to label. That matters
because the earlier measurement was taken on commits that no longer exist on this branch, and
renaming a sha in a table would print a number for a commit that was never run.

| leg | `a748afa` red arm | `bf77dc1` widened |
|---|---|---|
| `the_widened_rule_sees_the_unlocked_fs_writers` (#104's acceptance) | **FAILED** | ok |
| `every_fs_primitive_shape_reaches_the_rule` (law 31 reach) | **FAILED** | ok |
| `every_graph_writer_outside_the_allow_list_takes_the_lock` | ok | ok |
| cargo | `FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.16s` | `ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s` |

The red arm is also the answer to "is the old detector still blind on today's main?". It runs the
new acceptance legs against the **unwidened** rule on base `de01d7b`, not on the older base the
first measurement used, and they still fail. The blindness is present tense.

The final head reproduces the green:

```
tripwire: 99 files scanned under src/
tripwire: 1277 non-test functions visited
tripwire: 626 test functions skipped
tripwire: 10 write-call function(s) required to hold the lock
tripwire: 157 fs write-primitive site(s) seen in non-test functions
tripwire: 9 unlocked function(s) name a graph path and call a primitive; 0 outside the rule 2 allow-list
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s
```

**The control hiding in those numbers:** write-call functions checked is **10** on the
final head, in the red arm and in the green arm alike, which is what the script that opens this PR
checks across all three logs before it will publish the claim. Adding the test-module skip therefore
introduced no rule-1 regression. Otherwise that would be prose.

## The three legs

* **`the_widened_rule_sees_the_unlocked_fs_writers`** is #104's acceptance leg. It runs the scan
  with **both allow-lists empty** and asserts the three known unlocked writers are reported **by
  name**, not by count. A rule too loose (exempts everything) and one too narrow (never fires) are
  both green in the main test; this is what separates them. It expires when #87 lands.
* **`every_fs_primitive_shape_reaches_the_rule`** is law 31. It proves the rule reaches every
  primitive shape **enumerated from the codebase**, and asserts the shape table equals
  `FS_PRIMITIVES` so the two cannot drift. Three negative controls prove it is not simply flagging
  everything: no graph path named, lock held, and a `#[cfg(test)]` fixture.
* **control counts.** A scan that visited zero files, zero functions or zero primitive sites proved
  NOTHING, and fails saying so rather than passing quietly.

`scan_file` takes both allow-lists as **parameters** rather than reading the constants. A detector
that can only be run with its own exemptions applied cannot be asked what it can *see*, which is the
question #104 is about, and it lets a reviewer re-run the scan with any lists and get finding
*sites* as strings.

## Two decisions worth reviewing

**Rule 2's exemptions are `(FILE, FUNCTION)` pairs, and that is load-bearing.** File scope is
exactly what would let `restore_tier` ship unlocked inside a `doctor.rs` the tripwire had just
certified green; repeating it in the wider rule rebuilds that hole one level up. Rule 1 keeps file
scope where it is right: `src/dashboard/api.rs` is one deliberate entry covering 17 sites.

**The test-module skip is working code now, not a comment.** The previous version carried *"Skip the
test modules: fixtures legitimately write graphs directly"* above code that skipped comment LINES
and no test module at all. Harmless while three named calls were matched; fatal with primitives in
scope, because **626 of the 1903 functions under `src/` are test code** (both counts
printed by the run above), including
`src/hook/session_start.rs`'s own `graph.nq` fixture, which is that file's only filesystem
primitive. Greening that by re-adding files to an allow-list would re-blind the exact files under
repair.

## What rule 2 flags today, and each disposition

9 functions, which is exactly the number of rows `ALLOW_FNS` declares, cross-checked
against the constant before this PR was opened. Every `ALLOW_FNS` reason names the non-graph file
that function actually writes: an exemption that cannot say what it writes is a hole.

| file::fn | what it writes | disposition |
|---|---|---|
| `graph_move.rs::write_validated` | the graph (temp then rename) | `(#87)`, row removed when it takes the lock |
| `graph_move.rs::commit` | rollback copies over **both** graphs | `(#87)`, same |
| `doctor.rs::restore_tier` | the graph (copy then rename) | `(#87)`, same |
| `store.rs::write_back_inner` | the graph, under the seam | permanent, this **is** the atomic write |
| `doctor.rs::repair_tier` | the `.quarantine-<stamp>` sidecar | permanent, its graph write is rule 1's |
| `graph.rs::auto_compact_tiers` | the `.last-auto-compact` marker | permanent, its graph write is rule 1's |
| `install.rs::create_global_tier` | `base.toml`, `standards.toml`, seed docs | permanent, writes no graph |
| `relay/mod.rs::export_nq` | `inbox.nq`, an ephemeral export | permanent, never a tier graph |
| `scaffold.rs::run` | `domains.toml`, `base.toml` | permanent, writes no graph |

9 entries now, 6 once #87 lands: the three `(#87)` rows come off together.

**Signal notes.** `"nq.` is not decoration: `doctor::restore_tier` is reached by **no other signal**,
its only tell being `path.with_extension("nq.tmp")`. And `lock_path(` is deliberately *not* a graph
signal: the relay has a `lock_path` of its own over its spool, and including it flagged
`relay::with_lock`, which touches no graph.

## Mutation check

Pulling the `graph_move.rs::write_validated` row out of `ALLOW_FNS` reds the suite and names it:

```
src/graph_move.rs::write_validated  [rule 2, fs primitive: "nq.]
```

## clippy, the gate and its control (law 24)

`rustc 1.95.0 (59807616e 2026-04-14)`

| run | rc |
|---|---|
| control, permissive `cargo clippy --all-targets` | **0** |
| gate, `cargo clippy --all-targets -- -D warnings` | **0** |

The permissive run is not decoration, and on this branch it did not stay theoretical. It caught two
things the gate alone could not have told apart.

**It separated a missing tool from a failing crate.** The first attempt at this leg returned rc 127
from a harness shell that had no `~/.cargo/bin` on PATH. Read through the gate alone that is just a
non-zero rc, indistinguishable from real warnings; the control named it as a missing tool, and no
verdict reached the record.

**It found a real red on this branch before the gate did.** The control returned rc 0 while printing
two `clippy::collapsible_if` warnings, both in this PR's own file:

```
tests/lock_tripwire_test.rs:367:9  this `if` statement can be collapsed
tests/lock_tripwire_test.rs:387:9  this `if` statement can be collapsed
warning: `base` (test "lock_tripwire_test") generated 2 warnings
```

Under `-D warnings` those became errors and the gate returned **101**, `could not compile base (test
"lock_tripwire_test") due to 2 previous errors`. `8272b67` collapses both with let-chains,
which is what clippy suggested and what `src/` already does in 80 places on edition 2024. Both sites
are pure conjunctions, no `else` on either arm and nothing between the outer `if` and the inner one,
so the collapse cannot move a printed count; the counts above are the re-run saying so rather than
this paragraph asserting it.

Control rc 0 proves clippy actually ran, which is what makes gate rc 0 mean something. Run against
`de01d7b`, after #119 made this a blocking check.

**The green log does not name what it covered, so the green was checked against the artifacts.** The
failing run named its target in the warning line; the passing run prints only `Checking base` and
`Finished`, which is a green that says nothing about whether the test target was linted at all. Two
fingerprints exist for `test-integration-test-lock_tripwire_test`, and they agree on `rustc`,
`target` and `path` and differ **only** in `profile`, which is the component that must differ
between a lint pass and a test build. The one written at 12:30:03Z falls inside the gate leg's
window of 12:29:50Z to 12:30:06Z; the other, at 12:30:09Z, is the tripwire building its binary
afterwards. That establishes the gate processed this file. It does not establish what a clippy
profile hash looks like in general, and is not offered as that.

## Found while testing this

**#121**, filed to milestone 0.14.4, unranked: the `session_start.rs` "sentinel" `ALLOW_FILES` entry
is an exemption, so it guarantees the tripwire will **not** fire there, the opposite of what it was
placed to do. Measured as a pair with a control, the same injected unlocked write: entry present
gives green and unnamed, entry removed gives red and named. Nothing is mis-permitted today; the
exposure is the future write the entry was placed to catch. Deliberately not fixed here.

`2bb3ac4` removes the words "the sentinel" from a doc comment in this PR's own file: the same
false capability claim, which I had written, about the instrument the claim is about.

---

Refs #104, #87, #121.

https://claude.ai/code/session_014PnkVcTBJ6PRiWAXFAUbhu
