### PR TITLE
THROWAWAY red arm for #136 — do not merge, do not review

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -942,33 +942,48 @@ fn migrate_carl(global_dir: &Path, carl_path: &Path) -> Result<()> {
 
 // ─── Step 5: Install scripts ────────────────────────────────
 
+/// The file that marks a real `scripts/ast` directory. Probed rather than the
+/// directory itself, so a half-finished copy cannot answer as a source.
+const AST_SCRIPTS_MARKER: &str = "onto_ast.py";
+
+/// Where `scripts/ast/` lives relative to a `base` binary, most specific first.
+///
+/// `cwd` is a parameter rather than read from the process because
+/// `std::env::current_dir` is process-global: a test that set it would race
+/// every other test in the same binary.
+pub fn ast_scripts_source(binary_path: &Path, cwd: &Path) -> Option<std::path::PathBuf> {
+    // `n` levels above the binary's own directory, then `scripts/ast`.
+    let up = |n: usize| -> Option<std::path::PathBuf> {
+        let mut p = binary_path.parent()?;
+        for _ in 0..n {
+            p = p.parent()?;
+        }
+        Some(p.join("scripts").join("ast"))
+    };
+
+    [
+        // Source repo, binary one level in.
+        up(1),
+        // Cargo target dir: target/<profile>/base → ../../scripts/ast.
+        up(2),
+        // Whatever directory the shell happened to be in.
+        Some(cwd.join("scripts").join("ast")),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|p| p.join(AST_SCRIPTS_MARKER).exists())
+}
+
 fn install_scripts(binary_path: &Path, global_dir: &Path) -> Result<()> {
     print!("5. Install AST scripts ... ");
 
     let scripts_dest = global_dir.join("scripts").join("ast");
     std::fs::create_dir_all(&scripts_dest)?;
 
-    // Find scripts relative to the binary source (dev builds) or cwd
-    let source_candidates = [
-        // Same directory as source repo
-        binary_path
-            .parent()
-            .and_then(|p| p.parent())
-            .map(|p| p.join("scripts").join("ast")),
-        // Cargo target dir (target/release/../scripts/ast → ../../scripts/ast)
-        binary_path
-            .parent()
-            .and_then(|p| p.parent())
-            .and_then(|p| p.parent())
-            .map(|p| p.join("scripts").join("ast")),
-        // Current working directory
-        Some(std::env::current_dir().unwrap_or_default().join("scripts").join("ast")),
-    ];
-
-    let source_dir = source_candidates
-        .iter()
-        .filter_map(|p| p.as_ref())
-        .find(|p| p.join("onto_ast.py").exists());
+    let source_dir = ast_scripts_source(
+        binary_path,
+        &std::env::current_dir().unwrap_or_default(),
+    );
 
     let Some(source_dir) = source_dir else {
         // No source near the binary (e.g. `cargo install` drops only the binary,
@@ -986,7 +1001,7 @@ fn install_scripts(binary_path: &Path, global_dir: &Path) -> Result<()> {
 
     // Copy all .py files
     let mut count = 0;
-    for entry in std::fs::read_dir(source_dir)? {
+    for entry in std::fs::read_dir(&source_dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.extension().is_some_and(|ext| ext == "py") {

--- a/tests/hooks_self_heal_test.rs
+++ b/tests/hooks_self_heal_test.rs
@@ -56,3 +56,72 @@ fn no_claude_directory_means_nothing_to_wire() {
     assert!(wire_hooks_quiet(&settings).unwrap().is_empty());
     assert!(!settings.exists(), "base never invents a Claude Code install");
 }
+
+// ─── Issue #93 ──────────────────────────────────────────────
+//
+// `ensure_hooks_wired` returns an empty vec for TWO different states: "already
+// fully wired" and "there is no ~/.claude directory to write into". It stamped
+// the version for both. So on a machine where base was installed before Claude
+// Code, the first call disarmed the repair for the rest of that version's life
+// — which is what turns a delay into the permanent inertness #93 reports.
+//
+// The stamp means "reconciled against a real Claude Code config", not "tried".
+
+/// The stamp file `ensure_hooks_wired` gates itself on.
+fn stamp_of(home: &std::path::Path) -> std::path::PathBuf {
+    home.join(".base-gbl")
+        .join(format!(".hooks-wired-{}", env!("CARGO_PKG_VERSION")))
+}
+
+#[test]
+fn no_claude_code_yet_leaves_the_stamp_absent_so_the_next_run_retries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    // `.base-gbl` exists on every real install (step 2 runs before step 3), and
+    // it has to exist here too: without it the stamp write fails for an
+    // unrelated reason and this test would pass without proving anything.
+    std::fs::create_dir_all(home.join(".base-gbl")).unwrap();
+    assert!(home.join(".base-gbl").is_dir(), "the stamp has somewhere to land");
+    // No ~/.claude at all: base installed before Claude Code.
+    assert!(!home.join(".claude").exists());
+
+    base::home::with_thread_home(&home, || {
+        assert!(ensure_hooks_wired().is_empty(), "nothing to wire yet");
+        assert!(
+            !stamp_of(&home).exists(),
+            "no Claude Code config was reconciled, so nothing is stamped"
+        );
+
+        // Claude Code arrives. The very next call repairs, with no re-install.
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let added = ensure_hooks_wired();
+        assert_eq!(added.len(), HOOK_TABLE.len(), "every hook, on the next run");
+
+        let text = std::fs::read_to_string(home.join(".claude").join("settings.json")).unwrap();
+        for (_, cmd) in HOOK_TABLE {
+            assert_eq!(text.matches(cmd).count(), 1, "{cmd}: present exactly once");
+        }
+        assert!(stamp_of(&home).exists(), "now there was something to stamp");
+        assert!(ensure_hooks_wired().is_empty(), "and once per version after that");
+    });
+}
+
+#[test]
+fn an_already_wired_home_is_stamped_and_left_byte_identical() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    std::fs::create_dir_all(home.join(".claude")).unwrap();
+    std::fs::create_dir_all(home.join(".base-gbl")).unwrap();
+
+    let settings = home.join(".claude").join("settings.json");
+    base::home::with_thread_home(&home, || {
+        // Wire it once, then assert the second pass changes nothing at all.
+        assert_eq!(ensure_hooks_wired().len(), HOOK_TABLE.len());
+        std::fs::remove_file(stamp_of(&home)).unwrap();
+        let before = std::fs::read(&settings).unwrap();
+
+        assert!(ensure_hooks_wired().is_empty(), "nothing left to add");
+        assert_eq!(std::fs::read(&settings).unwrap(), before, "not one byte rewritten");
+        assert!(stamp_of(&home).exists(), "a real config WAS reconciled");
+    });
+}

--- a/tests/install_e2e_test.rs
+++ b/tests/install_e2e_test.rs
@@ -1,0 +1,300 @@
+//! End-to-end legs for #92 and #93, driven through the real binary.
+//!
+//! The unit legs in `install_scripts_source_test.rs` and `hooks_self_heal_test.rs`
+//! prove the two seams. These prove the WIRING: that `install_scripts` actually
+//! calls the candidate seam, and that `ensure_hooks_wired` actually has a caller
+//! outside the hook pipeline. A seam nothing calls is the whole shape of #93.
+//!
+//! Platform scope: these spawn `base` as a child process, the shape that #129
+//! (`STATUS_STACK_OVERFLOW`, debug profile only) crashes on Windows. Ubuntu CI is
+//! the acceptance surface; `cargo test --release` corroborates on Windows.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// The binary under test. Cargo builds it for this test target, so it is always
+/// this tree's binary and never something left in the target dir by another
+/// branch.
+const BASE: &str = env!("CARGO_BIN_EXE_base");
+
+/// This repo's real `scripts/ast/`, the directory the release archive stages.
+fn repo_scripts_ast() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts").join("ast")
+}
+
+fn mkdir(p: impl AsRef<Path>) -> PathBuf {
+    let p = p.as_ref().to_path_buf();
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// Lay out what `tar xzf base-linux-x86_64.tar.gz -C <into>` leaves behind:
+/// the binary and `scripts/ast/` as siblings. Returns the binary's path.
+///
+/// `requirements.txt` is deliberately NOT staged. `install_scripts` shells out
+/// to `pip install -r` when it lands one, and this leg is about where the
+/// scripts come from, not about pip.
+fn unpack_fake_archive(into: &Path) -> PathBuf {
+    mkdir(into);
+    let binary = into.join(format!("base{}", std::env::consts::EXE_SUFFIX));
+    // Hard link where the filesystem allows it: a debug binary is large and this
+    // runs twice. Content is identical either way, which is all that matters.
+    if std::fs::hard_link(BASE, &binary).is_err() {
+        std::fs::copy(BASE, &binary).unwrap();
+    }
+
+    let dest = mkdir(&into.join("scripts").join("ast"));
+    let mut staged = 0;
+    for entry in std::fs::read_dir(repo_scripts_ast()).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().is_some_and(|e| e == "py") {
+            std::fs::copy(&path, dest.join(path.file_name().unwrap())).unwrap();
+            staged += 1;
+        }
+    }
+    // Law 23: a loop that asserts over a set prints what it visited, and zero
+    // visited is a failure. A silently empty archive would make every assertion
+    // below meaningless.
+    assert!(staged >= 2, "staged {staged} .py files into the fake archive");
+    assert!(dest.join("onto_ast.py").is_file(), "the marker install probes for");
+    binary
+}
+
+/// A skills source beside the archive, so `install_skills` resolves locally and
+/// this test never reaches the network. `find_local_skills_dir` probes
+/// `<binary>/../../claude/skills` first, which is `<parent of archive>`.
+fn seed_local_skill(archive_parent: &Path) {
+    let dir = mkdir(&archive_parent.join("claude").join("skills").join("base-help"));
+    std::fs::write(dir.join("SKILL.md"), "---\nname: base-help\n---\n").unwrap();
+}
+
+/// Windows `STATUS_STACK_OVERFLOW` (`0xC00000FD`) as a process exit code. This
+/// is #129, and it is debug-profile only — tern measured `ovf=0` on every one of
+/// four targets with a release arm.
+const STATUS_STACK_OVERFLOW: i32 = 0xC000_00FD_u32 as i32;
+
+/// Run `base` with an explicit environment. Nothing is inherited implicitly:
+/// `BASE_HOME` is the only tier this touches, and `HOME` is left alone so the
+/// write tripwire stays armed (it compares against the real profile).
+///
+/// The crash check is not politeness. When #129 kills the child at startup it
+/// writes nothing, so an assertion on an ABSENCE — "stdout does not mention
+/// hooks", "settings.json was not created" — passes for the wrong reason, and
+/// an assertion on a presence fails with a message about the product rather
+/// than about the corpse. Law 24: a leg whose "could not run" and "failed"
+/// states share a shape is not a leg. Measured 2026-09-08: all seven legs in
+/// this file died this way on Windows debug, and one of them reported PASS.
+fn run_base(binary: &Path, cwd: &Path, home: &Path, args: &[&str]) -> std::process::Output {
+    let out = Command::new(binary)
+        .args(args)
+        .current_dir(cwd)
+        .env("BASE_HOME", home)
+        .env("BASE_NO_AUTO_UPDATE", "1")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap_or_else(|e| panic!("spawning {} {args:?}: {e}", binary.display()));
+
+    assert_ne!(
+        out.status.code(),
+        Some(STATUS_STACK_OVERFLOW),
+        "VOID, not a result: the child died with STATUS_STACK_OVERFLOW before it ran \
+         anything (#129, debug profile on Windows). Ubuntu CI is this file's acceptance \
+         surface; `cargo test --release` corroborates locally.\nargs: {args:?}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+// ─── #92 ────────────────────────────────────────────────────
+
+#[test]
+fn an_unpacked_archive_installs_the_ast_scripts_from_an_unrelated_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(&tmp.path().join("home"));
+    // The reproduction from the issue: run the unpacked binary from anywhere
+    // that is not the unpack directory.
+    let elsewhere = mkdir(&tmp.path().join("elsewhere"));
+
+    let out = run_base(&binary, &elsewhere, &home, &["install", "--no-starter-commands"]);
+    let installed = home.join(".base-gbl").join("scripts").join("ast");
+
+    assert!(
+        installed.join("extractor.py").is_file(),
+        "AST extraction is silently absent.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(installed.join("onto_ast.py").is_file());
+}
+
+#[test]
+fn the_same_archive_run_from_its_own_directory_also_installs_them() {
+    // The control. Before the fix this arm passed while the one above failed,
+    // which is the only reason either reading means anything: same script, same
+    // binary, one variable — the working directory.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(&tmp.path().join("home"));
+
+    let out = run_base(&binary, &archive, &home, &["install", "--no-starter-commands"]);
+    assert!(
+        home.join(".base-gbl").join("scripts").join("ast").join("extractor.py").is_file(),
+        "the cwd candidate still answers.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+// ─── #93 ────────────────────────────────────────────────────
+
+#[test]
+fn an_ordinary_command_wires_the_hooks_when_claude_code_arrived_later() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    // The state #93 describes, after Claude Code has been installed: base's
+    // global tier exists, `~/.claude` exists, and settings.json does not,
+    // because hook wiring was skipped at install time.
+    mkdir(&home.join(".base-gbl"));
+    mkdir(&home.join(".claude"));
+    let settings = home.join(".claude").join("settings.json");
+    assert!(!settings.exists(), "the precondition, stated rather than assumed");
+
+    let cwd = mkdir(&tmp.path().join("cwd"));
+    let out = run_base(Path::new(BASE), &cwd, &home, &["recall", "--keyword", "anything"]);
+
+    assert!(
+        settings.is_file(),
+        "an ordinary command left base inert.\nstatus:{:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = std::fs::read_to_string(&settings).unwrap();
+    for (event, cmd) in base::install::HOOK_TABLE {
+        assert_eq!(text.matches(cmd).count(), 1, "{event}: wired exactly once");
+    }
+
+    // And it does it silently: `base recall` must not grow a line of install
+    // chatter. This assertion is on an ABSENCE, so it only means anything
+    // beside the presence assertion above — on its own it would pass just as
+    // well against a process that printed nothing because it never ran.
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains("[hooks]"),
+        "the repair announced itself on an ordinary command:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn the_session_start_hook_still_announces_what_it_wired() {
+    // The control for excluding `Commands::Hook` from the CLI-level call. The
+    // hook path owns the `[hooks]` notice; if the CLI seam consumed the wiring
+    // first, this notice would silently disappear and nothing else would fail.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    mkdir(&home.join(".base-gbl"));
+    mkdir(&home.join(".claude"));
+
+    // An install from before the Stop hook existed: four of the five.
+    let four: Vec<String> = base::install::HOOK_TABLE
+        .iter()
+        .filter(|(event, _)| *event != "Stop")
+        .map(|(event, cmd)| format!(r#""{event}":[{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}]"#))
+        .collect();
+    assert_eq!(four.len(), 4, "seeded four of the five");
+    std::fs::write(
+        home.join(".claude").join("settings.json"),
+        format!("{{\"hooks\":{{{}}}}}", four.join(",")),
+    )
+    .unwrap();
+
+    let cwd = mkdir(&tmp.path().join("cwd"));
+    let out = run_base(Path::new(BASE), &cwd, &home, &["hook", "session-start"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("[hooks] wired base hook Stop"),
+        "the session-start notice named nothing.\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ─── #93, the reproduction in the issue ─────────────────────
+
+#[test]
+fn one_install_into_a_home_with_no_claude_code_still_leaves_the_hooks_wired() {
+    // The issue's own repro: "Install base into a home with no ~/.claude, then
+    // install Claude Code, then start a session."
+    //
+    // That session finds base's hooks or it finds nothing — there is no third
+    // path, because without settings.json base does not run inside a session at
+    // all. Step 3 cannot wire (no directory yet); steps 7 and 8 then create
+    // ~/.claude for base's own skill and CLAUDE.md. The wiring is deferred to
+    // after them rather than abandoned.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(&tmp.path().join("home"));
+    assert!(!home.join(".claude").exists(), "no Claude Code, stated not assumed");
+
+    let out = run_base(&binary, &archive, &home, &["install", "--no-starter-commands"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Step 3 still says what it saw. Losing that message would trade one silent
+    // state for another.
+    assert!(
+        stdout.contains("is Claude Code installed?"),
+        "step 3 stopped reporting what it found.\nstdout:\n{stdout}"
+    );
+
+    let settings = home.join(".claude").join("settings.json");
+    assert!(
+        settings.is_file(),
+        "the install left nothing for a later Claude Code to read.\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = std::fs::read_to_string(&settings).unwrap();
+    for (event, cmd) in base::install::HOOK_TABLE {
+        assert_eq!(text.matches(cmd).count(), 1, "{event}: wired exactly once");
+    }
+}
+
+#[test]
+fn skip_hooks_still_means_skip_hooks_even_after_base_creates_the_directory() {
+    // The control that separates "the wiring is deferred" from "the wiring is
+    // now unconditional". Without it the fix above could pass by quietly
+    // breaking --skip-hooks, and nothing else would fail.
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = unpack_fake_archive(&archive);
+    seed_local_skill(tmp.path());
+
+    let home = mkdir(&tmp.path().join("home"));
+    let out = run_base(
+        &binary,
+        &archive,
+        &home,
+        &["install", "--no-starter-commands", "--skip-hooks"],
+    );
+
+    // base still creates ~/.claude for its own skill, so the directory existing
+    // is not the thing under test — settings.json is.
+    assert!(
+        home.join(".claude").is_dir(),
+        "base created its own skill directory regardless.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        !home.join(".claude").join("settings.json").exists(),
+        "--skip-hooks wrote hooks anyway.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/tests/install_scripts_source_test.rs
+++ b/tests/install_scripts_source_test.rs
@@ -1,0 +1,167 @@
+//! Issue #92: `base install` finds `scripts/ast` only via CWD when run from an
+//! unpacked release archive.
+//!
+//! A release archive stages `base` and `scripts/ast/` as SIBLINGS
+//! (`.github/workflows/release.yml:65-77` for the tar legs, `:83-90` for the
+//! zip), so the unpacked layout is `<dir>/base` + `<dir>/scripts/ast/`. Before
+//! this test existed, `install_scripts` built three candidates and none of them
+//! was `<dir>/scripts/ast` — only `cwd/scripts/ast` could match, and only when
+//! the process happened to be started inside the unpack directory. Run the
+//! unpacked binary from anywhere else and AST extraction was silently absent
+//! while the install still reported success.
+//!
+//! `cwd` is a parameter of the seam rather than read from the process, because
+//! `std::env::set_current_dir` is process-global: a test that set it would race
+//! every other test in this binary.
+
+use base::install::ast_scripts_source;
+use std::path::{Path, PathBuf};
+
+/// Write a file, creating its parents. Returns the path, so a caller can assert
+/// on the exact bytes the seam is supposed to have found.
+fn touch(path: &Path) -> PathBuf {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, b"").unwrap();
+    path.to_path_buf()
+}
+
+/// The marker `install_scripts` actually probes for. Named once so a change to
+/// the probe cannot leave these tests passing against a file nothing reads.
+const MARKER: &str = "onto_ast.py";
+
+// ─── R1: the red ────────────────────────────────────────────
+
+#[test]
+fn an_unpacked_release_archive_is_found_from_any_working_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let elsewhere = tmp.path().join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+
+    // Exactly what `tar xzf base-linux-x86_64.tar.gz -C /tmp/x` leaves behind.
+    let binary = touch(&archive.join("base"));
+    let scripts = archive.join("scripts").join("ast");
+    touch(&scripts.join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &elsewhere).as_deref(),
+        Some(scripts.as_path()),
+        "the binary's own directory is the layout every release archive ships"
+    );
+}
+
+// ─── C1-C3: the dev-build candidates, unchanged ─────────────
+//
+// These three must be green BEFORE and AFTER the archive candidate is added.
+// That is what proves the new candidate shadows nothing — an assertion the fix
+// itself cannot make.
+
+#[test]
+fn a_cargo_target_build_still_resolves_to_the_source_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    let elsewhere = tmp.path().join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+
+    let binary = touch(&repo.join("target").join("release").join("base"));
+    let scripts = repo.join("scripts").join("ast");
+    touch(&scripts.join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &elsewhere).as_deref(),
+        Some(scripts.as_path()),
+        "target/<profile>/base resolves three levels up"
+    );
+}
+
+#[test]
+fn a_binary_one_level_under_the_repo_still_resolves_to_the_source_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    let elsewhere = tmp.path().join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+
+    let binary = touch(&repo.join("target").join("base"));
+    let scripts = repo.join("scripts").join("ast");
+    touch(&scripts.join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &elsewhere).as_deref(),
+        Some(scripts.as_path()),
+        "two levels up is the other dev layout"
+    );
+}
+
+#[test]
+fn the_working_directory_is_still_the_last_resort() {
+    let tmp = tempfile::tempdir().unwrap();
+    // An installed binary: nothing named scripts/ast anywhere above it.
+    let binary = touch(&tmp.path().join("home").join(".local").join("bin").join("base"));
+    let cwd = tmp.path().join("checkout");
+    let scripts = cwd.join("scripts").join("ast");
+    touch(&scripts.join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &cwd).as_deref(),
+        Some(scripts.as_path()),
+        "cwd still answers when no layout near the binary does"
+    );
+}
+
+// ─── C4: the must-fail control ──────────────────────────────
+//
+// Without this every row above could pass on a seam that never probes for the
+// marker at all and just returns the first path it can build. Law 24: a gate
+// whose failing and non-running states are indistinguishable is not a gate.
+
+#[test]
+fn nothing_anywhere_is_none_and_not_a_path_that_does_not_exist() {
+    let tmp = tempfile::tempdir().unwrap();
+    let binary = touch(&tmp.path().join("lonely").join("base"));
+    let cwd = tmp.path().join("empty");
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    assert_eq!(
+        ast_scripts_source(&binary, &cwd),
+        None,
+        "no candidate carries the marker, so there is no source dir"
+    );
+}
+
+#[test]
+fn a_directory_without_the_marker_is_not_a_source_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = touch(&archive.join("base"));
+    // scripts/ast exists but is empty — the shape a half-finished copy leaves.
+    std::fs::create_dir_all(archive.join("scripts").join("ast")).unwrap();
+    let cwd = tmp.path().join("empty");
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    assert_eq!(
+        ast_scripts_source(&binary, &cwd),
+        None,
+        "the marker is the probe, not the directory"
+    );
+}
+
+// ─── C5: precedence ─────────────────────────────────────────
+
+#[test]
+fn the_archive_beside_the_binary_wins_over_the_working_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("unpacked");
+    let binary = touch(&archive.join("base"));
+    let beside = archive.join("scripts").join("ast");
+    touch(&beside.join(MARKER));
+
+    // A different, equally valid-looking scripts/ast in the working directory.
+    let cwd = tmp.path().join("some-checkout");
+    touch(&cwd.join("scripts").join("ast").join(MARKER));
+
+    assert_eq!(
+        ast_scripts_source(&binary, &cwd).as_deref(),
+        Some(beside.as_path()),
+        "the binary's own layout is trusted over wherever the shell happened to be"
+    );
+}


### PR DESCRIPTION
**THROWAWAY. Do not review, do not merge. This PR exists only to make CI run, and it
will be closed and its ref deleted as soon as the result is read.**

It is the RED ARM for #136. Head is `8f5ecf0c4bc0202676b40f129d08f04bd93f0a51` — the tests
and the seam extraction, on today's `main`, **without either fix**. `ast_scripts_source` here
carries main's original three candidates and no `up(0)`, so the bug is intact by construction.

#136's ubuntu red arm (run `34253405764`) stopped at test target 42 of 66, because `ci.yml`
was a bare `cargo test` at the time and aborted on the first failing target. `install_e2e_test`
is target 43 and `install_scripts_source_test` is 44, so neither ever ran red. `main` now
carries `cargo test --no-fail-fast` (#135), so this run reaches every one of them.

Expected: `install_scripts_source_test` 5/2, `hooks_self_heal_test` 4/1, and
`install_e2e_test` red on the legs that pin the fixes. The step-level result goes into #136.
