### PR TITLE
`rule remove` removes what `rule list` showed, and reports the count it read back (#112)

### DIFF
--- a/src/crud/rule.rs
+++ b/src/crud/rule.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use oxigraph::sparql::QueryResults;
+use oxigraph::store::Store;
 
 use crate::config::NamespaceConfig;
 use crate::crud;
@@ -232,52 +233,124 @@ pub fn list_all_tiers(
 }
 
 /// Remove a rule by index from a domain.
-/// Remove one CLI rule from THIS tier. Returns how many went: 0 means the index
-/// is not in this tier, which is not the same as success.
+/// Remove one CLI rule from THIS tier. Returns how many went — READ BACK from the
+/// store after the write, not assumed: 0 means the index is not in this tier,
+/// which is not the same as success.
 ///
 /// #55. This ran the DELETE and returned `Ok(())` whatever matched, so
 /// `rule remove --domain X --index 10` against a tier with no rules at all
 /// printed "Rule 10 removed from domain 'X'" and exited 0. The index is
 /// tier-local and both tiers start at 0, so the number a user reads in their
 /// injected context routinely names a different rule here.
+///
+/// #112. #55 gave `cli.rs:2851-2858` an `Ok(0)` branch that exits non-zero, and
+/// this function could never reach it. The guard read `GRAPH ?g` — a wildcard over
+/// every named graph in this tier's FILE — while the DELETE was scoped to
+/// `GRAPH <graph/ws/{slug}>`, the tier's own graph. A rule sitting in a foreign
+/// named graph (460 quads of them on the reporting install) passed the guard,
+/// matched nothing in the DELETE, and the hardcoded `Ok(1)` reported success. Both
+/// sides now ask the wildcard's question, which is what six of the seven other
+/// removers in `crud` already ask, and the return value asks the store.
+///
+/// A wildcard cannot cross a tier: `lock_and_load` resolves ONE path through
+/// `find_workspace_base(cwd)`, so `GRAPH ?g` ranges over the named graphs inside
+/// one tier's own `graph.nq` and reaches nothing else.
 pub fn remove(cwd: &Path, ns: &NamespaceConfig, domain_name: &str, index: u32) -> Result<usize> {
-    // Check before deleting. `true` deliberately: a superseded rule still
-    // occupies its index in this tier, and refusing to remove one because the
-    // default view hides it would be a fresh false "no rule N" of exactly the
-    // kind #55 is about.
-    if !fetch(cwd, ns, domain_name, true)?
-        .iter()
-        .any(|(pri, _, _)| *pri == index)
-    {
-        return Ok(0);
-    }
     let p = &ns.prefix;
     let domain_slug = crud::slugify(domain_name);
     let domain_iri = crud::build_iri(ns, "domain", &domain_slug);
-    let ws_slug = crud::workspace_slug(cwd);
-    let graph = crud::workspace_graph_iri(ns, &ws_slug);
+
+    // One lock, one load, and the load is INSIDE the lock. The old guard was a
+    // second `fetch`, which parsed the whole graph through `load_and_query` before
+    // `load_and_mutate` parsed it again.
+    let (store, trig_path, _lock) = crud::lock_and_load(cwd)?;
+
+    // Counted as DISTINCT rules, which is the unit every other remover here
+    // reports (`decision::delete` returns decisions, `milestone::delete` returns
+    // cascade-deleted tasks). Superseded rules are counted deliberately: one still
+    // occupies its index, and refusing to remove it because the default view hides
+    // it would be a fresh false "no rule N" of exactly the kind #55 is about.
+    let count = format!(
+        "SELECT (COUNT(DISTINCT ?rule) AS ?n) WHERE {{\n\
+           GRAPH ?g {{\n\
+             <{domain_iri}> {p}:hasRule ?rule .\n\
+             ?rule {p}:index \"{index}\" .\n\
+           }}\n\
+         }}"
+    );
+    let before = count_rules(&store, ns, &count)?;
+    if before == 0 {
+        return Ok(0);
+    }
 
     // Match by {p}:index predicate, not constructed IRI — CLI rules live at
     // rule/{slug}/cli-N and are the only rules carrying {p}:index. Synced
     // rules are managed by editing domains.toml (sync GC handles them).
     let sparql = format!(
-        "DELETE {{\n\
-           GRAPH <{graph}> {{\n\
+        "{}\n\
+         DELETE {{\n\
+           GRAPH ?g {{\n\
              ?rule ?rp ?ro .\n\
              <{domain_iri}> {p}:hasRule ?rule .\n\
            }}\n\
          }}\n\
          WHERE {{\n\
-           GRAPH <{graph}> {{\n\
+           GRAPH ?g {{\n\
              <{domain_iri}> {p}:hasRule ?rule .\n\
              ?rule {p}:index \"{index}\" ;\n\
                ?rp ?ro .\n\
            }}\n\
-         }}"
+         }}",
+        crud::prefixes(ns)
     );
 
-    crud::load_and_mutate(cwd, ns, &sparql)?;
-    Ok(1)
+    // Wide, not Target: `changelog::derive_graph_iri` cannot name a target for a
+    // `GRAPH ?g` update, so Target would record a MultiGraph delta GAP where a
+    // retraction owes a delta. `note::remove` takes Wide for the same statement
+    // shape, and `store.rs` documents the scope for exactly this case.
+    crate::store::update_and_write(
+        &store,
+        &trig_path,
+        &sparql,
+        crate::store::Scope::Wide,
+        crate::store::Intent::Knowledge,
+    )?;
+
+    // READ BACK, which is the only thing that separates a repaired write from a
+    // silenced one. `update_and_write` applies the update to THIS store and only
+    // then serialises it to `trig_path`, propagating any failure — so on `Ok` the
+    // file on disk was written FROM the store being re-queried here, and the two
+    // cannot disagree. A count taken before the write, or assumed from the guard,
+    // would report exactly what #112 reported.
+    let after = count_rules(&store, ns, &count)?;
+    if after > before {
+        anyhow::bail!(
+            "removing rule {index} from domain '{domain_name}' left MORE rules at that \
+             index than it started with ({before} before, {after} after)"
+        );
+    }
+    Ok(before - after)
+}
+
+/// How many distinct rules a counting query binds, asked of a store already loaded.
+///
+/// Split out because `remove` asks it twice with the same text — once before the
+/// write and once after — and the two readings are only comparable if they are the
+/// same question put to the same store.
+fn count_rules(store: &Store, ns: &NamespaceConfig, sparql: &str) -> Result<usize> {
+    let full = format!("{}\n{}", crud::prefixes(ns), sparql);
+    let QueryResults::Solutions(mut solutions) = crate::store::query(store, &full)? else {
+        anyhow::bail!("rule count query did not return solutions: {sparql}");
+    };
+    let Some(row) = solutions.next().transpose()? else {
+        return Ok(0);
+    };
+    let Some(term) = row.get("n") else { return Ok(0) };
+    let text = crud::term_display(term.into());
+    // Parsed, never defaulted: a count that failed to parse is not a count of zero,
+    // and zero is the value the caller treats as "no such rule".
+    text.parse()
+        .with_context(|| format!("rule count returned an unreadable value: {text:?}"))
 }
 
 /// Find the next available rule index for a domain.

--- a/tests/rule_tier_scope_test.rs
+++ b/tests/rule_tier_scope_test.rs
@@ -1,0 +1,279 @@
+//! `rule remove` must remove what `rule list` showed, or say it did not.
+//!
+//! #112, reported by sstickel on 0.14.2/Linux. A global `graph.nq` holding rule
+//! quads in a named graph other than the tier's own — 460 of them on the
+//! reporter's install, origin unknown and unreproducible on 0.14.2 — makes the
+//! two halves of `crud::rule` disagree:
+//!
+//! - `fetch` (`crud/rule.rs:135`) reads `GRAPH ?g`, a wildcard over every named
+//!   graph in the tier's file, so `rule -g list` SHOWS the foreign rule.
+//! - `remove` (`:265`, `:271`) scoped its DELETE to `GRAPH <graph/ws/{slug}>`,
+//!   the tier's own graph, so the statement matched nothing.
+//! - `remove` then returned a hardcoded `Ok(1)` (`:280`) without asking the store
+//!   what had actually gone, and `cli.rs:2859` printed `Rule 7 removed` and
+//!   exited 0.
+//!
+//! A scripted cleanup loop could report twelve successful deletions and change
+//! nothing. That is the defect: not the wildcard read — `GRAPH ?g` is base's
+//! normal idiom, 197 occurrences across 37 files, and one tier is one FILE so a
+//! wildcard never crosses tiers — but a mutation whose read and write ask
+//! different questions and whose return value asks none.
+//!
+//! Two of these five legs are CONTROLS and pass before the fix. That is
+//! deliberate: `the_rule_in_this_tiers_own_graph_still_goes` separates a repair
+//! from a silencing (a `remove` that always refused, or that purged the graph,
+//! passes the defect leg identically), and
+//! `an_index_in_no_graph_at_all_reports_zero` proves #55's `Ok(0)` path — the
+//! branch `cli.rs:2851-2858` exits 1 on — is still reached afterwards.
+
+use std::path::{Path, PathBuf};
+
+use base::config::NamespaceConfig;
+use base::crud;
+
+fn ns() -> NamespaceConfig {
+    NamespaceConfig::default()
+}
+
+/// A workspace with an empty graph, which is what `base scaffold` leaves behind
+/// and what every read in `crud` expects to open.
+fn workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".base")).unwrap();
+    std::fs::write(tmp.path().join(".base").join("graph.nq"), "").unwrap();
+    tmp
+}
+
+fn graph_path(root: &Path) -> PathBuf {
+    root.join(".base").join("graph.nq")
+}
+
+/// Every non-blank line of the tier's graph file.
+///
+/// Returned rather than counted so each leg can print the set it actually
+/// visited: an assertion that looped over nothing proved nothing, and must fail
+/// rather than pass.
+fn quad_lines(root: &Path) -> Vec<String> {
+    std::fs::read_to_string(graph_path(root))
+        .unwrap()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Every line mentioning one rule's IRI, in any named graph.
+///
+/// Matched on the IRI rather than on the bytes I appended, because a write
+/// re-serializes the whole store and the reporter's hand-written spacing does
+/// not survive it. The IRI does.
+fn lines_for_rule(root: &Path, ns: &NamespaceConfig, domain: &str, tail: &str) -> Vec<String> {
+    let iri = format!("<{}rule/{}/{}>", ns.uri, domain, tail);
+    quad_lines(root).into_iter().filter(|l| l.contains(&iri)).collect()
+}
+
+/// The reporter's stray: five quads for one rule, in a named graph this tier does
+/// not own, appended to the tier's own file exactly as #112's reproduction does.
+/// Returns how many quads it wrote.
+///
+/// Built from `ns.uri`, never from a pasted literal. A hardcoded IRI that drifted
+/// from the configured namespace would make the stray inert, the wildcard reader
+/// would never see it, and every leg below would pass vacuously against a fixture
+/// that was never there.
+///
+/// `tail` is separate from `index` on purpose: two rules at the same index must be
+/// two distinct subjects, or the store folds them into one and a count cannot tell
+/// a read-back from a constant.
+fn append_foreign_rule(
+    root: &Path,
+    ns: &NamespaceConfig,
+    domain: &str,
+    tail: &str,
+    index: u32,
+    text: &str,
+) -> usize {
+    let u = &ns.uri;
+    let g = format!("{u}graph/ws/otherws");
+    let d = format!("{u}domain/{domain}");
+    let r = format!("{u}rule/{domain}/{tail}");
+    let quads = [
+        format!("<{d}> <{u}hasRule> <{r}> <{g}> ."),
+        format!("<{r}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{u}Rule> <{g}> ."),
+        format!("<{r}> <{u}index> \"{index}\" <{g}> ."),
+        format!("<{r}> <{u}priority> \"{index}\" <{g}> ."),
+        format!("<{r}> <{u}ruleText> \"{text}\" <{g}> ."),
+    ];
+
+    let mut body = std::fs::read_to_string(graph_path(root)).unwrap();
+    if !body.is_empty() && !body.ends_with('\n') {
+        body.push('\n');
+    }
+    for q in &quads {
+        body.push_str(q);
+        body.push('\n');
+    }
+    std::fs::write(graph_path(root), body).unwrap();
+    quads.len()
+}
+
+/// The reporter's starting state: one real rule in the tier's own graph, and one
+/// stray at index 7 in a graph the tier does not own.
+fn tier_with_a_stray(root: &Path) -> usize {
+    crud::rule::add(root, &ns(), "demoapp", "real global rule", None).unwrap();
+    append_foreign_rule(
+        root,
+        &ns(),
+        "demoapp",
+        "cli-7",
+        7,
+        "stray rule from another workspace graph",
+    )
+}
+
+/// FIXTURE CONTROL. Separates "the assertion failed" from "the assertion could
+/// not run": if the stray never reaches the wildcard reader, every leg below is
+/// measuring an empty graph and would pass no matter what `remove` did.
+#[test]
+fn the_stray_is_really_there_and_the_listing_really_shows_it() {
+    let tmp = workspace();
+    let written = tier_with_a_stray(tmp.path());
+    assert_eq!(written, 5, "the reporter's stray is five quads");
+
+    let on_disk = lines_for_rule(tmp.path(), &ns(), "demoapp", "cli-7");
+    assert_eq!(
+        on_disk.len(),
+        5,
+        "the stray must be on disk before any leg runs; found {}: {on_disk:?}",
+        on_disk.len()
+    );
+
+    let seen = crud::rule::fetch(tmp.path(), &ns(), "demoapp", true).unwrap();
+    assert_eq!(
+        seen.len(),
+        2,
+        "the wildcard reader must see BOTH rules — at 1 the fixture is inert and \
+         every leg in this file would pass vacuously: {seen:?}"
+    );
+    assert!(
+        seen.iter().any(|(n, _, _)| *n == 7),
+        "index 7 is what the operator reads and what they will type: {seen:?}"
+    );
+}
+
+/// THE DEFECT. Red before the fix: `remove` reports success and the five quads it
+/// claimed to delete are still on disk.
+#[test]
+fn removing_a_rule_the_listing_showed_actually_removes_it() {
+    let tmp = workspace();
+    tier_with_a_stray(tmp.path());
+
+    let removed = crud::rule::remove(tmp.path(), &ns(), "demoapp", 7).unwrap();
+
+    let left_on_disk = lines_for_rule(tmp.path(), &ns(), "demoapp", "cli-7");
+    assert!(
+        left_on_disk.is_empty(),
+        "`remove` returned {removed} and left {} of the rule's quads on disk: {left_on_disk:?}",
+        left_on_disk.len()
+    );
+    assert_eq!(removed, 1, "one rule was addressed and one rule went");
+
+    let after = crud::rule::fetch(tmp.path(), &ns(), "demoapp", true).unwrap();
+    assert_eq!(after.len(), 1, "the listing must agree with the delete: {after:?}");
+    assert_eq!(
+        after[0].1, "real global rule",
+        "the surviving rule is this tier's own: {after:?}"
+    );
+}
+
+/// THE COUNT IS READ BACK, NOT ASSUMED. Two distinct rules sit at index 7 — one in
+/// this tier's own graph, one in a graph it does not own — so the honest answer is
+/// 2. A hardcoded `Ok(1)`, or any fix that returns what it hoped for instead of
+/// what left the store, reports 1 here.
+#[test]
+fn the_count_comes_back_from_the_store() {
+    let tmp = workspace();
+    // Eight rules, so index 7 is legitimately this tier's own.
+    for i in 1..=8 {
+        crud::rule::add(tmp.path(), &ns(), "demoapp", &format!("rule number {i}"), None).unwrap();
+    }
+    append_foreign_rule(
+        tmp.path(),
+        &ns(),
+        "demoapp",
+        "stray-7",
+        7,
+        "a stray sharing index 7",
+    );
+
+    let both = crud::rule::fetch(tmp.path(), &ns(), "demoapp", true).unwrap();
+    let at_seven = both.iter().filter(|r| r.0 == 7).count();
+    assert_eq!(at_seven, 2, "precondition: two distinct rules share index 7: {both:?}");
+
+    let removed = crud::rule::remove(tmp.path(), &ns(), "demoapp", 7).unwrap();
+    assert_eq!(
+        removed, 2,
+        "two rules were at index 7 and both had to go; a constant return says 1 here"
+    );
+
+    for tail in ["cli-7", "stray-7"] {
+        let left = lines_for_rule(tmp.path(), &ns(), "demoapp", tail);
+        assert!(left.is_empty(), "{tail} survived a reported removal: {left:?}");
+    }
+    let after = crud::rule::fetch(tmp.path(), &ns(), "demoapp", true).unwrap();
+    assert_eq!(after.len(), 7, "the other seven rules were not addressed: {after:?}");
+}
+
+/// CONTROL, passes before the fix. A `remove` "fixed" by always refusing, or by
+/// purging every rule it could reach, passes the defect leg above identically.
+/// This is the leg that separates a repair from a silencing: the addressed rule
+/// goes, and nothing else does.
+#[test]
+fn the_rule_in_this_tiers_own_graph_still_goes_and_nothing_else_does() {
+    let tmp = workspace();
+    tier_with_a_stray(tmp.path());
+    crud::rule::add(tmp.path(), &ns(), "otherdomain", "a rule on another domain", None).unwrap();
+
+    let removed = crud::rule::remove(tmp.path(), &ns(), "demoapp", 0).unwrap();
+    assert_eq!(removed, 1, "the tier's own rule 0 was addressed and went");
+
+    let gone = lines_for_rule(tmp.path(), &ns(), "demoapp", "cli-0");
+    assert!(gone.is_empty(), "rule 0 was reported removed and is still here: {gone:?}");
+
+    let stray = lines_for_rule(tmp.path(), &ns(), "demoapp", "cli-7");
+    assert_eq!(
+        stray.len(),
+        5,
+        "index 7 was never addressed and must survive — a purge takes it too: {stray:?}"
+    );
+
+    let other = crud::rule::fetch(tmp.path(), &ns(), "otherdomain", true).unwrap();
+    assert_eq!(other.len(), 1, "another domain's rules were collateral: {other:?}");
+}
+
+/// CONTROL, passes before the fix. #55's zero path must still be REACHED after the
+/// change — it is the branch `cli.rs:2851-2858` prints the tier-scoped error and
+/// calls `std::process::exit(1)` on. A fix that returned a non-zero count
+/// unconditionally passes every leg above and fails this one.
+#[test]
+fn an_index_in_no_graph_at_all_reports_zero_and_writes_nothing() {
+    let tmp = workspace();
+    tier_with_a_stray(tmp.path());
+
+    let before = quad_lines(tmp.path());
+    assert!(
+        !before.is_empty(),
+        "this leg visited zero quads, so it proved nothing about writing none"
+    );
+
+    let removed = crud::rule::remove(tmp.path(), &ns(), "demoapp", 99).unwrap();
+    assert_eq!(removed, 0, "index 99 is in no graph in this file, and 0 is not success");
+
+    let after = quad_lines(tmp.path());
+    assert_eq!(
+        after.len(),
+        before.len(),
+        "a refused removal wrote to the graph: {} lines before, {} after",
+        before.len(),
+        after.len()
+    );
+}


### PR DESCRIPTION
Closes #112.

## The defect

A tier's `graph.nq` holding rule quads in a named graph other than the tier's own — 460 of them on
the reporter's install — makes the two halves of `crud::rule` ask different questions:

| site | question it asks |
|---|---|
| `fetch` `src/crud/rule.rs:136` | is index N anywhere in this tier's **file**? (`GRAPH ?g`) |
| `remove`'s DELETE, before this PR | is index N in this tier's **own graph**? (`GRAPH <graph/ws/{slug}>`) |
| `remove`'s return, before this PR | nothing — a hardcoded `Ok(1)` |

So `rule -g list` shows the foreign rule, the existence guard passes on it, the DELETE matches
nothing, and `Ok(1)` reaches `cli.rs:2859`, which prints `Rule 7 removed` and exits 0. A scripted
cleanup loop can report twelve successful deletions and change nothing.

## The fix, and which side of the mismatch moves

`GRAPH ?g` is not the defect. It is base's normal read idiom — **197 occurrences across 37 files**
under `src/` — and one tier is one FILE (`crud::lock_and_load`, `load_and_query` and
`load_and_mutate` all resolve through `config::find_workspace_base(cwd)`), so a wildcard **never
crosses a tier**. It ranges over the named graphs inside one file.

Censusing every remover in `src/crud/` says which side is the outlier:

| remover | existence check | DELETE scope | agree? |
|---|---|---|---|
| `decision::delete` | wildcard | wildcard | yes |
| `milestone::delete` | wildcard | wildcard | yes |
| `note::remove` | scoped | scoped | yes |
| `project::delete` | scoped | wildcard | yes (delete covers the read; an empty plan is an `Err`) |
| `reminder::remove` | none | wildcard | yes |
| `task::delete` | none | wildcard | yes |
| `task::tag` | none | wildcard delete / scoped insert | yes (delete covers the insert) |
| **`rule::remove`** | **wildcard** | **scoped** | **NO — the only one** |

Six of seven siblings delete with `GRAPH ?g`; the seventh is scoped on both sides. `rule::remove`
is the only remover whose delete covers **less** than its read showed, and the only one returning a
constant. So the **scoped DELETE** moves, not the wildcard read:

1. The DELETE matches `GRAPH ?g`, the same question the guard asks (`rule.rs:292`, `:298`).
2. The write takes `Scope::Wide` (`:315`), which `src/store.rs:366-373` documents for exactly this
   statement shape — "deletes and purges, whose `DELETE … WHERE { GRAPH ?g … }` cannot name a
   target" — and which `note::remove` already takes. Under `Target`,
   `changelog::derive_graph_iri` derives no target from a `GRAPH ?g` update and the write records
   a `MultiGraph` delta **gap**, so a retraction that owes a delta would ship none.
3. The return value is **read back from the store after the write** (`count_rules` at `:340`,
   called at `:281` and `:325`). Read-back is the only thing that separates a repaired write from
   a silenced one: a count taken before the write, or inherited from the guard, reports exactly
   what #112 reported.

Incidentally, one lock and one load replace three parses — the old guard called `fetch`, which
loaded the graph through `load_and_query`, before `load_and_mutate` loaded it again — and the
existence check and the delete now sit in one critical section.

**`fetch` `:136` and `next_rule_index` `:362` keep `GRAPH ?g`, deliberately.** `fetch` is the
shared reader for `rule list` *and* the domain block the prompt hook injects (its doc comment
records that ruling), so narrowing it changes what every agent receives in every prompt — and it
would hide the foreign quads, while `doctor`, the surface that should report them, is a separate
issue. `next_rule_index`'s wildcard is load-bearing: MAX+1 across the whole file is what keeps
`--index N` unambiguous, and scoping it would let the allocator hand out an index a visible rule
already occupies. `rule_index_test.rs`'s four tests pin both as unchanged.

`cli.rs` needs **no change**: `:2851-2858` has printed the tier-scoped error and called
`std::process::exit(1)` on `Ok(0)` since #55. It was never handed a truthful 0.

## Red-first — two commits, two runs, step conclusions

| commit | run | `test` job / `cargo test` step | `clippy` job / `-D warnings` step |
|---|---|---|---|
| `b81ea7423333ed5c1496604d916060f026588c8e` — the five legs, no production code | `34257474013` | `102166814893` step 5 = **failure** | `102166814850` step 5 = success |
| `1e03465064cb81ed854151cdd115cea5729e8553` — the fix, no test changes | `34258046321` | `102168715959` step 5 = **success** | `102168715836` step 5 = success |

All four jobs green at `1e03465`, every step: `python-ast-tests` `102168715584` step 5,
`release-invocations` `102168715867` steps 3/4/5, and the `test` job's step 6 release rehearsal.

| leg | at `b81ea742` | at `1e03465` |
|---|---|---|
| `removing_a_rule_the_listing_showed_actually_removes_it` | **RED** | ok |
| `the_count_comes_back_from_the_store` (two rules at one index, so `Ok(2)`) | **RED** | ok |
| `the_stray_is_really_there_and_the_listing_really_shows_it` (fixture control) | ok | ok |
| `the_rule_in_this_tiers_own_graph_still_goes_and_nothing_else_does` (repaired vs silenced) | ok | ok |
| `an_index_in_no_graph_at_all_reports_zero_and_writes_nothing` (`Ok(0)` still reached) | ok | ok |

At `b81ea742`: `rule_tier_scope_test` reported **3 passed, 2 failed**, and cargo's roll-up read
`error: 1 target failed` — the only failing target in the whole suite, so there is no pre-existing
red on this base to attribute the result to. `--no-fail-fast` (#135) is what made that visible.

At `1e03465`: `rule_tier_scope_test` reported **5 passed, 0 failed**, and across the suite the
`Running` line count **equals** the `test result:` line count (66 = 66), which is what proves no
target is hidden from the count. Zero targets report a non-zero `failed`. Both counts were taken
after stripping ANSI — `CARGO_TERM_COLOR: always` colourises cargo's own `Running` lines, and an
anchored grep reads a false zero through them.

The two failures at `b81ea742`, verbatim:

```
---- removing_a_rule_the_listing_showed_actually_removes_it stdout ----
`remove` returned 1 and left 5 of the rule's quads on disk: [
 "<O#rule/demoapp/cli-7> <O#ruleText> \"stray rule from another workspace graph\" <O#graph/ws/otherws> .",
 "<O#rule/demoapp/cli-7> <O#priority> \"7\" <O#graph/ws/otherws> .",
 "<O#rule/demoapp/cli-7> <O#index> \"7\" <O#graph/ws/otherws> .",
 "<O#rule/demoapp/cli-7> <rdf-syntax-ns#type> <O#Rule> <O#graph/ws/otherws> .",
 "<O#domain/demoapp> <O#hasRule> <O#rule/demoapp/cli-7> <O#graph/ws/otherws> ."]

---- the_count_comes_back_from_the_store stdout ----
assertion `left == right` failed: two rules were at index 7 and both had to go;
a constant return says 1 here
  left: 1
 right: 2
```

`O` stands in for `http://ops-sys.local/ontology` for width **in this summary only**; the run log
carries every IRI in full and was read whole, never through a slicing filter.

**Two legs green before the fix is the point, not an oversight.** A `remove` that always refused, or
that purged every rule it could reach, passes the defect leg identically — the control legs are what
separate a repair from a silencing, and they are why the `Ok(0)` exit-1 path is proven still
reachable afterwards. Every leg builds its fixture from `ns.uri` rather than a pasted literal: an IRI
that drifted from the configured namespace would make the stray inert and every leg pass vacuously.

## Behaviour deltas beyond the reported defect

1. **A malformed rule carrying an `index` but no `ruleText` is now removable.** The old guard went
   through `fetch`, whose SPARQL requires `?rule {p}:ruleText ?text`; the new counting query
   requires only `hasRule` + `index`. Such a rule was previously invisible to `rule list` *and*
   un-removable by `rule remove`.
2. **`Scope::Wide` snapshots the whole store twice** to compute the delta, where `Target`
   snapshotted one graph. `note::remove` already pays this for the same reason; `rule remove` is an
   operator command, not a hook path.
3. **`remove` now holds the graph lock across the check and the delete.** Before, the guard's
   `fetch` read happened outside any lock.

## Guards checked by reading, before the push

- `lock_tripwire_test.rs`: `update_and_write(` is in `WRITE_CALLS`, so `remove` is a Rule-1 subject;
  `lock_and_load(` is in `LOCK_TOKENS`, and `remove` calls it in code, not in a comment (which
  `code_only` strips). Not a finding. Rule 2 needs an `FS_PRIMITIVES` call; `remove` makes none.
- `guard_test.rs`: `no_hand_built_sparql_change_outside_the_seam` forbids constructing
  `Change::SparqlWithDelta(` / `Change::SparqlNoDelta(` outside `store.rs`/`changelog.rs`. This
  constructs neither — it calls `update_and_write`, which is what the guard's message tells writers
  to do.

## Declared limits

- The 460-quad leak's **origin** is not investigated. The reporter could not reproduce the write on
  0.14.2 across 16 verbs and concluded it is an old-version artefact. This fixes the reporting.
- `doctor` printing `global tier — HEALTHY` over foreign-graph quads, and `BASE_GLOBAL_DIR` being
  ignored, are the issue's two smaller points and are **out of scope** here — separate issues.
- The `cli.rs` exit-1 arm is asserted by **inspection**, not by a test: reaching
  `std::process::exit(1)` needs a subprocess, and the arm is eight lines of unconditional code.
- **This branch is based on `74cbb466` and is deliberately not rebased.** `main` moved to
  `a421f9df` (#137) mid-flight; rebasing would orphan `b81ea742` and destroy the exact
  fail-here / pass-there pair, which is the artifact. GitHub tests `refs/pull/140/merge` against
  current `main` regardless.
- **No local `cargo` was run at any point.** The box was held by another lane for the whole build;
  every number above is a CI step conclusion or a log read from the API.

Fork doc: `C:/Users/Chris/.base-gbl/forks/base-0.14.3-lane-rule-remove.md` — G0 draft, auk's
verdict, build record and the design-to-code map.
