### PR TITLE
ci: --no-fail-fast on the trunk suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: cargo test
-        run: cargo test
+        run: cargo test --no-fail-fast
       # Cut a whole release in a throwaway clone. It runs here rather than in a
       # job of its own because it reuses this one's target directory and cargo
       # registry; on its own it would pay for both again. 0.13.16's first


### PR DESCRIPTION
One line. In `.github/workflows/ci.yml`, the ubuntu `test` job's `run: cargo test` becomes `run: cargo test --no-fail-fast`. Nothing else is touched.

## Why this one passes the bar

It is the instrument that decides whether real user-facing bugs are seen at all: while it is absent, one red target aborts the trunk suite and every target after it is never measured, so a genuine user-facing failure can sit on `main` reported as "one test failed". Verification discipline is explicitly exempt from the no-internal-work bar.

## The defect, measured

`cargo test` stops at the first test binary that fails. Run [34243724191](https://github.com/ChristopherKahler/base/actions/runs/34243724191) at `1199219a02b645bce6931e7e81e541fb1f46527c`, ubuntu `test` job `102120189361`, step `cargo test` = `failure`:

| | |
|---|---|
| integration targets in `tests/` at that head | **62** |
| targets the log shows `Running` | **4** |
| last target with a `FAILED` result | `ast_extension_registry` |
| targets that **never ran** | **58 of 62** |

cargo ran the two unit-test binaries and four integration targets in alphabetical order, hit a failure inside `ast_extension_registry`, and stopped. Among the 58 that never executed: `ast_relation_query_test`, `hook_log_tier_test`, `hook_output_channel_test`, `guard_test`, `lock_tripwire_test`, `fork_test`.

Those 58 are not green and not red on that commit. They are **unmeasured** — and the job reports one failure whether the true count is 1 or 40.

## What it does not change

- The job still fails when anything fails. `--no-fail-fast` changes what gets *reported*, never what gets *enforced*.
- No new jobs, no matrix, no runner changes, no test changes.
- Not a fix for #128 or #129. Those are separate and both measured non-user-facing this round.
- Deliberately does **not** touch `.gitattributes`. #125 was closed `not_planned`; nothing here reopens it.

## How the edit was made

Anchored on content, not on a line number: the exact byte string `        run: cargo test\r\n`, asserted to occur **exactly once** in the file, aborting without writing on any other count. This matters because an unanchored grep for `cargo test` in this file hits the step's *display name* first, and renaming a step passes review by eye while changing nothing.

The workflow was re-parsed after the edit and `cargo test --no-fail-fast` is present in the parsed `jobs.test.steps` structure, not merely in the text.
