### PR TITLE
fix(install): #93 permanently-inert install, #92 scripts/ast beside the binary

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -143,15 +143,18 @@
             Say '  then reopen your terminal.'
         }
 
-        # Hooks are only written into an existing ~\.claude. Installing base
-        # before Claude Code leaves it inert with no way to self-heal, because the
-        # repair runs from the session-start hook that was never wired. Test
-        # settings.json, not the directory: `base install` creates ~\.claude
-        # itself for the bundled skill, so the directory always exists afterwards.
+        # Since #93 `base install` wires the hooks even when Claude Code is not
+        # installed yet: it creates ~\.claude itself for the bundled skill, and
+        # the wiring is deferred to after that rather than dropped, so a later
+        # Claude Code finds them. This file therefore exists after every install
+        # that did not pass --skip-hooks; if it does not, the wiring FAILED
+        # rather than being deferred. Test settings.json, not the directory,
+        # which `base install` creates either way.
         if (-not (Test-Path (Join-Path $binHome '.claude\settings.json'))) {
             Say ''
-            Say 'base: no ~\.claude directory, so the hooks were not wired and base will'
-            Say '  not do anything yet. Install Claude Code, then run:'
+            Say 'base: the hooks were not wired, so base will not do anything yet.'
+            Say '  Re-run the line below; if it happens twice, please report it at'
+            Say '  https://github.com/ChristopherKahler/base/issues'
             Say ''
             Say '    base install'
             Say ''

--- a/install.sh
+++ b/install.sh
@@ -105,16 +105,19 @@ case ":${PATH}:" in
     ;;
 esac
 
-# Hooks are what make base do anything, and they are only written into an
-# existing ~/.claude. Installing base before Claude Code leaves it inert with no
-# way to self-heal, because the repair runs from the session-start hook that was
-# never wired. Test settings.json rather than the directory: `base install`
-# creates ~/.claude itself to hold the bundled skill, so the directory always
-# exists afterwards and cannot tell us anything.
+# Hooks are what make base do anything. Since #93 `base install` wires them even
+# when Claude Code is not installed yet: it creates ~/.claude itself for the
+# bundled skill, and the wiring is deferred to after that rather than dropped, so
+# a later Claude Code finds them. This file therefore exists after every install
+# that did not pass --skip-hooks; if it does not, the wiring FAILED rather than
+# being deferred, and that is worth saying. Test settings.json rather than the
+# directory, which `base install` creates either way and which cannot tell us
+# anything.
 if [ ! -f "$root/.claude/settings.json" ]; then
   say ""
-  say "base: no ~/.claude directory, so the hooks were not wired and base will"
-  say "  not do anything yet. Install Claude Code, then run:"
+  say "base: the hooks were not wired, so base will not do anything yet."
+  say "  Re-run the line below; if it happens twice, please report it at"
+  say "  https://github.com/ChristopherKahler/base/issues"
   say ""
   say "    base install"
   say ""

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1445,6 +1445,22 @@ fn tier_cwd(cwd: &std::path::Path, global: bool) -> std::path::PathBuf {
 
 pub fn run() {
     let cli = Cli::parse();
+
+    // #93: `ensure_hooks_wired` had exactly one caller — the session-start hook
+    // — so a home whose hooks were never wired had no path back: no hook fires,
+    // therefore nothing re-checks, and `base update` re-wires nothing either.
+    // Any ordinary command repairs it now. The gate is one stat on a per-version
+    // stamp, which that function checks before anything else.
+    //
+    // The hook arm is excluded on purpose. `hook::dispatch` reaches
+    // `session_start`, which calls the same function and uses its RETURN VALUE
+    // to print the `[hooks]` notice; calling it here first would consume the
+    // wiring and hand that notice an empty vec — a silent regression with
+    // nothing to fail.
+    if !matches!(&cli.command, Some(Commands::Hook { .. })) {
+        let _ = base::install::ensure_hooks_wired();
+    }
+
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1452,12 +1452,44 @@ pub fn run() {
     // Any ordinary command repairs it now. The gate is one stat on a per-version
     // stamp, which that function checks before anything else.
     //
-    // The hook arm is excluded on purpose. `hook::dispatch` reaches
-    // `session_start`, which calls the same function and uses its RETURN VALUE
-    // to print the `[hooks]` notice; calling it here first would consume the
-    // wiring and hand that notice an empty vec — a silent regression with
-    // nothing to fail.
-    if !matches!(&cli.command, Some(Commands::Hook { .. })) {
+    // Three arms are excluded, all for one reason: they OWN the hook state, so
+    // reaching it from here takes the decision away from them — and this call
+    // runs BEFORE the dispatch, so it always wins.
+    //
+    // These three are not a guess. `wire_hooks_quiet` and `remove_hooks` are the
+    // only writers of `~/.claude/settings.json` in the tree; of the 39 `Commands`
+    // variants, exactly these three reach one. (`Hooks` only prints the manifest.)
+    //
+    // `Hook` — `hook::dispatch` reaches `session_start`, which calls this same
+    // function and uses its RETURN VALUE to print the `[hooks]` notice. Calling
+    // it here first would consume the wiring and hand that notice an empty vec:
+    // a silent regression with nothing to fail.
+    //
+    // `Install` — step 3 wires, and #93's deferred block wires after step 8.
+    // Without this arm, `base install --skip-hooks` on a home that already has
+    // `~/.claude` wired all five hooks and stamped the version, and step 3's
+    // `⊘ Hook wiring skipped (--skip-hooks)` then printed over work already done.
+    // The flag is documented as "skip hook wiring in settings.json" and it held
+    // before #93 only because this function had exactly one caller.
+    //
+    // `Uninstall` — `remove_hooks` is reached from nowhere else. Without this
+    // arm, `base uninstall` on a home with `~/.claude/` and no `settings.json`
+    // took `wire_hooks_quiet`'s "the parent is a directory" branch, CREATED that
+    // file, wired five hooks and stamped the version — and `remove_hooks` then
+    // stripped them and reported removing hooks from settings.json. A command
+    // asked to remove base left behind a config file that was never there.
+    //
+    // Both non-hook arms were found in review — the first by raven reading the
+    // tree, the second by sweeping every variant against the mutators' callers.
+    // The controls beside them could not reach either: their fake homes have no
+    // `~/.claude` at entry, so this seam returns empty for an unrelated reason
+    // and the legs passed while the product was broken.
+    if !matches!(
+        &cli.command,
+        Some(Commands::Hook { .. })
+            | Some(Commands::Install { .. })
+            | Some(Commands::Uninstall { .. })
+    ) {
         let _ = base::install::ensure_hooks_wired();
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -942,33 +942,48 @@ fn migrate_carl(global_dir: &Path, carl_path: &Path) -> Result<()> {
 
 // ─── Step 5: Install scripts ────────────────────────────────
 
+/// The file that marks a real `scripts/ast` directory. Probed rather than the
+/// directory itself, so a half-finished copy cannot answer as a source.
+const AST_SCRIPTS_MARKER: &str = "onto_ast.py";
+
+/// Where `scripts/ast/` lives relative to a `base` binary, most specific first.
+///
+/// `cwd` is a parameter rather than read from the process because
+/// `std::env::current_dir` is process-global: a test that set it would race
+/// every other test in the same binary.
+pub fn ast_scripts_source(binary_path: &Path, cwd: &Path) -> Option<std::path::PathBuf> {
+    // `n` levels above the binary's own directory, then `scripts/ast`.
+    let up = |n: usize| -> Option<std::path::PathBuf> {
+        let mut p = binary_path.parent()?;
+        for _ in 0..n {
+            p = p.parent()?;
+        }
+        Some(p.join("scripts").join("ast"))
+    };
+
+    [
+        // Source repo, binary one level in.
+        up(1),
+        // Cargo target dir: target/<profile>/base → ../../scripts/ast.
+        up(2),
+        // Whatever directory the shell happened to be in.
+        Some(cwd.join("scripts").join("ast")),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|p| p.join(AST_SCRIPTS_MARKER).exists())
+}
+
 fn install_scripts(binary_path: &Path, global_dir: &Path) -> Result<()> {
     print!("5. Install AST scripts ... ");
 
     let scripts_dest = global_dir.join("scripts").join("ast");
     std::fs::create_dir_all(&scripts_dest)?;
 
-    // Find scripts relative to the binary source (dev builds) or cwd
-    let source_candidates = [
-        // Same directory as source repo
-        binary_path
-            .parent()
-            .and_then(|p| p.parent())
-            .map(|p| p.join("scripts").join("ast")),
-        // Cargo target dir (target/release/../scripts/ast → ../../scripts/ast)
-        binary_path
-            .parent()
-            .and_then(|p| p.parent())
-            .and_then(|p| p.parent())
-            .map(|p| p.join("scripts").join("ast")),
-        // Current working directory
-        Some(std::env::current_dir().unwrap_or_default().join("scripts").join("ast")),
-    ];
-
-    let source_dir = source_candidates
-        .iter()
-        .filter_map(|p| p.as_ref())
-        .find(|p| p.join("onto_ast.py").exists());
+    let source_dir = ast_scripts_source(
+        binary_path,
+        &std::env::current_dir().unwrap_or_default(),
+    );
 
     let Some(source_dir) = source_dir else {
         // No source near the binary (e.g. `cargo install` drops only the binary,
@@ -986,7 +1001,7 @@ fn install_scripts(binary_path: &Path, global_dir: &Path) -> Result<()> {
 
     // Copy all .py files
     let mut count = 0;
-    for entry in std::fs::read_dir(source_dir)? {
+    for entry in std::fs::read_dir(&source_dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.extension().is_some_and(|ext| ext == "py") {

--- a/src/install.rs
+++ b/src/install.rs
@@ -56,12 +56,13 @@ pub fn run(
     create_global_tier(&global_dir)?;
 
     // Step 3: Wire hooks in ~/.claude/settings.json
-    if !skip_hooks {
-        let settings_path = home.join(".claude").join("settings.json");
-        wire_hooks(&settings_path)?;
+    let settings_path = home.join(".claude").join("settings.json");
+    let hooks_deferred = if !skip_hooks {
+        wire_hooks(&settings_path)?
     } else {
         println!("⊘ Hook wiring skipped (--skip-hooks)\n");
-    }
+        false
+    };
 
     // Step 4: Migrate carl.json decisions if provided
     if let Some(carl_path) = carl_json_path {
@@ -89,6 +90,23 @@ pub fn run(
     // Step 8: Append BASE CLI section to ~/.claude/CLAUDE.md
     let claude_md = home.join(".claude").join("CLAUDE.md");
     append_claude_md(&claude_md)?;
+
+    // #93: step 3 could not wire because ~/.claude did not exist yet. Steps 7
+    // and 8 have since created it — for base's own bundled skill, then for
+    // CLAUDE.md — so the wiring lands now rather than never. Without this, a
+    // home that got base before Claude Code stays inert through the install
+    // AND through the first session, because the session has no base hook to
+    // run. `--skip-hooks` never reaches here: it sets `hooks_deferred` false.
+    if hooks_deferred {
+        let added = wire_hooks_quiet(&settings_path).unwrap_or_default();
+        if !added.is_empty() {
+            println!(
+                "   ↳ hooks wired into {} after all — base created that directory for its \
+                 own skill, so Claude Code will find them when it is installed.",
+                settings_path.display()
+            );
+        }
+    }
 
     // Step 9: Write manifest.toml
     write_manifest(&global_dir, full)?;
@@ -807,12 +825,33 @@ pub fn hooks_manifest() -> serde_json::Value {
     })
 }
 
-fn wire_hooks(settings_path: &Path) -> Result<()> {
+/// True when there is somewhere for the hook wiring to land: the settings file,
+/// or the directory that would hold it.
+///
+/// Deliberately NOT a test for "is Claude Code installed" — `base install`
+/// creates `~/.claude` itself for the bundled skill, so the directory proves
+/// nothing about that. It answers the only question the wiring needs: can this
+/// write reach a file Claude Code will read.
+fn claude_config_tier(settings_path: &Path) -> bool {
+    settings_path.exists() || settings_path.parent().is_some_and(|d| d.is_dir())
+}
+
+/// Wire the hooks, returning whether the wiring was DEFERRED for want of a
+/// `~/.claude` to write into.
+///
+/// Deferred, not abandoned: steps 7 and 8 of this same install create that
+/// directory themselves — the bundled skill, then CLAUDE.md — so a wiring that
+/// cannot land at step 3 can land after them, in the same run. Before #93 it
+/// was simply dropped, and a home that got base before Claude Code had no path
+/// back at all: Claude Code learns about base's hooks from settings.json, so
+/// without one base never runs inside a session, and the repair that would fix
+/// it ran from a hook.
+fn wire_hooks(settings_path: &Path) -> Result<bool> {
     print!("3. Wire hooks → {} ... ", settings_path.display());
 
-    if !settings_path.exists() && !settings_path.parent().is_some_and(|d| d.is_dir()) {
-        println!("⊘ no ~/.claude directory (is Claude Code installed?), skipped");
-        return Ok(());
+    if !claude_config_tier(settings_path) {
+        println!("⊘ no ~/.claude directory (is Claude Code installed?), deferred to step 8");
+        return Ok(true);
     }
 
     let added = wire_hooks_quiet(settings_path)?;
@@ -821,7 +860,7 @@ fn wire_hooks(settings_path: &Path) -> Result<()> {
     } else {
         println!("✓ (added base hook {})", added.join(", "));
     }
-    Ok(())
+    Ok(false)
 }
 
 /// Session start: wire any hook this release added that the host's
@@ -841,6 +880,15 @@ pub fn ensure_hooks_wired() -> Vec<&'static str> {
         return Vec::new();
     }
     let settings = home.join(".claude").join("settings.json");
+    // An empty result has two causes — already wired, and nothing to write into
+    // — and stamping the second is what made #93 PERMANENT rather than merely
+    // delayed: one call on a home with no Claude Code disarmed the repair for
+    // the rest of this version's life. Stamp only when there was a config tier
+    // to reconcile against; otherwise leave it absent and retry next time, at a
+    // cost of two stats.
+    if !claude_config_tier(&settings) {
+        return Vec::new();
+    }
     let added = wire_hooks_quiet(&settings).unwrap_or_default();
     let _ = std::fs::write(&stamp, b"");
     added
@@ -962,6 +1010,13 @@ pub fn ast_scripts_source(binary_path: &Path, cwd: &Path) -> Option<std::path::P
     };
 
     [
+        // An unpacked release archive: `base` and `scripts/ast/` are siblings.
+        // `.github/workflows/release.yml` stages exactly that and tars from
+        // inside `staging/`, so this is the only candidate here derived from a
+        // layout base itself ships. It is first because it is the most
+        // specific, and it shadows no dev layout: for `target/<profile>/base`
+        // it names `target/<profile>/scripts/ast`, which nothing produces.
+        up(0),
         // Source repo, binary one level in.
         up(1),
         // Cargo target dir: target/<profile>/base → ../../scripts/ast.

--- a/tests/hooks_self_heal_test.rs
+++ b/tests/hooks_self_heal_test.rs
@@ -56,3 +56,72 @@ fn no_claude_directory_means_nothing_to_wire() {
     assert!(wire_hooks_quiet(&settings).unwrap().is_empty());
     assert!(!settings.exists(), "base never invents a Claude Code install");
 }
+
+// ─── Issue #93 ──────────────────────────────────────────────
+//
+// `ensure_hooks_wired` returns an empty vec for TWO different states: "already
+// fully wired" and "there is no ~/.claude directory to write into". It stamped
+// the version for both. So on a machine where base was installed before Claude
+// Code, the first call disarmed the repair for the rest of that version's life
+// — which is what turns a delay into the permanent inertness #93 reports.
+//
+// The stamp means "reconciled against a real Claude Code config", not "tried".
+
+/// The stamp file `ensure_hooks_wired` gates itself on.
+fn stamp_of(home: &std::path::Path) -> std::path::PathBuf {
+    home.join(".base-gbl")
+        .join(format!(".hooks-wired-{}", env!("CARGO_PKG_VERSION")))
+}
+
+#[test]
+fn no_claude_code_yet_leaves_the_stamp_absent_so_the_next_run_retries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    // `.base-gbl` exists on every real install (step 2 runs before step 3), and
+    // it has to exist here too: without it the stamp write fails for an
+    // unrelated reason and this test would pass without proving anything.
+    std::fs::create_dir_all(home.join(".base-gbl")).unwrap();
+    assert!(home.join(".base-gbl").is_dir(), "the stamp has somewhere to land");
+    // No ~/.claude at all: base installed before Claude Code.
+    assert!(!home.join(".claude").exists());
+
+    base::home::with_thread_home(&home, || {
+        assert!(ensure_hooks_wired().is_empty(), "nothing to wire yet");
+        assert!(
+            !stamp_of(&home).exists(),
+            "no Claude Code config was reconciled, so nothing is stamped"
+        );
+
+        // Claude Code arrives. The very next call repairs, with no re-install.
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let added = ensure_hooks_wired();
+        assert_eq!(added.len(), HOOK_TABLE.len(), "every hook, on the next run");
+
+        let text = std::fs::read_to_string(home.join(".claude").join("settings.json")).unwrap();
+        for (_, cmd) in HOOK_TABLE {
+            assert_eq!(text.matches(cmd).count(), 1, "{cmd}: present exactly once");
+        }
+        assert!(stamp_of(&home).exists(), "now there was something to stamp");
+        assert!(ensure_hooks_wired().is_empty(), "and once per version after that");
+    });
+}
+
+#[test]
+fn an_already_wired_home_is_stamped_and_left_byte_identical() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    std::fs::create_dir_all(home.join(".claude")).unwrap();
+    std::fs::create_dir_all(home.join(".base-gbl")).unwrap();
+
+    let settings = home.join(".claude").join("settings.json");
+    base::home::with_thread_home(&home, || {
+        // Wire it once, then assert the second pass changes nothing at all.
+        assert_eq!(ensure_hooks_wired().len(), HOOK_TABLE.len());
+        std::fs::remove_file(stamp_of(&home)).unwrap();
+        let before = std::fs::read(&settings).unwrap();
+
+        assert!(ensure_hooks_wired().is_empty(), "nothing left to add");
+        assert_eq!(std::fs::read(&settings).unwrap(), before, "not one byte rewritten");
+        assert!(stamp_of(&home).exists(), "a real config WAS reconciled");
+    });
+}

--- a/tests/install_e2e_test.rs
+++ b/tests/install_e2e_test.rs
@@ -1,0 +1,300 @@
+//! End-to-end legs for #92 and #93, driven through the real binary.
+//!
+//! The unit legs in `install_scripts_source_test.rs` and `hooks_self_heal_test.rs`
+//! prove the two seams. These prove the WIRING: that `install_scripts` actually
+//! calls the candidate seam, and that `ensure_hooks_wired` actually has a caller
+//! outside the hook pipeline. A seam nothing calls is the whole shape of #93.
+//!
+//! Platform scope: these spawn `base` as a child process, the shape that #129
+//! (`STATUS_STACK_OVERFLOW`, debug profile only) crashes on Windows. Ubuntu CI is
+//! the acceptance surface; `cargo test --release` corroborates on Windows.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// The binary under test. Cargo builds it for this test target, so it is always
+/// this tree's binary and never something left in the target dir by another
+/// branch.
+const BASE: &str = env!("CARGO_BIN_EXE_base");
+
+/// This repo's real `scripts/ast/`, the directory the release archive stages.
+fn repo_scripts_ast() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts").join("ast")
+}
+
+fn mkdir(p: impl AsRef<Path>) -> PathBuf {
+    let p = p.as_ref().to_path_buf();
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// Lay out what `tar xzf base-linux-x86_64.tar.gz -C <into>` leaves behind:
+/// the binary and `scripts/ast/` as siblings. Returns the binary's path.
+///
+/// `requirements.txt` is deliberately NOT staged. `install_scripts` shells out
+/// to `pip install -r` when it lands one, and this leg is about where the
+/// scripts come from, not about pip.
+fn unpack_fake_archive(into: &Path) -> PathBuf {
+    mkdir(into);
+    let binary = into.join(format!("base{}", std::env::consts::EXE_SUFFIX));
+    // Hard link where the filesystem allows it: a debug binary is large and this
+    // runs twice. Content is identical either way, which is all that matters.
+    if std::fs::hard_link(BASE, &binary).is_err() {
+        std::fs::copy(BASE, &binary).unwrap();
+    }
+
+    let dest = mkdir(&into.join("scripts").join("ast"));
+    let mut staged = 0;
+    for entry in std::fs::read_dir(repo_scripts_ast()).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().is_some_and(|e| e == "py") {
+            std::fs::copy(&path, dest.join(path.file_name().unwrap())).unwrap();
+            staged += 1;
+        }
+    }
+    // Law 23: a loop that asserts over a set prints what it visited, and zero
+    // visited is a failure. A silently empty archive would make every assertion
+    // below meaningless.
+    assert!(staged >= 2, "staged {staged} .py files into the fake archive");
+    assert!(dest.join("onto_ast.py").is_file(), "the marker install probes for");
+    binary
+}
+
+/// A skills source beside the archive, so `install_skills` resolves locally and
+/// this test never reaches the network. `find_local_skills_dir` probes
+/// `<binary>/../../claude/skills` first, which is `<parent of archive>`.
+fn seed_local_skill(archive_parent: &Path) {
+    let dir = mkdir(&archive_parent.join("claude").join("skills").join("base-help"));
+    std::fs::write(dir.join("SKILL.md"), "---\nname: base-help\n---\n").unwrap();
+}
+
+/// Windows `STATUS_STACK_OVERFLOW` (`0xC00000FD`) as a process exit code. This
+/// is #129, and it is debug-profile only — tern measured `ovf=0` on every one of
+/// four targets with a release arm.
+const STATUS_STACK_OVERFLOW: i32 = 0xC000_00FD_u32 as i32;
+
+/// Run `base` with an explicit environment. Nothing is inherited implicitly:
+/// `BASE_HOME` is the only tier this touches, and `HOME` is left alone so the
+/// write tripwire stays armed (it compares against the real profile).
+///
+/// The crash check is not politeness. When #129 kills the child at startup it
+/// writes nothing, so an assertion on an ABSENCE — "stdout does not mention
+/// hooks", "settings.json was not created" — passes for the wrong reason, and
+/// an assertion on a presence fails with a message about the product rather
+/// than about the corpse. Law 24: a leg whose "could not run" and "failed"
+/// states share a shape is not a leg. Measured 2026-09-08: all seven legs in
+/// this file died this way on Windows debug, and one of them reported PASS.
+fn run_base(binary: &Path, cwd: &Path, home: &Path, args: &[&str]) -> std::process::Output {
+    let out = Command::new(binary)
+        .args(args)
+        .current_dir(cwd)
+        .env("BASE_HOME", home)
+        .env("BASE_NO_AUTO_UPDATE", "1")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap_or_else(|e| panic!("spawning {} {args:?}: {e}", binary.display()));
+
+    assert_ne!(
+        out.status.code(),
+        Some(STATUS_STACK_OVERFLOW),
+        "VOID, not a result: the child died with STATUS_STACK_OVERFLOW before it ran \
+         anything (#129, debug profile on Windows). Ubuntu CI is this file's acceptance \
+         surface; `cargo test --release` corroborates locally.\nargs: {args:?}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+// ─── #92 ────────────────────────────────────────────────────
+
+#[test]
+fn an_unpacked_archive_installs_the_ast_scripts_from_an_unrelated_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(&tmp.path().join("home"));
+    // The reproduction from the issue: run the unpacked binary from anywhere
+    // that is not the unpack directory.
+    let elsewhere = mkdir(&tmp.path().join("elsewhere"));
+
+    let out = run_base(&binary, &elsewhere, &home, &["install", "--no-starter-commands"]);
+    let installed = home.join(".base-gbl").join("scripts").join("ast");
+
+    assert!(
+        installed.join("extractor.py").is_file(),
+        "AST extraction is silently absent.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(installed.join("onto_ast.py").is_file());
+}
+
+#[test]
+fn the_same_archive_run_from_its_own_directory_also_installs_them() {
+    // The control. Before the fix this arm passed while the one above failed,
+    // which is the only reason either reading means anything: same script, same
+    // binary, one variable — the working directory.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(&tmp.path().join("home"));
+
+    let out = run_base(&binary, &archive, &home, &["install", "--no-starter-commands"]);
+    assert!(
+        home.join(".base-gbl").join("scripts").join("ast").join("extractor.py").is_file(),
+        "the cwd candidate still answers.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+// ─── #93 ────────────────────────────────────────────────────
+
+#[test]
+fn an_ordinary_command_wires_the_hooks_when_claude_code_arrived_later() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    // The state #93 describes, after Claude Code has been installed: base's
+    // global tier exists, `~/.claude` exists, and settings.json does not,
+    // because hook wiring was skipped at install time.
+    mkdir(&home.join(".base-gbl"));
+    mkdir(&home.join(".claude"));
+    let settings = home.join(".claude").join("settings.json");
+    assert!(!settings.exists(), "the precondition, stated rather than assumed");
+
+    let cwd = mkdir(&tmp.path().join("cwd"));
+    let out = run_base(Path::new(BASE), &cwd, &home, &["recall", "--keyword", "anything"]);
+
+    assert!(
+        settings.is_file(),
+        "an ordinary command left base inert.\nstatus:{:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = std::fs::read_to_string(&settings).unwrap();
+    for (event, cmd) in base::install::HOOK_TABLE {
+        assert_eq!(text.matches(cmd).count(), 1, "{event}: wired exactly once");
+    }
+
+    // And it does it silently: `base recall` must not grow a line of install
+    // chatter. This assertion is on an ABSENCE, so it only means anything
+    // beside the presence assertion above — on its own it would pass just as
+    // well against a process that printed nothing because it never ran.
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains("[hooks]"),
+        "the repair announced itself on an ordinary command:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn the_session_start_hook_still_announces_what_it_wired() {
+    // The control for excluding `Commands::Hook` from the CLI-level call. The
+    // hook path owns the `[hooks]` notice; if the CLI seam consumed the wiring
+    // first, this notice would silently disappear and nothing else would fail.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    mkdir(&home.join(".base-gbl"));
+    mkdir(&home.join(".claude"));
+
+    // An install from before the Stop hook existed: four of the five.
+    let four: Vec<String> = base::install::HOOK_TABLE
+        .iter()
+        .filter(|(event, _)| *event != "Stop")
+        .map(|(event, cmd)| format!(r#""{event}":[{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}]"#))
+        .collect();
+    assert_eq!(four.len(), 4, "seeded four of the five");
+    std::fs::write(
+        home.join(".claude").join("settings.json"),
+        format!("{{\"hooks\":{{{}}}}}", four.join(",")),
+    )
+    .unwrap();
+
+    let cwd = mkdir(&tmp.path().join("cwd"));
+    let out = run_base(Path::new(BASE), &cwd, &home, &["hook", "session-start"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("[hooks] wired base hook Stop"),
+        "the session-start notice named nothing.\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ─── #93, the reproduction in the issue ─────────────────────
+
+#[test]
+fn one_install_into_a_home_with_no_claude_code_still_leaves_the_hooks_wired() {
+    // The issue's own repro: "Install base into a home with no ~/.claude, then
+    // install Claude Code, then start a session."
+    //
+    // That session finds base's hooks or it finds nothing — there is no third
+    // path, because without settings.json base does not run inside a session at
+    // all. Step 3 cannot wire (no directory yet); steps 7 and 8 then create
+    // ~/.claude for base's own skill and CLAUDE.md. The wiring is deferred to
+    // after them rather than abandoned.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(&tmp.path().join("home"));
+    assert!(!home.join(".claude").exists(), "no Claude Code, stated not assumed");
+
+    let out = run_base(&binary, &archive, &home, &["install", "--no-starter-commands"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Step 3 still says what it saw. Losing that message would trade one silent
+    // state for another.
+    assert!(
+        stdout.contains("is Claude Code installed?"),
+        "step 3 stopped reporting what it found.\nstdout:\n{stdout}"
+    );
+
+    let settings = home.join(".claude").join("settings.json");
+    assert!(
+        settings.is_file(),
+        "the install left nothing for a later Claude Code to read.\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = std::fs::read_to_string(&settings).unwrap();
+    for (event, cmd) in base::install::HOOK_TABLE {
+        assert_eq!(text.matches(cmd).count(), 1, "{event}: wired exactly once");
+    }
+}
+
+#[test]
+fn skip_hooks_still_means_skip_hooks_even_after_base_creates_the_directory() {
+    // The control that separates "the wiring is deferred" from "the wiring is
+    // now unconditional". Without it the fix above could pass by quietly
+    // breaking --skip-hooks, and nothing else would fail.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(&tmp.path().join("home"));
+    let out = run_base(
+        &binary,
+        &archive,
+        &home,
+        &["install", "--no-starter-commands", "--skip-hooks"],
+    );
+
+    // base still creates ~/.claude for its own skill, so the directory existing
+    // is not the thing under test — settings.json is.
+    assert!(
+        home.join(".claude").is_dir(),
+        "base created its own skill directory regardless.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        !home.join(".claude").join("settings.json").exists(),
+        "--skip-hooks wrote hooks anyway.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/tests/install_e2e_test.rs
+++ b/tests/install_e2e_test.rs
@@ -298,3 +298,161 @@ fn skip_hooks_still_means_skip_hooks_even_after_base_creates_the_directory() {
         String::from_utf8_lossy(&out.stdout)
     );
 }
+
+#[test]
+fn skip_hooks_holds_when_claude_code_is_already_installed() {
+    // The shape the leg above CANNOT reach, and the only one an ordinary user is
+    // ever in: Claude Code got here first, so `~/.claude` exists BEFORE base runs.
+    //
+    // `cli::run` calls `ensure_hooks_wired` once, before it dispatches to any
+    // subcommand. A seam that excludes only `Commands::Hook` therefore reaches
+    // `install` too: with a config tier already present it wires all five hooks
+    // and stamps the version, and step 3's `⊘ Hook wiring skipped (--skip-hooks)`
+    // then prints over work that has already happened. The leg above passes
+    // against that bug, because its home has no `~/.claude` at entry and the seam
+    // returns empty for a reason that has nothing to do with the flag.
+    //
+    // Found by raven reading the tree, not by any test here. Law 31: a guard is
+    // only proven against the shapes the CODEBASE has, never against its own.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(tmp.path().join("home"));
+    mkdir(home.join(".claude"));
+    // The stamp needs somewhere to land, or a write that "did not happen" may
+    // only have failed, and this leg would pass without proving anything.
+    mkdir(home.join(".base-gbl"));
+
+    let settings = home.join(".claude").join("settings.json");
+    let stamp = home
+        .join(".base-gbl")
+        .join(format!(".hooks-wired-{}", env!("CARGO_PKG_VERSION")));
+    assert!(!settings.exists(), "the precondition, stated rather than assumed");
+    assert!(!stamp.exists(), "and this version is unstamped, which is what arms the seam");
+
+    let out = run_base(
+        &binary,
+        &archive,
+        &home,
+        &["install", "--no-starter-commands", "--skip-hooks"],
+    );
+
+    assert!(
+        !settings.exists(),
+        "--skip-hooks wrote hooks anyway, into a home that already had ~/.claude.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        !stamp.exists(),
+        "--skip-hooks stamped the version, which disarms the repair for the rest of it.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn uninstall_does_not_create_a_settings_file_on_its_way_to_emptying_one() {
+    // The same shape as the leg above, one command over, and found by sweeping
+    // all 39 `Commands` variants against every caller of the two settings.json
+    // mutators rather than by trusting a list. Exactly three commands own hook
+    // state: `Hook` (session_start), `Install` (step 3 and the deferred block)
+    // and `Uninstall` (`remove_hooks`, whose only caller is `install::uninstall`).
+    //
+    // `~/.claude/` exists and `settings.json` does not — a Claude Code install
+    // that has never been configured. The CLI seam runs before the dispatch, so
+    // an exclusion list missing `Uninstall` lets `wire_hooks_quiet` take the
+    // "parent is a dir" branch, CREATE the file, wire five hooks and stamp the
+    // version — and `remove_hooks` then strips them and reports that it removed
+    // hooks from settings.json. The user asked base to leave, and it left a
+    // config file behind that was never there.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+
+    let home = mkdir(tmp.path().join("home"));
+    mkdir(home.join(".claude"));
+    mkdir(home.join(".base-gbl"));
+
+    let settings = home.join(".claude").join("settings.json");
+    let stamp = home
+        .join(".base-gbl")
+        .join(format!(".hooks-wired-{}", env!("CARGO_PKG_VERSION")));
+    assert!(!settings.exists(), "the precondition, stated rather than assumed");
+    assert!(!stamp.exists(), "and this version is unstamped, which is what arms the seam");
+
+    let out = run_base(&binary, &archive, &home, &["uninstall"]);
+
+    assert!(
+        !settings.exists(),
+        "uninstall created a settings.json that was never there.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        !stamp.exists(),
+        "uninstall stamped the hooks version on its way out.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn a_second_install_over_the_first_leaves_settings_json_byte_identical() {
+    // Law 22: an installer gets a first-run leg AND an over-the-top-of-an-
+    // existing-install leg, and the assertion is on CONTENT, not presence.
+    // Every other leg in this file uses a fresh home, so none of them would
+    // notice a re-install that duplicated the hook entries or rewrote the file.
+    //
+    // The assertion is byte identity rather than "the hooks are still there":
+    // `wire_hooks_quiet` returns early when every command in HOOK_TABLE is
+    // already present, so a correct second install must not touch the file at
+    // all. A version that re-serialised it — same hooks, reordered keys — would
+    // pass a presence check and fail this one.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(tmp.path().join("home"));
+    mkdir(home.join(".claude"));
+    let settings = home.join(".claude").join("settings.json");
+
+    let first = run_base(&binary, &archive, &home, &["install", "--no-starter-commands"]);
+    assert!(
+        settings.is_file(),
+        "the first install did not wire anything, so the second proves nothing.\nstdout:\n{}",
+        String::from_utf8_lossy(&first.stdout)
+    );
+    let before = std::fs::read(&settings).unwrap();
+    for (event, cmd) in base::install::HOOK_TABLE {
+        let text = String::from_utf8_lossy(&before);
+        assert_eq!(text.matches(cmd).count(), 1, "{event}: wired exactly once by the first run");
+    }
+
+    let second = run_base(&binary, &archive, &home, &["install", "--no-starter-commands"]);
+    // Byte identity is an assertion on an ABSENCE of change, so it passes just
+    // as well against a second install that died at step 1 and never reached the
+    // wiring. Prove it ran the whole way first.
+    let stdout = String::from_utf8_lossy(&second.stdout).into_owned();
+    assert!(
+        stdout.contains("Install complete"),
+        "the second install did not finish, so byte identity proves nothing.\n\
+         status:{:?}\nstdout:\n{stdout}\nstderr:\n{}",
+        second.status.code(),
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    let after = std::fs::read(&settings).unwrap();
+
+    assert_eq!(
+        before.len(),
+        after.len(),
+        "the second install changed settings.json's length.\nstdout:\n{}",
+        String::from_utf8_lossy(&second.stdout)
+    );
+    assert!(
+        before == after,
+        "the second install rewrote settings.json.\nbefore:\n{}\nafter:\n{}",
+        String::from_utf8_lossy(&before),
+        String::from_utf8_lossy(&after)
+    );
+}

--- a/tests/install_e2e_test.rs
+++ b/tests/install_e2e_test.rs
@@ -43,7 +43,7 @@ fn unpack_fake_archive(into: &Path) -> PathBuf {
         std::fs::copy(BASE, &binary).unwrap();
     }
 
-    let dest = mkdir(&into.join("scripts").join("ast"));
+    let dest = mkdir(into.join("scripts").join("ast"));
     let mut staged = 0;
     for entry in std::fs::read_dir(repo_scripts_ast()).unwrap() {
         let path = entry.unwrap().path();
@@ -64,7 +64,7 @@ fn unpack_fake_archive(into: &Path) -> PathBuf {
 /// this test never reaches the network. `find_local_skills_dir` probes
 /// `<binary>/../../claude/skills` first, which is `<parent of archive>`.
 fn seed_local_skill(archive_parent: &Path) {
-    let dir = mkdir(&archive_parent.join("claude").join("skills").join("base-help"));
+    let dir = mkdir(archive_parent.join("claude").join("skills").join("base-help"));
     std::fs::write(dir.join("SKILL.md"), "---\nname: base-help\n---\n").unwrap();
 }
 
@@ -114,10 +114,10 @@ fn an_unpacked_archive_installs_the_ast_scripts_from_an_unrelated_directory() {
     let binary = unpack_fake_archive(&archive);
     seed_local_skill(tmp.path());
 
-    let home = mkdir(&tmp.path().join("home"));
+    let home = mkdir(tmp.path().join("home"));
     // The reproduction from the issue: run the unpacked binary from anywhere
     // that is not the unpack directory.
-    let elsewhere = mkdir(&tmp.path().join("elsewhere"));
+    let elsewhere = mkdir(tmp.path().join("elsewhere"));
 
     let out = run_base(&binary, &elsewhere, &home, &["install", "--no-starter-commands"]);
     let installed = home.join(".base-gbl").join("scripts").join("ast");
@@ -141,7 +141,7 @@ fn the_same_archive_run_from_its_own_directory_also_installs_them() {
     let binary = unpack_fake_archive(&archive);
     seed_local_skill(tmp.path());
 
-    let home = mkdir(&tmp.path().join("home"));
+    let home = mkdir(tmp.path().join("home"));
 
     let out = run_base(&binary, &archive, &home, &["install", "--no-starter-commands"]);
     assert!(
@@ -160,12 +160,12 @@ fn an_ordinary_command_wires_the_hooks_when_claude_code_arrived_later() {
     // The state #93 describes, after Claude Code has been installed: base's
     // global tier exists, `~/.claude` exists, and settings.json does not,
     // because hook wiring was skipped at install time.
-    mkdir(&home.join(".base-gbl"));
-    mkdir(&home.join(".claude"));
+    mkdir(home.join(".base-gbl"));
+    mkdir(home.join(".claude"));
     let settings = home.join(".claude").join("settings.json");
     assert!(!settings.exists(), "the precondition, stated rather than assumed");
 
-    let cwd = mkdir(&tmp.path().join("cwd"));
+    let cwd = mkdir(tmp.path().join("cwd"));
     let out = run_base(Path::new(BASE), &cwd, &home, &["recall", "--keyword", "anything"]);
 
     assert!(
@@ -198,8 +198,8 @@ fn the_session_start_hook_still_announces_what_it_wired() {
     // first, this notice would silently disappear and nothing else would fail.
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");
-    mkdir(&home.join(".base-gbl"));
-    mkdir(&home.join(".claude"));
+    mkdir(home.join(".base-gbl"));
+    mkdir(home.join(".claude"));
 
     // An install from before the Stop hook existed: four of the five.
     let four: Vec<String> = base::install::HOOK_TABLE
@@ -214,7 +214,7 @@ fn the_session_start_hook_still_announces_what_it_wired() {
     )
     .unwrap();
 
-    let cwd = mkdir(&tmp.path().join("cwd"));
+    let cwd = mkdir(tmp.path().join("cwd"));
     let out = run_base(Path::new(BASE), &cwd, &home, &["hook", "session-start"]);
     let stdout = String::from_utf8_lossy(&out.stdout);
 
@@ -242,7 +242,7 @@ fn one_install_into_a_home_with_no_claude_code_still_leaves_the_hooks_wired() {
     let binary = unpack_fake_archive(&archive);
     seed_local_skill(tmp.path());
 
-    let home = mkdir(&tmp.path().join("home"));
+    let home = mkdir(tmp.path().join("home"));
     assert!(!home.join(".claude").exists(), "no Claude Code, stated not assumed");
 
     let out = run_base(&binary, &archive, &home, &["install", "--no-starter-commands"]);
@@ -277,7 +277,7 @@ fn skip_hooks_still_means_skip_hooks_even_after_base_creates_the_directory() {
     let binary = unpack_fake_archive(&archive);
     seed_local_skill(tmp.path());
 
-    let home = mkdir(&tmp.path().join("home"));
+    let home = mkdir(tmp.path().join("home"));
     let out = run_base(
         &binary,
         &archive,

--- a/tests/install_scripts_source_test.rs
+++ b/tests/install_scripts_source_test.rs
@@ -1,0 +1,167 @@
+//! Issue #92: `base install` finds `scripts/ast` only via CWD when run from an
+//! unpacked release archive.
+//!
+//! A release archive stages `base` and `scripts/ast/` as SIBLINGS
+//! (`.github/workflows/release.yml:65-77` for the tar legs, `:83-90` for the
+//! zip), so the unpacked layout is `<dir>/base` + `<dir>/scripts/ast/`. Before
+//! this test existed, `install_scripts` built three candidates and none of them
+//! was `<dir>/scripts/ast` — only `cwd/scripts/ast` could match, and only when
+//! the process happened to be started inside the unpack directory. Run the
+//! unpacked binary from anywhere else and AST extraction was silently absent
+//! while the install still reported success.
+//!
+//! `cwd` is a parameter of the seam rather than read from the process, because
+//! `std::env::set_current_dir` is process-global: a test that set it would race
+//! every other test in this binary.
+
+use base::install::ast_scripts_source;
+use std::path::{Path, PathBuf};
+
+/// Write a file, creating its parents. Returns the path, so a caller can assert
+/// on the exact bytes the seam is supposed to have found.
+fn touch(path: &Path) -> PathBuf {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, b"").unwrap();
+    path.to_path_buf()
+}
+
+/// The marker `install_scripts` actually probes for. Named once so a change to
+/// the probe cannot leave these tests passing against a file nothing reads.
+const MARKER: &str = "onto_ast.py";
+
+// ─── R1: the red ────────────────────────────────────────────
+
+#[test]
+fn an_unpacked_release_archive_is_found_from_any_working_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let elsewhere = tmp.path().join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+
+    // Exactly what `tar xzf base-linux-x86_64.tar.gz -C /tmp/x` leaves behind.
+    let binary = touch(&archive.join("base"));
+    let scripts = archive.join("scripts").join("ast");
+    touch(&scripts.join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &elsewhere).as_deref(),
+        Some(scripts.as_path()),
+        "the binary's own directory is the layout every release archive ships"
+    );
+}
+
+// ─── C1-C3: the dev-build candidates, unchanged ─────────────
+//
+// These three must be green BEFORE and AFTER the archive candidate is added.
+// That is what proves the new candidate shadows nothing — an assertion the fix
+// itself cannot make.
+
+#[test]
+fn a_cargo_target_build_still_resolves_to_the_source_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    let elsewhere = tmp.path().join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+
+    let binary = touch(&repo.join("target").join("release").join("base"));
+    let scripts = repo.join("scripts").join("ast");
+    touch(&scripts.join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &elsewhere).as_deref(),
+        Some(scripts.as_path()),
+        "target/<profile>/base resolves three levels up"
+    );
+}
+
+#[test]
+fn a_binary_one_level_under_the_repo_still_resolves_to_the_source_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    let elsewhere = tmp.path().join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+
+    let binary = touch(&repo.join("target").join("base"));
+    let scripts = repo.join("scripts").join("ast");
+    touch(&scripts.join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &elsewhere).as_deref(),
+        Some(scripts.as_path()),
+        "two levels up is the other dev layout"
+    );
+}
+
+#[test]
+fn the_working_directory_is_still_the_last_resort() {
+    let tmp = tempfile::tempdir().unwrap();
+    // An installed binary: nothing named scripts/ast anywhere above it.
+    let binary = touch(&tmp.path().join("home").join(".local").join("bin").join("base"));
+    let cwd = tmp.path().join("checkout");
+    let scripts = cwd.join("scripts").join("ast");
+    touch(&scripts.join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &cwd).as_deref(),
+        Some(scripts.as_path()),
+        "cwd still answers when no layout near the binary does"
+    );
+}
+
+// ─── C4: the must-fail control ──────────────────────────────
+//
+// Without this every row above could pass on a seam that never probes for the
+// marker at all and just returns the first path it can build. Law 24: a gate
+// whose failing and non-running states are indistinguishable is not a gate.
+
+#[test]
+fn nothing_anywhere_is_none_and_not_a_path_that_does_not_exist() {
+    let tmp = tempfile::tempdir().unwrap();
+    let binary = touch(&tmp.path().join("lonely").join("base"));
+    let cwd = tmp.path().join("empty");
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    assert_eq!(
+        ast_scripts_source(&binary, &cwd),
+        None,
+        "no candidate carries the marker, so there is no source dir"
+    );
+}
+
+#[test]
+fn a_directory_without_the_marker_is_not_a_source_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = touch(&archive.join("base"));
+    // scripts/ast exists but is empty — the shape a half-finished copy leaves.
+    std::fs::create_dir_all(archive.join("scripts").join("ast")).unwrap();
+    let cwd = tmp.path().join("empty");
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    assert_eq!(
+        ast_scripts_source(&binary, &cwd),
+        None,
+        "the marker is the probe, not the directory"
+    );
+}
+
+// ─── C5: precedence ─────────────────────────────────────────
+
+#[test]
+fn the_archive_beside_the_binary_wins_over_the_working_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = touch(&archive.join("base"));
+    let beside = archive.join("scripts").join("ast");
+    touch(&beside.join(MARKER));
+
+    // A different, equally valid-looking scripts/ast in the working directory.
+    let cwd = tmp.path().join("some-checkout");
+    touch(&cwd.join("scripts").join("ast").join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &cwd).as_deref(),
+        Some(beside.as_path()),
+        "the binary's own layout is trusted over wherever the shell happened to be"
+    );
+}


### PR DESCRIPTION
Closes #93. Closes #92.

Two install defects that stop a new user ever getting value. Both `bug` + `confirmed` +
`rank:05`, both against 0.14.1, both re-measured on `main` before anything was written.

## Re-measurement first — the issues are accurate, only their line numbers moved

| citation | issue says (0.14.1) | measured on `3b736901` |
|---|---|---|
| `wire_hooks` | `src/install.rs:791` | `src/install.rs:810` |
| `ensure_hooks_wired` | `src/install.rs:805-826` | `src/install.rs:833-845` |
| `install_scripts` | `src/install.rs:931-948` | `src/install.rs:945-1007` |

Nothing else in either body was stale.

## #93 — base installed before Claude Code is permanently inert

`ensure_hooks_wired` is the only repair path, and it had **exactly one caller in the whole
tree**: `src/hook/session_start.rs:66`. The repair for "hooks were never wired" ran *from a
hook*. Measured with `grep -rn ensure_hooks_wired src tests` — 7 hits, of which one is the
definition, one is that call site, two are doc-comment mentions and three are tests.

**Two things the issue does not say, found by reading the tree:**

1. **`base update` never re-wires either.** `wire_hooks` has one non-test caller
   (`install.rs:61`); `src/update/mod.rs` calls neither it nor `wire_hooks_quiet` — it only
   reuses the same *stamp pattern*. So the state was not reachable by updating, only by a
   manual re-install.

2. **The stamp was written even when nothing was wired, and that is what made the state
   permanent rather than merely delayed.** `wire_hooks_quiet` returns `Ok(vec![])` for two
   different states — "already fully wired" and "there is no `~/.claude` to write into" — and
   `ensure_hooks_wired` stamped the version for both. The issue's suggested option 1, built
   literally, would therefore have **disarmed itself on the first CLI call**: stamp written,
   nothing wired, product still inert, and a success-path acceptance leg would have passed
   identically to the bug.

### The fix

- `ensure_hooks_wired` stamps only when there was a Claude Code config tier to reconcile
  against. When there is not, it returns empty and **leaves the stamp absent**, so the next
  invocation retries. Cost of a retry: two `stat`s.
- The predicate is extracted as `claude_config_tier` and shared with `wire_hooks`, which had
  the same condition spelled out inline, so the two cannot drift.
- One call at the CLI entry seam (`src/cli.rs`, immediately after `Cli::parse()`), gated on
  the stamp the function already checks. **`Commands::Hook` is excluded deliberately:**
  `hook::dispatch` reaches `session_start`, which calls the same function and uses its
  *return value* to print the `[hooks]` notice. Calling it first from `run()` would consume
  the wiring and hand that notice an empty vec — a silent regression with nothing to fail.

`base doctor` is **not** touched. The issue offers it as option 2; under this fix the first
`base` command a user runs repairs the wiring, so a doctor line would name a state that no
longer survives to be diagnosed.

## #92 — `base install` finds `scripts/ast` only via CWD from an unpacked archive

Confirmed from the release workflow rather than assumed:
`.github/workflows/release.yml:65-77` stages `staging/base` and `staging/scripts/ast/` as
siblings and tars from inside `staging/`; `:83-90` does the same with `Compress-Archive`.
So the unpacked layout is `<dir>/base` + `<dir>/scripts/ast/`, and none of the three
candidates was `<dir>/scripts/ast`.

### The fix

The candidate list becomes a named seam, `ast_scripts_source(binary_path, cwd)`, with the
archive layout added **first**:

| # | expression | layout |
|---|---|---|
| **1 (new)** | `binary.parent()/scripts/ast` | the unpacked release archive |
| 2 | `binary.parent().parent()/scripts/ast` | source repo |
| 3 | `binary.parent().parent().parent()/scripts/ast` | `target/<profile>/base` |
| 4 | `cwd/scripts/ast` | last resort, unchanged |

First cannot shadow a dev build: for `<repo>/target/release/base` it evaluates to
`<repo>/target/release/scripts/ast`, which no layout produces. That is asserted, not argued —
three control tests pin candidates 2, 3 and 4 and must stay green across the reorder.

`cwd` is a **parameter** rather than read from the process, because
`std::env::current_dir` is process-global: a test that set it would race every other test in
the same binary.

## Head, and the three commits under it

    8504ddd7e480468a9a09ea8b3f8e6792f6686799   the regression found in review, and its legs
    806d2faac4e01b3ba6c31433d1e26ec05039970d   both fixes
    8f5ecf0c4bc0202676b40f129d08f04bd93f0a51   the tests, and the seam extraction

The branch was rebased onto `74cbb466` (which added `cargo test --no-fail-fast` in #135) after
the first arms were measured, and the third commit is a fast-forward on top. The rebase moved
two commits and **changed no file of this branch's**: the only tree difference between the
pre-rebase head and `806d2fa` is `.github/workflows/ci.yml`, which is main's own change.
`8f5ecf0` and `806d2fa` were `f26b0d5` and `400f601` before it.

Two of the CI runs below ran on those pre-rebase shas and are named by them, because that is
what they measured; the trees they measured are the trees here.

## Evidence

### Unit legs — local, Windows MSVC debug. These spawn nothing and run everywhere.

`cargo 1.97.1 / rustc 1.97.1`, `stable-x86_64-pc-windows-msvc`. Every rc written to its own
file before anything was reported.

| target | RED — `3b736901` + the tests (`runs/red03`, rc `101`) | GREEN — `f26b0d5` + the fixes (`runs/green01`, rc `0`) |
|---|---|---|
| `install_scripts_source_test` | **5 passed, 2 failed** | **7 passed, 0 failed** |
| `hooks_self_heal_test` | **4 passed, 1 failed** | **5 passed, 0 failed** |

Exactly three legs flip, and they are the three named in the test plan before the fix was
written:

- `an_unpacked_release_archive_is_found_from_any_working_directory` (#92) — `None` → the
  archive path
- `the_archive_beside_the_binary_wins_over_the_working_directory` (#92) — cwd won → the
  binary's own directory wins
- `no_claude_code_yet_leaves_the_stamp_absent_so_the_next_run_retries` (#93) — stamp written
  → stamp absent, so the next run retries

**Every other row is green in both arms.** That is not decoration: it is the only thing that
can prove the candidate reorder shadows no dev layout, and the fix cannot make that claim
about itself.

### Ubuntu CI, read at STEP level

Steps, not jobs — and the reason is **not** the one this paragraph originally gave. It said
`ci.yml`'s `clippy` job carries `continue-on-error: true`. **That is false on this repo today**
and raven caught it before it reached the merge record: on `main` the string occurs exactly
once, at `ci.yml:102`, inside a comment recording that it *used* to be there, and the `clippy`
job at `:108` is required. (Control on the same read: `runs-on` = 4, so a zero would have been
a void read rather than a finding.) It was true once: `continue-on-error: true` was removed in
[`745b1d0`](https://github.com/ChristopherKahler/base/commit/745b1d0), the commit that made
clippy a required check (#119) — the count in `ci.yml` goes 2 → 1 across it, the surviving one
being that comment. The claim reached this body from a standing process note measured before
that commit, restated here without re-measuring against today's tree: a downstream document
restating an upstream fact does not verify it, it launders it.

The discipline stands on its own footing: a job conclusion says nothing about whether a step
ran, was skipped, or was masked, and this repo has had an advisory clippy job before. Every CI
reading below is therefore a **step** conclusion, read through the API.

| run | head | `cargo test` | `cargo clippy --all-targets -- -D warnings` | `python-ast-tests` | `release-invocations` |
|---|---|---|---|---|---|
| [`34253405764`](https://github.com/ChristopherKahler/base/actions/runs/34253405764) | `f26b0d5` — tests only | **failure** | **failure** | success | success |
| [`34253881055`](https://github.com/ChristopherKahler/base/actions/runs/34253881055) | `400f601` — fixes | **success** | **success** | success | success |
| [`34257019193`](https://github.com/ChristopherKahler/base/actions/runs/34257019193) | `806d2fa` — both fixes, after the rebase | **success** | **success** | success | success |
| [`34259230056`](https://github.com/ChristopherKahler/base/actions/runs/34259230056) | **`8504ddd` — this head** | **success** | **success** | success | success |

Same workflow, same jobs, one arm red and two green. That pair is itself the control that the
clippy step genuinely ran and can fail, rather than being skipped or masked — the red arm is
the only thing that licenses reading the green ones as evidence.

`34259230056` is the run that grades this head, job `102172704729`: **67 test targets started
(2 unittests + 65 integration) and 68 `test result:` lines — the 67 targets plus the doc-test
run, which reconciles exactly — 0 non-`ok` result lines and 0 individual `FAILED` lines
anywhere in the job.** Per lane target, attributed by test name: `hooks_self_heal_test` 5/5,
`install_e2e_test` **9/9**, `install_scripts_source_test` 7/7, all ok.

The target count moved 66 → 67 between the two green runs and the extra one is **not** from this
branch: a `pull_request` run builds the merge of this head into current `main`, and `main` gained
`tests/rule_tier_scope_test.rs` in #140 (`a117d0d`) meanwhile. Named rather than left as an
unexplained delta, because an unexplained +1 in a target count is how a real change hides.

### Controls, and what each one separates

- **`nothing_anywhere_is_none_and_not_a_path_that_does_not_exist` and
  `a_directory_without_the_marker_is_not_a_source_dir`** — the must-fail rows. Without them
  every other row could pass on a seam that never probes for `onto_ast.py` and simply returns
  the first path it can build.
- **The three dev-layout rows** — green *before and after* the reorder, per the table above.
- **`the_same_archive_run_from_its_own_directory_also_installs_them`** — same script, same
  binary, one variable: the working directory. Before the fix this arm passed while the other
  failed, which is the only reason either reading means anything.
- **`the_session_start_hook_still_announces_what_it_wired`** — the control for the
  `Commands::Hook` exclusion. It asserts the `[hooks]` notice still *names the event*, not
  that the exclusion compiles.
- **The absence assertion inside
  `an_ordinary_command_wires_the_hooks_when_claude_code_arrived_later`** — `base recall` must
  not grow a line of install chatter. It sits *inside* the leg that asserts the wiring
  happened, rather than being a leg of its own: alone it would pass just as well against a
  process that printed nothing because it never ran. It was a separate test until it did
  exactly that — see the platform note below.
- **`skip_hooks_still_means_skip_hooks_even_after_base_creates_the_directory`** — the row that
  separates *repaired* from *silenced*. The deferred wiring runs after step 8, by which point
  `~/.claude` exists because base itself made it; without this row a "fix" that quietly
  ignored `--skip-hooks` would pass every other row identically.
- **`an_already_wired_home_is_stamped_and_left_byte_identical`** — separates *the stamp is
  still correct* from *we stopped stamping*.

### Platform scope, stated rather than skipped

`tests/install_e2e_test.rs` spawns `base` as a child process — the shape #129
(`STATUS_STACK_OVERFLOW`) crashes on Windows **in the debug profile only**, measured by tern
across four targets whose release arm read `ovf=0` on every one. **Ubuntu CI is the acceptance
surface for those six legs.**

A local Windows reading of that file is **VOID, not red**. Measured 2026-09-08: all seven legs
then in the file died with `status: Some(-1073741571)` = `0xC00000FD`, and one of them
**reported PASS** — it asserted that stdout did not contain `[hooks]`, and a process that never
started produces exactly that absence. A false PASS, in the instrument, on its first run.
`run_base` now asserts on that exit code and reports VOID rather than measuring a corpse, and
that absence assertion was folded into the presence assertion beside it so it can no longer
pass alone. The file carries six legs as committed, for that reason.

The unit legs (`install_scripts_source_test.rs`, `hooks_self_heal_test.rs`) spawn nothing and
run on every platform.

## Design-to-code map

| G0 design bullet | symbol at `file:line` | test that pins it |
|---|---|---|
| #92 — the candidate list becomes a named seam, `cwd` a parameter | `src/install.rs:1002` `ast_scripts_source` | `install_scripts_source_test.rs:118`, `:132` (must-fail) |
| #92 — archive candidate, first | `src/install.rs:1019` `up(0)` | `install_scripts_source_test.rs:35`, `:151` |
| #92 — the three existing candidates, otherwise unchanged | `src/install.rs:1021`, `:1023`, `:1025` | `install_scripts_source_test.rs:78`, `:60`, `:96` — green in both arms |
| #92 — `install_scripts` calls the seam and is otherwise untouched | `src/install.rs:1038` | `install_e2e_test.rs:111`, `:135` |
| #93 — stamp written only when there was a config tier to reconcile | `src/install.rs:889`, inside `ensure_hooks_wired` (`:872`) | `hooks_self_heal_test.rs:77` |
| #93 — that predicate shared with `wire_hooks` rather than respelled | `src/install.rs:835` `claude_config_tier` | `hooks_self_heal_test.rs:53`, `:110` |
| #93 — a caller outside the hook pipeline | `src/cli.rs:1487-1493` | `install_e2e_test.rs:157` |
| #93 — that seam excludes every command that owns hook state (`Hook`, `Install`, `Uninstall`) | `src/cli.rs:1489-1491` | `install_e2e_test.rs:303`, `:355` |
| #93 — the hook path byte-for-byte unchanged | `src/hook/session_start.rs:66`, untouched | `install_e2e_test.rs:195` |
| #93 — step 3 DEFERS rather than drops, keeping its honest line | `src/install.rs:849` `wire_hooks -> Result<bool>`, bound at `:60` | `install_e2e_test.rs:231` |
| #93 — the deferred wiring lands after step 8 | `src/install.rs:100-109` | `install_e2e_test.rs:231`, `:271` |
| law 22 — an installer gets an over-the-top leg, asserted on content | `src/install.rs:857` (`wire_hooks_quiet` returns early when all present) | `install_e2e_test.rs:399` |
| #93 — `base doctor` deliberately not built | — | `src/doctor.rs`, 0 lines changed |

No empty cells.

## The regression this PR introduced, found in review

The CLI seam in §"#93" above ran **before** the subcommand dispatch and excluded only
`Commands::Hook`. So it reached two commands that own the hook state themselves, and — because
it runs first — always won.

**raven found the first by reading the tree**, not from any test here. `base install
--skip-hooks`, on a home that already has `~/.claude` and is unstamped for this version:
`cli::run` calls `ensure_hooks_wired()`, `claude_config_tier` is true, `wire_hooks_quiet` writes
all five hooks, the version is stamped — and only then does step 3 print
`⊘ Hook wiring skipped (--skip-hooks)` over work that has already happened. The flag is
documented as *"Skip hook wiring in settings.json"*, and it held before this PR only because
`ensure_hooks_wired` had exactly one caller.

**The second came from sweeping the codebase rather than trusting a list.** `wire_hooks_quiet`
and `remove_hooks` are the only writers of `~/.claude/settings.json` in the tree; checked
against all **39** `Commands` variants, exactly **three** reach one — `Hook` (via
`session_start`), `Install` (step 3 and the deferred block) and `Uninstall` (`remove_hooks`,
whose only caller is `install::uninstall`). `Commands::Hooks` prints the manifest and writes
nothing, which was read rather than inferred from its name.

`base uninstall`, on a home with `~/.claude/` and **no** `settings.json`: the seam runs,
`wire_hooks_quiet` takes its *"the parent is a directory"* branch and **creates** the file,
wires five hooks and stamps the version; `remove_hooks` then strips them and prints
`1. Remove hooks from settings.json ... ✓`. A command asked to remove base left behind a config
file the user never had, and a stamp that disarms the repair for the rest of the version.

### Why the existing controls passed over both

`skip_hooks_still_means_skip_hooks_even_after_base_creates_the_directory` builds its fake home
as a bare empty directory. At the moment the seam runs there is no `~/.claude`, so
`claude_config_tier` is false, the seam returns empty, and the leg passes for a reason that has
nothing to do with the flag it is named for. That is law 31 exactly: **the guard fires, on every
case in its own suite, and is blind to the shape the codebase actually has.** Three CI arms
were green over both defects.

### The fix, and the legs that pin it

One more arm each on the same `matches!`, on the same reasoning that already excluded `Hook`:
a command that owns the hook state decides for itself.

| | |
|---|---|
| RED, both legs, on `806d2fa` + the tests only | [`34258760997`](https://github.com/ChristopherKahler/base/actions/runs/34258760997), head `12c97d8` |
| RED, the first leg alone, before the second was found | [`34258339624`](https://github.com/ChristopherKahler/base/actions/runs/34258339624), head `e96401e`, job `102169706955` — 19 tests visited, 18 ok, **exactly 1 FAILED** |
| GREEN at this head | see the table at the top |

Each leg asserts the **stamp** is absent as well as the file. `install.rs:893` stamps in the
same breath as the write, so a fix that stopped the write and kept the stamp would satisfy the
file assertion and still disarm the repair for the rest of the version — law 25, a leg that
separates *repaired* from *silenced*. raven asked for the file assertion; the stamp half is the
one that makes it a leg rather than a claim.

## The red arm — the one hole, and how it was closed

**It was real.** `tests/install_e2e_test.rs` reached this PR **green with no red anywhere**:

- The ubuntu RED arm never reached it. Run `34253405764` started **42 of 66 test targets**
  (all started targets: 2 unittests + 40 integration, against the green run's 2 + 64) and
  stopped at `hooks_self_heal_test`, target 42, because `ci.yml:28` was a bare `cargo test` at
  the time. `install_e2e_test` is target 43 and `install_scripts_source_test` is 44, so 24
  targets — both of those included — never ran in that arm. Every position here is on the
  all-started-targets basis; on the integration-only basis the same reading is 40 of 64.
- The Windows reading is VOID, per the platform note above, and a void is not a red.

Counted per test rather than per target, this branch adds **15**: 6 in `install_e2e_test.rs`,
7 in `install_scripts_source_test.rs`, 2 in `hooks_self_heal_test.rs` (3 on `main`, 5 here).
**13 of those 15 had no ubuntu red** — including the deferred-wiring shape that closes the
issue's own reproduction.

### Closed by a throwaway red arm, #138

`8f5ecf0` — this branch's test commit **alone**, on `main`, with **neither fix**. `main` now
carries `cargo test --no-fail-fast` (#135), so every target reports rather than the first
failure aborting the job.

The arm is proven able to fail rather than assumed to be:
`git show 8f5ecf0:src/install.rs` carries `up(1)`, `up(2)` and the cwd candidate and **no
`up(0)`** — main's original candidate list behind the extracted seam. The job compiled
cleanly: **0 `error[E…]`, 0 `could not compile`**, so this is a red and not a void.

| run | head | `cargo test` | clippy step | new legs FAILED |
|---|---|---|---|---|
| [`34257221144`](https://github.com/ChristopherKahler/base/actions/runs/34257221144) job `102165958551` | `8f5ecf0` — tests, **no fixes** | **failure** | **failure** | **6 of 15** |
| [`34257019193`](https://github.com/ChristopherKahler/base/actions/runs/34257019193) job `102165281946` | `806d2fa` — this head | **success** | **success** | **0 of 15** |

Per target, attributed **by test name** rather than by position in the log (see the note
below), every one of the 18 tests in the three files visited in both arms:

| target | RED `8f5ecf0` | GREEN `806d2fa` |
|---|---|---|
| `install_e2e_test` | 6/6 visited — 3 ok, **3 FAILED** | 6/6 — **6 ok, 0 failed** |
| `install_scripts_source_test` | 7/7 visited — 5 ok, **2 FAILED** | 7/7 — **7 ok, 0 failed** |
| `hooks_self_heal_test` | 5/5 visited — 4 ok, **1 FAILED** | 5/5 — **5 ok, 0 failed** |

The six legs that flip, and nothing else in the entire job flips — the whole red-arm log
contains exactly **6** distinct `... FAILED` test names and exactly **3** non-`ok`
`test result:` lines (`4 passed; 1 failed`, `3 passed; 3 failed`, `5 passed; 2 failed`):

| leg | pins |
|---|---|
| `an_unpacked_release_archive_is_found_from_any_working_directory` | #92, the seam |
| `the_archive_beside_the_binary_wins_over_the_working_directory` | #92, candidate precedence |
| `an_unpacked_archive_installs_the_ast_scripts_from_an_unrelated_directory` | #92, end to end through the real binary |
| `no_claude_code_yet_leaves_the_stamp_absent_so_the_next_run_retries` | #93, the poisoned stamp |
| `an_ordinary_command_wires_the_hooks_when_claude_code_arrived_later` | #93, the CLI seam |
| `one_install_into_a_home_with_no_claude_code_still_leaves_the_hooks_wired` | #93, **the deferred wiring — the issue's own reproduction** |

The other nine new tests are **green in both arms**. That is what they are for: they are the
controls, and a control that flipped would mean the reorder shadowed a layout or the exclusion
broke the hook path.

These are true reds with the product's own voice in them, not harness noise. The red arm's
`an_ordinary_command_wires_the_hooks_when_claude_code_arrived_later` failed with
`status:Some(0)` — `base recall` ran, succeeded, printed `No results found.`, and left no
`settings.json`. The `#92` e2e leg's captured stdout is the install itself saying
`3. Wire hooks → … ⊘ no ~/.claude directory (is Claude Code installed?), skipped` and
`5. Install AST scripts ... ⊘ scripts/ast/ not found near binary — skipped`. That is both bugs,
printed by the binary, in the log.

### One instrument defect found while reading this, recorded because it nearly shipped

My first pass attributed each `test result:` line to the most recent `Running tests/<x>.rs`
line above it. **That is unsound on a piped CI log**: cargo writes the `Running` lines and the
test binary writes its own output, and the two streams interleave under buffering. The false
table it produced read `install_scripts_source_test: 3 passed, 3 failed` (those were
`install_e2e_test`'s numbers), `install_e2e_test: no result line`, and — the dangerous one —
**`lock_tripwire_test` among the failing targets**, which would have put a false red on another
lane's #104/#126 work into this PR. Re-derived by mapping every `test <name> ... ok|FAILED`
line through a name→file map read from the tree: `lock_tripwire_test` appears in **no** failing
line in either job. Every table above is name-attributed and prints the visited count, and a
visited count below the file's test count would be a failure, not a pass.

#138 is closed and its ref deleted; it exists in this record only.

The unit legs are unaffected: they have a measured red-then-green pair on Windows with controls
green in both arms, and a green on ubuntu.
