### PR TITLE
Make the #112 zero-path control a pair, so it cannot pass blind

### DIFF
--- a/tests/rule_tier_scope_test.rs
+++ b/tests/rule_tier_scope_test.rs
@@ -250,10 +250,22 @@ fn the_rule_in_this_tiers_own_graph_still_goes_and_nothing_else_does() {
     assert_eq!(other.len(), 1, "another domain's rules were collateral: {other:?}");
 }
 
-/// CONTROL, passes before the fix. #55's zero path must still be REACHED after the
-/// change — it is the branch `cli.rs:2851-2858` prints the tier-scoped error and
-/// calls `std::process::exit(1)` on. A fix that returned a non-zero count
+/// CONTROL. #55's zero path must still be REACHED — it is the branch
+/// `cli.rs:2851-2858` prints the tier-scoped error and calls
+/// `std::process::exit(1)` on. A `remove` that returned a non-zero count
 /// unconditionally passes every leg above and fails this one.
+///
+/// It is a PAIR, and the second half is the point. On its own, "asking for index
+/// 99 returns 0" is satisfied just as well by a counting query that finds nothing
+/// for ANY index — a domain IRI built from a broken slug path resolves to no
+/// rules at all, `remove` returns 0 every time, and this leg passes having proven
+/// nothing about index 99. So the same fixture, through the same code path, is
+/// then asked for an index that IS present and must answer non-zero.
+///
+/// tern found this against its own leg while #140 was frozen for review, one law
+/// after raven found the same shape in osprey's `--skip-hooks` control, where a
+/// fake home missing `~/.claude` short-circuited the seam and the control passed
+/// without ever testing the flag. A leg that cannot fail is not a control.
 #[test]
 fn an_index_in_no_graph_at_all_reports_zero_and_writes_nothing() {
     let tmp = workspace();
@@ -275,5 +287,16 @@ fn an_index_in_no_graph_at_all_reports_zero_and_writes_nothing() {
         "a refused removal wrote to the graph: {} lines before, {} after",
         before.len(),
         after.len()
+    );
+
+    // The positive half. Same tier, same fixture, same function — an index that
+    // IS there must come back non-zero, or the 0 above was a blind query rather
+    // than an answer about index 99.
+    let present = crud::rule::remove(tmp.path(), &ns(), "demoapp", 0).unwrap();
+    assert_eq!(
+        present, 1,
+        "the same code path found nothing at index 0 either, so the 0 reported for \
+         index 99 proved nothing: this leg cannot tell an absent index from a \
+         counting query that never sees anything"
     );
 }


### PR DESCRIPTION
Follow-up to #140 (#112). **Test-only — no production code.**

## The finding, against my own leg

`an_index_in_no_graph_at_all_reports_zero_and_writes_nothing` is the control that proves #55's
`Ok(0)` path is still reached after #140 changed `rule::remove` — it is the branch
`cli.rs:2851-2858` prints the tier-scoped error and calls `std::process::exit(1)` on.

As written it asserted two things: `remove(.., 99)` returns `0`, and the graph file's line count is
unchanged. **Neither can distinguish the state it is meant to prove from a blind query.** If the
counting query found nothing for *any* index — a domain IRI built from a broken slug path resolves
to no rules at all — then `remove` returns 0 every time, writes nothing every time, and this leg
passes having proven nothing whatsoever about index 99.

That is the shape raven found in osprey's `--skip-hooks` control on #136 the same evening: a fake
home missing `~/.claude` short-circuited the seam, so the leg passed without ever testing the flag.
**A leg that cannot fail is not a control** (law 26).

## The fix

The same fixture, through the same function, is now also asked for an index that **is** present:

```rust
let present = crud::rule::remove(tmp.path(), &ns(), "demoapp", 0).unwrap();
assert_eq!(present, 1, "the same code path found nothing at index 0 either, so the 0 reported \
                        for index 99 proved nothing: ...");
```

If the query were blind, `present` is `0` and this assertion fails. That is what makes the
negative half mean something, and it is why the pair is the unit rather than either line.

The positive half runs **after** the file-unchanged assertion, so it cannot disturb what that
measures.

## Why it is a pair and not an assertion on `fetch`

The obvious alternative — assert `fetch` can see the domain's rules before asking for 99 — is
weaker, because `remove` no longer goes through `fetch`. Since #140 it counts through its own
query (`count_rules`, `src/crud/rule.rs`). Proving `fetch`'s query works says nothing about
`count_rules`'s. Driving the function under test in both directions on one fixture does.

## Scope

- The other four legs in `tests/rule_tier_scope_test.rs` are untouched, so the red/green pair
  recorded on #140 — `b81ea742` fails 2 of 5, `1e03465` passes 5 of 5 — still stands as measured.
- No `src/` change, so #140's fix is not re-litigated here.
- Found while #140 was frozen for review and deliberately **not** pushed onto that branch: it would
  have orphaned the red sha and destroyed the exact fail-here / pass-there pair, which auk had
  already made the round ruling.
