### PR TITLE
#87: the nine Tier C writers take the graph lock, and write_back goes private

### DIFF
--- a/src/apply_ops.rs
+++ b/src/apply_ops.rs
@@ -445,27 +445,21 @@ pub fn run(graph_path: &Path, input: &str) -> (Value, i32) {
         return (Outcome::default().to_json(), 0);
     }
 
-    // A machine that has never written anything has no graph.nq yet, and a first
-    // pull is exactly that case — so start from an empty store rather than
-    // refusing, matching `crud::load_workspace_store`, the write path `base learn`
-    // already takes on a fresh home.
-    let store = if graph_path.exists() {
-        match crate::store::load_graph(graph_path) {
-            Ok(s) => s,
-            Err(e) => {
-                return (OpError::whole("graph_load_failed", e.to_string()).to_json(), 1);
-            }
-        }
-    } else {
-        match Store::new() {
-            Ok(s) => s,
-            Err(e) => {
-                return (OpError::whole("store_init_failed", e.to_string()).to_json(), 1);
-            }
+    // #87: lock, THEN load, and the conditional is gone rather than moved.
+    // `lock_and_load_graph` loads through `load_or_empty`, which already answers
+    // the case this branch existed for: a machine that has never written anything
+    // has no graph.nq yet, and a first pull is exactly that — an empty store, not
+    // a refusal. One route now covers both, so there is no second path to keep in
+    // step. The guard holds to the end of the function, covering the write below.
+    let locked = match crate::store::lock_and_load_graph(graph_path) {
+        Ok(g) => g,
+        Err(e) => {
+            return (OpError::whole("graph_load_failed", e.to_string()).to_json(), 1);
         }
     };
+    let store = locked.store();
 
-    let outcome = match apply(&store, &prepared) {
+    let outcome = match apply(store, &prepared) {
         Ok(o) => o,
         Err(e) => return (e.to_json(), 1),
     };
@@ -476,8 +470,7 @@ pub fn run(graph_path: &Path, input: &str) -> (Value, i32) {
         return (outcome.to_json(), 0);
     }
 
-    if let Err(e) = crate::store::write_back(&store, graph_path, Change::RemoteOps(&outcome.records))
-    {
+    if let Err(e) = locked.write(Change::RemoteOps(&outcome.records)) {
         return (OpError::whole("write_failed", e.to_string()).to_json(), 1);
     }
     (outcome.to_json(), 0)

--- a/src/crud/mod.rs
+++ b/src/crud/mod.rs
@@ -193,6 +193,25 @@ pub fn lock_and_load(cwd: &Path) -> Result<(Store, PathBuf, crate::store::GraphL
     Ok((store, trig_path, guard))
 }
 
+/// Take the workspace graph lock, THEN load, and hand back a [`LockedGraph`].
+///
+/// The bulk twin of [`lock_and_load`], for the writers that rewrite the WHOLE
+/// file rather than applying a SPARQL update to it. Two differences, both
+/// deliberate: it waits on the bulk bound rather than the hot-path one, because
+/// none of these is on a per-tool-call path; and the value it returns carries
+/// the file identity, so the write refuses a file that changed under the
+/// snapshot instead of overwriting it.
+///
+/// `lock_and_load`'s five CRUD callers stay on the tuple form: they write
+/// through `update_and_write`, which applies a SPARQL update and takes no
+/// identity, so there is nothing for the backstop to compare. That coverage gap
+/// is filed to 0.14.4 — it is a gap in the guard, not in the lock, and those
+/// five do take the lock.
+pub fn lock_and_load_workspace(cwd: &Path) -> Result<crate::store::LockedGraph> {
+    let path = workspace_graph_path(cwd)?;
+    crate::store::lock_and_load_graph(&path)
+}
+
 pub fn load_workspace_store(cwd: &Path) -> Result<(Store, PathBuf)> {
     let base_dir = require_base_for_write(cwd)?;
     let trig_path = base_dir.join("graph.nq");

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -82,6 +82,15 @@ pub struct DoctorReport {
     /// Counts against `healthy`: an inert trigger is a domain that silently stopped
     /// loading, and the fix is one line in domains.toml.
     pub trigger_faults: Vec<String>,
+    /// The write seam this binary was built with, [`store::LOCK_SEAM_MARKER`].
+    ///
+    /// Not diagnostic information for an operator — it is here so a verification
+    /// harness can prove WHICH binary it is driving from the binary's own output,
+    /// rather than from a filename, an mtime or a directory it was copied to.
+    /// Referencing it from a live path is also what keeps the constant reachable
+    /// in the linked binary, so a substring probe of the executable means
+    /// something.
+    pub seam: &'static str,
 }
 
 /// Diagnose a single graph file. PURE: only touches `path` and its siblings
@@ -219,6 +228,7 @@ pub fn diagnose(cwd: &Path) -> DoctorReport {
         warnings,
         config_errors,
         trigger_faults,
+        seam: store::LOCK_SEAM_MARKER,
     }
 }
 
@@ -1151,6 +1161,7 @@ mod coach_drift_tests {
             warnings: vec![skill_drift_warning(Some("0.12.3"), "0.13.2", true).unwrap()],
             config_errors: vec![],
             trigger_faults: vec![],
+            seam: store::LOCK_SEAM_MARKER,
         };
         assert!(report.healthy, "an advisory must not flip the verdict");
         // Reaches the reader even with no graph tiers present — a lagging coach

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -776,6 +776,16 @@ pub fn repair_tier(tier: &str, path: &Path) -> Result<RepairOutcome> {
         GraphHealth::Missing => Ok(base(None, None, 0, 0, true)),
         GraphHealth::Healthy => Ok(base(None, None, count_lines(path), 0, true)),
         GraphHealth::Unhealthy { .. } => {
+            // #87: the lock is taken before the snapshot, so the backup, the
+            // lenient re-parse and the rewrite all describe one file.
+            //
+            // NOT `lock_and_load_graph`: this arm runs on a graph that does not
+            // parse, so a load here would fail on exactly the file the repair
+            // exists to fix. `lock_for_rebuild` takes the lock and records the
+            // identity without loading, and the rebuilt store goes through
+            // `write_store`.
+            let locked = store::lock_for_rebuild(path)?;
+
             // 1. Snapshot first (rotating, in-binary backup — Phase 36 store::snapshot).
             let backup_path = store::snapshot(path, "pre-repair")
                 .context("failed to back up before repair")?;
@@ -800,7 +810,7 @@ pub fn repair_tier(tier: &str, path: &Path) -> Result<RepairOutcome> {
             };
 
             // 4. Atomic rewrite of the good set (temp → validate → rename).
-            store::write_back(&good, path, Change::Op("doctor.repair"))?;
+            locked.write_store(&good, Change::Op("doctor.repair"))?;
 
             // 5. Re-verify.
             let healthy_after = matches!(store::graph_health(path), GraphHealth::Healthy);

--- a/src/domain/sync.rs
+++ b/src/domain/sync.rs
@@ -58,13 +58,15 @@ fn sync_domain_list(
     domains: &[domain::DomainDef],
     carl_json_path: Option<&Path>,
 ) -> Result<SyncStats> {
-    let (store, trig_path) = crud::load_workspace_store(cwd)?;
+    // #87: lock, THEN load; the guard on `locked` holds to the end of the function.
+    let locked = crud::lock_and_load_workspace(cwd)?;
+    let store = locked.store();
     let ws_slug = crud::workspace_slug(cwd);
     let graph = crud::workspace_graph_iri(ns, &ws_slug);
     // Snapshot the one graph this writer targets, so the record can carry what
     // actually changed instead of only a label. Scoped to the target graph
     // because this runs often and diffing the whole store would not be free.
-    let before = crate::store::snapshot_graphs(&store, std::slice::from_ref(&graph));
+    let before = crate::store::snapshot_graphs(store, std::slice::from_ref(&graph));
 
     let pfx = crud::prefixes(ns);
     let p = &ns.prefix;
@@ -209,15 +211,15 @@ fn sync_domain_list(
 
     // Migrate rules + decisions from carl.json if provided
     let (carl_rules, total_decisions) = if let Some(carl_path) = carl_json_path {
-        sync_carl_decisions(&store, ns, &graph, &pfx, carl_path)?
+        sync_carl_decisions(store, ns, &graph, &pfx, carl_path)?
     } else {
         (0, 0)
     };
     total_rules += carl_rules;
 
-    let delta = crate::store::delta_since(&store, std::slice::from_ref(&graph), before);
+    let delta = crate::store::delta_since(store, std::slice::from_ref(&graph), before);
     let ops = delta.to_ops();
-    crate::store::write_back(&store, &trig_path, Change::OpWithDelta("domain.sync", &ops))?;
+    locked.write(Change::OpWithDelta("domain.sync", &ops))?;
 
     Ok(SyncStats {
         domains: domains.len(),

--- a/src/extension/ingest.rs
+++ b/src/extension/ingest.rs
@@ -62,20 +62,23 @@ pub fn ingest_extension(
         return Ok(IngestStats::default());
     }
 
-    // Load workspace graph
-    let (graph_store, trig_path) = crud::load_workspace_store(cwd)
-        .context("Failed to load workspace store for ingest")?;
+    // #87: lock the workspace graph, THEN load it; the guard on `locked` holds to
+    // the end of the function so the load and the conditional write are one
+    // critical section.
+    let locked = crud::lock_and_load_workspace(cwd)
+        .context("Failed to lock and load workspace store for ingest")?;
+    let graph_store = locked.store();
     let ns = &config.namespace;
     let ws_slug = crud::workspace_slug(cwd);
     let graph_iri = crud::workspace_graph_iri(ns, &ws_slug);
 
     // Snapshot the target graph so the record carries the delta, not just a label.
-    let before = store::snapshot_graphs(&graph_store, std::slice::from_ref(&graph_iri));
+    let before = store::snapshot_graphs(graph_store, std::slice::from_ref(&graph_iri));
     let pfx = crud::prefixes(ns);
     let p = &ns.prefix;
 
     let ctx = IngestCtx {
-        store: &graph_store,
+        store: graph_store,
         ns,
         graph_iri: &graph_iri,
         pfx: &pfx,
@@ -125,9 +128,10 @@ pub fn ingest_extension(
     // Write back if we changed anything
     if graph_dirty {
         let op = format!("extension.ingest:{}", ext.name);
-        let delta = store::delta_since(&graph_store, std::slice::from_ref(&graph_iri), before);
+        let delta = store::delta_since(graph_store, std::slice::from_ref(&graph_iri), before);
         let ops = delta.to_ops();
-        store::write_back(&graph_store, &trig_path, Change::OpWithDelta(&op, &ops))
+        locked
+            .write(Change::OpWithDelta(&op, &ops))
             .with_context(|| format!("Failed to write back graph after ext:{} ingest", ext.name))?;
     }
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -23,13 +23,19 @@ pub struct SyncReport {
 /// Run sync: scan workspace files, extract metadata to graph.
 pub fn sync(cwd: &Path, config: &BaseConfig, incremental: bool) -> Result<SyncReport> {
     let ns = &config.namespace;
-    let (store, trig_path) = crud::load_workspace_store(cwd)?;
+    // #87: lock, THEN load. The guard lives on `locked`, so the critical section
+    // runs to the end of this function — and this is the WIDEST load-to-write
+    // window in the tree, which is why both forks lost on 2026-09-07 went through
+    // it: `fork create` succeeded, then `base sync` overwrote the file from a
+    // snapshot taken before it.
+    let locked = crud::lock_and_load_workspace(cwd)?;
+    let store = locked.store();
     let ws_slug = crud::workspace_slug(cwd);
     let graph_iri = crud::workspace_graph_iri(ns, &ws_slug);
     // Snapshot the one graph this writer targets, so the record can carry what
     // actually changed instead of only a label. Scoped to the target graph
     // because this runs often and diffing the whole store would not be free.
-    let before = crate::store::snapshot_graphs(&store, std::slice::from_ref(&graph_iri));
+    let before = crate::store::snapshot_graphs(store, std::slice::from_ref(&graph_iri));
 
     let prefixes = crud::prefixes(ns);
 
@@ -60,7 +66,7 @@ pub fn sync(cwd: &Path, config: &BaseConfig, incremental: bool) -> Result<SyncRe
 
         // Incremental: check mtime vs lastExtracted
         if incremental
-            && let Some(true) = is_up_to_date(&store, &file_iri, file_path, ns)
+            && let Some(true) = is_up_to_date(store, &file_iri, file_path, ns)
         {
             report.skipped += 1;
             continue;
@@ -178,14 +184,14 @@ pub fn sync(cwd: &Path, config: &BaseConfig, incremental: bool) -> Result<SyncRe
     }
 
     // Extract ledger.toml (append-only session ledger for cost attribution)
-    let ledger_count = ledger::extract_ledger(cwd, &store, ns, &graph_iri);
+    let ledger_count = ledger::extract_ledger(cwd, store, ns, &graph_iri);
     if ledger_count > 0 {
         report.extracted += ledger_count;
     }
 
-    let delta = crate::store::delta_since(&store, std::slice::from_ref(&graph_iri), before);
+    let delta = crate::store::delta_since(store, std::slice::from_ref(&graph_iri), before);
     let ops = delta.to_ops();
-    crate::store::write_back(&store, &trig_path, Change::OpWithDelta("extract.markdown", &ops))?;
+    locked.write(Change::OpWithDelta("extract.markdown", &ops))?;
     Ok(report)
 }
 

--- a/src/extract/paul_toml.rs
+++ b/src/extract/paul_toml.rs
@@ -194,13 +194,15 @@ pub fn ingest_paul_projects(
     projects: &[(PathBuf, PaulToml)],
 ) -> Result<IngestStats> {
     let ns = &config.namespace;
-    let (store, trig_path) = crud::load_workspace_store(cwd)?;
+    // #87: lock, THEN load; the guard on `locked` holds to the end of the function.
+    let locked = crud::lock_and_load_workspace(cwd)?;
+    let store = locked.store();
 
     // Whole-store snapshot, not a per-graph one: this writer picks a target graph
     // per project as it goes (a project can be scoped to another workspace), so
     // the set is not known until the loop has run. It is affordable here because
     // this runs when a paul.toml changes, not on every tool call.
-    let before = crate::store::snapshot_graphs(&store, &[]);
+    let before = crate::store::snapshot_graphs(store, &[]);
     // Per-project home routing: a project's named graph comes from where it physically
     // lives (scope::home of its discovered dir), NOT the CWD slug — so the tag is correct
     // and CWD-independent (re-running session-start never re-pollutes). Unscoped → CWD slug.
@@ -256,7 +258,7 @@ pub fn ingest_paul_projects(
         // F25: what the store already holds for this project, `updatedAt` excluded.
         // Compared against the same set after the re-ingest, it decides whether this
         // project really changed — and so whether the store is touched at all.
-        let managed_before = managed_quads(&store, ns, &iri, &graph);
+        let managed_before = managed_quads(store, ns, &iri, &graph);
 
         let _ = store.update(&delete);
 
@@ -331,7 +333,7 @@ pub fn ingest_paul_projects(
         // store untouched, which is what keeps `migrate_tiers`' delta gate closed: the
         // old unconditional refresh moved the store's identity every session, re-opened
         // that gate, and bought a full re-plan that was then discarded (F25).
-        let managed_after = managed_quads(&store, ns, &iri, &graph);
+        let managed_after = managed_quads(store, ns, &iri, &graph);
         if managed_after != managed_before {
             let touch = format!(
                 "{pfx}\n\
@@ -346,7 +348,7 @@ pub fn ingest_paul_projects(
         }
     }
 
-    let delta = crate::store::delta_since(&store, &[], before);
+    let delta = crate::store::delta_since(store, &[], before);
 
     // F25: nothing moved, so do not rewrite the whole store to change nothing. The
     // rewrite was unconditional, it moved the store's identity, and
@@ -360,7 +362,7 @@ pub fn ingest_paul_projects(
     }
 
     let ops = delta.to_ops();
-    crate::store::write_back(&store, &trig_path, Change::OpWithDelta("extract.paul_toml", &ops))?;
+    locked.write(Change::OpWithDelta("extract.paul_toml", &ops))?;
 
     Ok(IngestStats {
         scanned: projects.len(),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -38,11 +38,22 @@ pub fn compact_tier(path: &Path) -> Result<CompactOutcome> {
         );
     }
 
+    // #87. This site has a ONE LINE load-to-write window and it fires UNATTENDED
+    // on a timer through `auto_compact_tiers`, which makes it the most dangerous
+    // entry on the issue's list and the one a window-width reading triages last.
+    //
+    // The outer guard takes the lock BEFORE the snapshot, so the backup and the
+    // store that gets written describe the same file, and the original ordering
+    // (count, snapshot, load) is preserved rather than rearranged.
+    // `lock_and_load_graph` below RE-ENTERS this same lock through `HELD_LOCKS`,
+    // so there is one critical section and exactly one load.
+    let _outer = store::lock_graph_bulk(path)?;
+
     let lines_before = count_lines(path);
     let backup = store::snapshot(path, "compact").context("failed to snapshot before compact")?;
 
-    let graph = store::load_graph(path)?;
-    store::write_back(&graph, path, Change::Op("graph.compact"))?;
+    let locked = store::lock_and_load_graph(path)?;
+    locked.write(Change::Op("graph.compact"))?;
 
     let lines_after = count_lines(path);
     Ok(CompactOutcome {

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -323,9 +323,13 @@ pub fn migrate_tier(
         return Ok(out);
     }
 
-    let store = store::load_graph(path)?;
+    // #87: lock, THEN load. The snapshot at the write branch below is already
+    // inside this critical section, and the `graph_health` probe above is a READ,
+    // which deliberately never takes this lock.
+    let locked = store::lock_and_load_graph(path)?;
+    let store = locked.store();
 
-    let stamped = stamp_of(&store, ns, graph_iri).as_deref() == Some(SCHEMA_VERSION);
+    let stamped = stamp_of(store, ns, graph_iri).as_deref() == Some(SCHEMA_VERSION);
 
     // The fast path, and ONLY for the hook. Not a truth source — the work below is
     // recomputed from the store whenever it is not taken, so a restored
@@ -343,7 +347,7 @@ pub fn migrate_tier(
     // delta pass below re-plans it. The cheap skip already happened, above.
 
     let root = path.parent().and_then(Path::parent).unwrap_or(path).to_path_buf();
-    let facts = Facts::gather(&store, ns, root);
+    let facts = Facts::gather(store, ns, root);
     let plan = plan_backfill(&facts, ns);
 
     // Re-planned and there is genuinely nothing to do. Return without touching the
@@ -370,15 +374,16 @@ pub fn migrate_tier(
         if !is_delta {
             out.backup = Some(store::snapshot(path, "migrate")?.display().to_string());
         }
-        apply(&store, ns, graph_iri, &plan, &mut out)?;
+        apply(store, ns, graph_iri, &plan, &mut out)?;
     }
 
-    write_stamp(&store, ns, graph_iri)?;
+    write_stamp(store, ns, graph_iri)?;
     out.stamped = true;
     out.delta = is_delta;
 
     let label = if is_delta { "migrate.domain-1.delta" } else { "migrate.domain-1" };
-    store::write_back(&store, path, Change::Op(label))
+    locked
+        .write(Change::Op(label))
         .context("migration write-back failed — the store is unchanged")?;
     stamp_delta_marker(path);
 

--- a/src/standards/sync.rs
+++ b/src/standards/sync.rs
@@ -250,13 +250,15 @@ pub fn sync_standards_to_graph(
 ) -> Result<usize> {
     let ns = &config.namespace;
     let p = &ns.prefix;
-    let (store, trig_path) = crud::load_workspace_store(dir)?;
+    // #87: lock, THEN load; the guard on `locked` holds to the end of the function.
+    let locked = crud::lock_and_load_workspace(dir)?;
+    let store = locked.store();
     let ws_slug = crud::workspace_slug(dir);
     let graph = crud::workspace_graph_iri(ns, &ws_slug);
     // Snapshot the one graph this writer targets, so the record can carry what
     // actually changed instead of only a label. Scoped to the target graph
     // because this runs often and diffing the whole store would not be free.
-    let before = crate::store::snapshot_graphs(&store, std::slice::from_ref(&graph));
+    let before = crate::store::snapshot_graphs(store, std::slice::from_ref(&graph));
 
     let pfx = crud::prefixes(ns);
 
@@ -317,9 +319,9 @@ pub fn sync_standards_to_graph(
             .with_context(|| format!("Failed to insert standard '{}'", s.id))?;
     }
 
-    let delta = crate::store::delta_since(&store, std::slice::from_ref(&graph), before);
+    let delta = crate::store::delta_since(store, std::slice::from_ref(&graph), before);
     let ops = delta.to_ops();
-    crate::store::write_back(&store, &trig_path, Change::OpWithDelta("standards.sync", &ops))?;
+    locked.write(Change::OpWithDelta("standards.sync", &ops))?;
     Ok(standards.len())
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -639,6 +639,180 @@ pub fn query_union(store: &Store, sparql: &str) -> Result<QueryResults> {
         .with_context(|| format!("SPARQL query failed: {sparql}"))
 }
 
+/// The provenance marker for #87's write seam.
+///
+/// A deliberate named constant, referenced from a live path -- `base doctor
+/// --json` carries it as `seam` -- so a harness can prove which binary it is
+/// driving without trusting a filename or an mtime. Probe it in a binary by
+/// SUBSTRING, never with an anchored `^...$`: rustc glues string literals into
+/// `.rodata`, and an anchored match reads zero on a binary that carries it.
+pub const LOCK_SEAM_MARKER: &str = "base:lock-seam:0.14.3:write_back-private+identity-check";
+
+/// What a graph file looked like at a moment in time.
+///
+/// `Absent` is a real answer, not a failure: a tier that has never been written
+/// has no graph file. It is also load-bearing -- absent at load and present at
+/// write means another writer CREATED the graph, which is refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileIdentity {
+    Absent,
+    Present {
+        len: u64,
+        mtime: std::time::SystemTime,
+    },
+}
+
+impl FileIdentity {
+    /// Stat `path` now.
+    ///
+    /// Fails closed. A missing file is `Absent`, but an unreadable mtime on a
+    /// file that DOES exist is an error rather than a variant: an unknown
+    /// identity must never be able to compare equal to a recorded one, and a
+    /// third "unknown" variant would do exactly that under a derived `PartialEq`.
+    pub fn of(path: &Path) -> Result<Self> {
+        match fs::metadata(path) {
+            Ok(m) => {
+                let mtime = m.modified().with_context(|| {
+                    format!(
+                        "reading the modified time of {} — the identity backstop cannot be \
+                         armed without it, and proceeding would let an unknown identity \
+                         compare as unchanged",
+                        path.display()
+                    )
+                })?;
+                Ok(FileIdentity::Present {
+                    len: m.len(),
+                    mtime,
+                })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(FileIdentity::Absent),
+            Err(e) => Err(e).with_context(|| format!("stat {}", path.display())),
+        }
+    }
+
+    /// For the refusal message. Both identities are named there, because a
+    /// refusal that does not say what changed cannot be triaged.
+    pub fn describe(&self) -> String {
+        match self {
+            FileIdentity::Absent => "absent".to_string(),
+            FileIdentity::Present { len, mtime } => {
+                let stamp = mtime
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| format!("{}.{:09}", d.as_secs(), d.subsec_nanos()))
+                    .unwrap_or_else(|_| "pre-epoch".to_string());
+                format!("{len} bytes, mtime {stamp}")
+            }
+        }
+    }
+}
+
+/// A graph loaded INSIDE its lock, carrying the guard and the file identity
+/// observed at load. The intended single route to a graph write.
+///
+/// The guard field keeps the critical section open until this value drops, so
+/// the load and the write are inside one lock without restructuring a long
+/// function body into a closure. `load inside the lock` is the whole point --
+/// see [`with_graph_lock`]: a store loaded BEFORE the lock is precisely the
+/// stale snapshot that produces the lost update #87 is about.
+///
+/// `write` takes `&self` rather than `&mut self` on purpose. A caller does
+/// `let store = g.store();` near the top of a long function and writes at the
+/// bottom; with `&mut self` that outstanding immutable borrow makes the write a
+/// compile error, and the migration would have to restructure nine function
+/// bodies to satisfy the borrow checker rather than to fix a bug. The identity
+/// therefore lives in a `Cell`, which is also what oxigraph's own `Store` does
+/// with its interior mutability.
+pub struct LockedGraph {
+    path: PathBuf,
+    store: Store,
+    identity: std::cell::Cell<FileIdentity>,
+    _guard: GraphLockGuard,
+}
+
+impl LockedGraph {
+    /// The store, loaded inside the lock.
+    pub fn store(&self) -> &Store {
+        &self.store
+    }
+
+    /// The graph file this lock and store belong to.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The identity observed at load, or refreshed by the last successful write.
+    pub fn identity(&self) -> FileIdentity {
+        self.identity.get()
+    }
+
+    /// Write the store this value loaded.
+    pub fn write(&self, change: Change<'_>) -> Result<()> {
+        self.write_store(&self.store, change)
+    }
+
+    /// Write a store this value did NOT load.
+    ///
+    /// Exactly one caller needs this: `doctor::repair_tier` writes a `good`
+    /// store built from a lenient re-parse inside the function. Forcing that
+    /// through a closure over `self.store` would be a lie about what it does.
+    /// What must hold is the lock and the identity check, not the provenance of
+    /// the bytes.
+    ///
+    /// It is deliberately ONE caller with a name rather than a pattern: "two
+    /// callers write a store they did not load" is an escape hatch, "one caller
+    /// does, and it is the lenient repair path" is a special case that can be
+    /// defended now and removed later.
+    pub fn write_store(&self, store: &Store, change: Change<'_>) -> Result<()> {
+        write_back_inner(
+            store,
+            &self.path,
+            change,
+            |file| file,
+            None,
+            Some(self.identity.get()),
+        )?;
+        // Refresh from the file we just renamed into place, so a second write
+        // from the same LockedGraph is legal.
+        //
+        // This is a FORWARD guarantee, not a description of any current caller:
+        // measured on this tree, 0 of the 9 Tier C sites write twice within one
+        // LockedGraph. The three functions invoked once per tier by their caller
+        // (`migrate_tier`, `repair_tier`, `compact_tier`) each do their own load,
+        // so each gets its own LockedGraph and writes it once. The refresh is
+        // here so the first writer that DOES write twice is correct, and it is
+        // written down as forward-looking rather than presented as observed.
+        self.identity.set(FileIdentity::of(&self.path)?);
+        Ok(())
+    }
+}
+
+/// Take the graph lock on the bulk bound, THEN load, and hand back both plus the
+/// guard and the file identity.
+///
+/// The order is the whole point and it is why this exists as a primitive rather
+/// than as a convention. `crud::lock_and_load` already had this shape for the
+/// five CRUD callers; this is the same seam at the store level, where the nine
+/// Tier C writers can reach it.
+pub fn lock_and_load_graph(path: &Path) -> Result<LockedGraph> {
+    let guard = lock_graph_bulk(path)?;
+    let store = load_or_empty(path)?;
+    // Stat AFTER the load, per the approved design. Note the residual honestly:
+    // this records the identity of the file as it is NOW, not of the inode the
+    // load actually read, so an unlocked writer landing between the open and
+    // this stat would be recorded as our baseline and then overwritten. Holding
+    // the lock excludes every locked writer from that window; the ones left are
+    // the deprecated dashboard route and anything outside `src/`, which is
+    // exactly the population this backstop is aimed at. Statting the fd the load
+    // opened would close it and is a 0.14.4 refinement, not a change of shape.
+    let identity = FileIdentity::of(path)?;
+    Ok(LockedGraph {
+        path: path.to_path_buf(),
+        store,
+        identity: std::cell::Cell::new(identity),
+        _guard: guard,
+    })
+}
+
 /// Serialize the store to NQuads and write atomically (temp + rename).
 /// Validates the output by re-parsing before committing the rename.
 ///
@@ -648,7 +822,10 @@ pub fn query_union(store: &Store, sparql: &str) -> Result<QueryResults> {
 /// that forgets to log is indistinguishable, to the reader, from no write at all;
 /// requiring it makes that a compile error instead of a silent gap.
 pub fn write_back(store: &Store, path: &Path, change: Change<'_>) -> Result<()> {
-    write_back_inner(store, path, change, |file| file, None)
+    // No identity expectation: this entry point is the unlocked whole-file route
+    // the deprecated dashboard uses, and it has no load to compare against.
+    // Writers that hold a [`LockedGraph`] go through its `write`, which does.
+    write_back_inner(store, path, change, |file| file, None, None)
 }
 
 /// `write_back` with its two failure paths exposed for tests: `wrap` sees the
@@ -665,8 +842,9 @@ pub fn write_back_seamed<W: Write>(
     change: Change<'_>,
     wrap: impl FnOnce(fs::File) -> W,
     validation_len: Option<usize>,
+    expect: Option<FileIdentity>,
 ) -> Result<()> {
-    write_back_inner(store, path, change, wrap, validation_len)
+    write_back_inner(store, path, change, wrap, validation_len, expect)
 }
 
 /// Bytes the dump is buffered in before each write syscall. oxrdfio's serializer
@@ -681,6 +859,7 @@ fn write_back_inner<W: Write>(
     change: Change<'_>,
     wrap: impl FnOnce(fs::File) -> W,
     validation_len: Option<usize>,
+    expect: Option<FileIdentity>,
 ) -> Result<()> {
     crate::home::assert_isolated_write(path);
     let parent = path
@@ -731,6 +910,44 @@ fn write_back_inner<W: Write>(
     if let Err(e) = dump_and_validate(store, &tmp_path, wrap(tmp_file), validation_len) {
         let _ = fs::remove_file(&tmp_path);
         return Err(e);
+    }
+
+    // Runtime identity backstop (#87 step 3), checked immediately before the
+    // rename so the window it cannot cover is one syscall pair wide.
+    //
+    // A lock only serialises writers that TAKE it. This catches the ones that do
+    // not: the deprecated dashboard route, a shell-out, a dependency, and the
+    // routes outside `src/` that the tripwire test cannot see at all. It is a
+    // complement to the lock, never a substitute -- it fires from inside this
+    // writer, before its own rename, and cannot see a clobber that lands after
+    // it. That one is read-back-after-write, filed to 0.14.4.
+    //
+    // Stat, not hash. Every legitimate write lands via temp+rename, which always
+    // produces a fresh len/mtime pair, and hashing costs seconds on a real graph
+    // (1 540 ms to dump 27 MB, shrike, 0.14.2). The stated limit -- a same-length
+    // rewrite inside one mtime tick -- was MEASURED with the real write shape:
+    // 2000 back-to-back temp+rename writes of an identical 4 096-byte payload
+    // with no sleep, giving 0 collisions in 1 999 consecutive pairs on both ext4
+    // (tightest gap 46 182 ns) and NTFS (tightest gap 975 400 ns, four orders of
+    // magnitude above its own 100 ns granularity). Two sequential base writes
+    // cannot land in one tick. If that ever changes the fix is the unix inode or
+    // the Windows file index, not a hash.
+    if let Some(expected) = expect {
+        let now = FileIdentity::of(path)?;
+        if now != expected {
+            let _ = fs::remove_file(&tmp_path);
+            anyhow::bail!(
+                "refusing to write {}: it changed while this writer held the lock. \
+                 At load it was {}; it is now {}. NOTHING was written — the file on \
+                 disk is the other writer's and this command's changes are lost, \
+                 which is the honest outcome, because overwriting would have \
+                 destroyed theirs with no error on either side. Re-run the command. \
+                 ({LOCK_SEAM_MARKER})",
+                path.display(),
+                expected.describe(),
+                now.describe(),
+            );
+        }
     }
 
     // Atomic rename

--- a/src/store.rs
+++ b/src/store.rs
@@ -725,13 +725,32 @@ impl FileIdentity {
 pub struct LockedGraph {
     path: PathBuf,
     store: Store,
+    /// False only for a value from [`lock_for_rebuild`], whose file could not be
+    /// parsed. Read by [`LockedGraph::store`], which refuses to hand back a
+    /// store that is not the file.
+    store_is_the_file: bool,
     identity: std::cell::Cell<FileIdentity>,
     _guard: GraphLockGuard,
 }
 
 impl LockedGraph {
     /// The store, loaded inside the lock.
+    ///
+    /// # Panics
+    ///
+    /// If this value came from [`lock_for_rebuild`], where the file could not be
+    /// parsed and there is therefore no loaded store to hand back. A silently
+    /// EMPTY store returned to a caller that expected the file's contents is a
+    /// worse failure than a loud one: it would serialize as a valid, empty graph
+    /// and erase everything. That is a programming error, not a runtime
+    /// condition, so it is an assert rather than a `Result`.
     pub fn store(&self) -> &Store {
+        assert!(
+            self.store_is_the_file,
+            "store() on a LockedGraph from lock_for_rebuild: the file could not be \
+             parsed, so there is no loaded store. That caller brings its own store \
+             and writes it through write_store."
+        );
         &self.store
     }
 
@@ -747,7 +766,9 @@ impl LockedGraph {
 
     /// Write the store this value loaded.
     pub fn write(&self, change: Change<'_>) -> Result<()> {
-        self.write_store(&self.store, change)
+        // Through `store()`, not the field, so a `lock_for_rebuild` value cannot
+        // reach the write path with an empty store by this route either.
+        self.write_store(self.store(), change)
     }
 
     /// Write a store this value did NOT load.
@@ -808,6 +829,27 @@ pub fn lock_and_load_graph(path: &Path) -> Result<LockedGraph> {
     Ok(LockedGraph {
         path: path.to_path_buf(),
         store,
+        store_is_the_file: true,
+        identity: std::cell::Cell::new(identity),
+        _guard: guard,
+    })
+}
+
+/// Take the graph lock on the bulk bound and record the identity WITHOUT loading.
+///
+/// For the one writer whose file cannot be parsed. `doctor --repair` runs on an
+/// UNHEALTHY graph by definition, so [`lock_and_load_graph`] is unusable there:
+/// its load would fail on exactly the file the repair exists to fix. The
+/// returned value's [`LockedGraph::store`] is NOT the file's contents and
+/// panics if called; that caller brings its own store, built from a lenient
+/// re-parse, and writes it through [`LockedGraph::write_store`].
+pub fn lock_for_rebuild(path: &Path) -> Result<LockedGraph> {
+    let guard = lock_graph_bulk(path)?;
+    let identity = FileIdentity::of(path)?;
+    Ok(LockedGraph {
+        path: path.to_path_buf(),
+        store: Store::new().context("creating the placeholder store for a rebuild lock")?,
+        store_is_the_file: false,
         identity: std::cell::Cell::new(identity),
         _guard: guard,
     })
@@ -816,12 +858,20 @@ pub fn lock_and_load_graph(path: &Path) -> Result<LockedGraph> {
 /// Serialize the store to NQuads and write atomically (temp + rename).
 /// Validates the output by re-parsing before committing the rename.
 ///
+/// **PRIVATE since #87, and the privacy is the fix.** This is a whole-file
+/// overwrite that takes NO lock, so any caller holding a pre-lock snapshot
+/// erases whatever landed in between and reports success. Nine callers outside
+/// this module did exactly that. They now go through [`LockedGraph::write`],
+/// which cannot be constructed without the lock, so the compile error IS the
+/// acceptance leg: a tenth caller cannot be added from outside this file.
+/// [`write_back_seamed`] is the test-only entry and is feature-gated.
+///
 /// `change` describes what produced this write and is appended to the sibling
 /// `changes.jsonl` **after** the rename commits -- see [`crate::changelog`]. It is a
 /// required parameter rather than an optional call at each writer because a writer
 /// that forgets to log is indistinguishable, to the reader, from no write at all;
 /// requiring it makes that a compile error instead of a silent gap.
-pub fn write_back(store: &Store, path: &Path, change: Change<'_>) -> Result<()> {
+fn write_back(store: &Store, path: &Path, change: Change<'_>) -> Result<()> {
     // No identity expectation: this entry point is the unlocked whole-file route
     // the deprecated dashboard uses, and it has no load to compare against.
     // Writers that hold a [`LockedGraph`] go through its `write`, which does.
@@ -1397,6 +1447,40 @@ pub fn load_or_empty(path: &Path) -> Result<Store> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The claim `tests/write_back_test.rs` can no longer make: the two entry
+    /// points into the seam produce identical bytes.
+    ///
+    /// It lives here because `write_back` is private since #87, so only a test
+    /// inside this module can call both sides. Without it, "write_back_seamed
+    /// with no injection behaves exactly like write_back" is an assertion about
+    /// two functions that nothing compares.
+    #[test]
+    fn the_two_entry_points_write_identical_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let via_private = dir.path().join("private.nq");
+        let via_seam = dir.path().join("seam.nq");
+
+        let store = Store::new().unwrap();
+        store
+            .insert(&oxigraph::model::Quad::new(
+                oxigraph::model::NamedNode::new("http://test.local/s").unwrap(),
+                oxigraph::model::NamedNode::new("http://test.local/p").unwrap(),
+                oxigraph::model::Literal::new_simple_literal("v"),
+                oxigraph::model::GraphName::NamedNode(
+                    oxigraph::model::NamedNode::new("http://test.local/g").unwrap(),
+                ),
+            ))
+            .unwrap();
+
+        write_back(&store, &via_private, Change::Op("test.private")).unwrap();
+        write_back_seamed(&store, &via_seam, Change::Op("test.seam"), |f| f, None, None).unwrap();
+
+        let a = fs::read(&via_private).unwrap();
+        let b = fs::read(&via_seam).unwrap();
+        assert!(!a.is_empty(), "precondition: the private entry wrote something");
+        assert_eq!(a, b, "the two entry points must write identical bytes");
+    }
     use std::io::Write;
 
     fn write_file(dir: &Path, name: &str, contents: &str) -> std::path::PathBuf {

--- a/src/store.rs
+++ b/src/store.rs
@@ -38,6 +38,11 @@ pub fn graph_loads() -> usize {
 /// Auto-migrate a legacy graph.trig to graph.nq if present.
 /// Loads the TriG file, writes it as NQuads, and removes the old file.
 /// Returns Ok(true) if migration happened, Ok(false) if no legacy file found.
+///
+/// Takes the graph lock on the bulk bound, but only in the branch that writes:
+/// this is row TEN of #87 and its `write_back` at the end used to run unlocked.
+/// The `nq_path.exists()` test is repeated inside the lock, because a check made
+/// outside it and a whole-file write made inside it are still a lost update.
 pub fn migrate_trig_to_nq(nq_path: &Path) -> Result<bool> {
     let trig_path = nq_path.with_extension("trig");
     // If the caller passed a .trig path directly, trig_path == nq_path and the
@@ -50,6 +55,37 @@ pub fn migrate_trig_to_nq(nq_path: &Path) -> Result<bool> {
     }
 
     // If graph.nq already exists alongside graph.trig, just remove the old one
+    if nq_path.exists() {
+        let _ = fs::remove_file(&trig_path);
+        return Ok(false);
+    }
+
+    // Row TEN of #87's table. Everything from here on WRITES nq_path, so the lock
+    // is taken here and held to the end of the function by the guard binding.
+    //
+    // It is NOT taken above the three early returns: none of them writes a graph.
+    // The middle one removes the dead legacy .trig once graph.nq exists, which is
+    // not a graph write at all.
+    //
+    // It is deliberately NOT taken in `load_graph`, which calls this function.
+    // `load_graph` has 27 call sites and most are pure readers -- `graph_analyze`,
+    // `graph_query`, `graph_tools`, `protocol::reconcile`, and `graph_health`,
+    // which is `base doctor`. `with_graph_lock`'s own doc comment forbids exactly
+    // that: readers never take this lock, because hooks read on every tool call
+    // and must not queue behind a writer.
+    //
+    // Re-entrant per path via `HELD_LOCKS`, so a caller that already holds this
+    // graph's lock -- every migrated Tier C writer, and `crud::lock_and_load` --
+    // re-enters here instead of waiting out its own timeout on a file it holds.
+    let _guard = lock_graph_bulk(nq_path)?;
+
+    // The `!nq_path.exists()` test above ran OUTSIDE the lock. Between it and this
+    // line another process can have created and written the graph, and the write
+    // below is a whole-file overwrite built from the legacy .trig, so it would
+    // erase that graph and report success -- #87's own failure, one level down
+    // from the write it is fixing. A lock that only serialises the write still
+    // loses the update; the re-check inside it is what makes the test and the
+    // write one decision. Same branch as above: the .trig is dead weight now.
     if nq_path.exists() {
         let _ = fs::remove_file(&trig_path);
         return Ok(false);
@@ -854,6 +890,27 @@ fn rotate_backups(path: &Path, fname: &str, just_written: &Path) {
 /// and still an obvious error rather than a hang.
 const LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// How long a BULK writer waits for the graph lock before giving up.
+///
+/// The hot path keeps [`LOCK_WAIT`]: a timeout there is loud, immediate and
+/// loses nothing, and lengthening it would make the per-tool-call hooks queue
+/// behind a bulk writer -- the failure the "readers never lock" rule exists to
+/// prevent. Bulk and maintenance acquirers are none of them on a per-tool-call
+/// path, and the two forks lost to #87 were lost at session close, when
+/// `base sync` runs. A `base sync` that FAILS because a compact held the lock
+/// for twelve seconds is a worse outcome than one that waits.
+///
+/// The number is measurement, not taste: `ceil(4 x p100 hold time of
+/// compact_tier and repair_tier)`, floor 30 s, cap 120 s. Measured on a copy of
+/// the 37.1 MB workspace graph, N=10 per arm, every iteration from pristine,
+/// the repair arm made unhealthy so it takes the write branch: `compact_tier`
+/// p100 6 626 ms, `repair_tier` p100 2 336 ms, so `4 x p100 = 27 s` and the
+/// **floor governs**. Insensitive to the single outlier -- discard compact run 7
+/// and it is 13 s, still 30 s. Biased upward, because the harness sets
+/// `BASE_HOME`, which arms `assert_isolated_write`; production does not carry
+/// that cost. The 120 s cap is not reached.
+const LOCK_WAIT_BULK: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// A lock file older than this is reaped. Same reasoning and same number as the
 /// abandoned-temp sweep in [`write_back_inner`]: a real write finishes in well
 /// under a second, so a minute-old lock is a crashed writer, not a live one.
@@ -991,6 +1048,25 @@ pub fn with_graph_lock<T>(graph: &Path, f: impl FnOnce() -> Result<T>) -> Result
 /// why the lock exists and what it must span; this is the same lock, for callers
 /// whose load and write are too far apart to wrap in a closure.
 pub fn lock_graph(graph: &Path) -> Result<GraphLockGuard> {
+    lock_graph_waiting(graph, LOCK_WAIT)
+}
+
+/// [`lock_graph`] on the bulk wait bound, [`LOCK_WAIT_BULK`].
+///
+/// For the bulk and maintenance writers only -- the Tier C whole-graph writers,
+/// `graph compact`, `doctor --repair`, `graph move` and the legacy TriG
+/// migration. Never for a per-tool-call path: a hook that waits thirty seconds
+/// behind a compact is a hang from the user's side, and readers do not take this
+/// lock at all.
+pub fn lock_graph_bulk(graph: &Path) -> Result<GraphLockGuard> {
+    lock_graph_waiting(graph, LOCK_WAIT_BULK)
+}
+
+/// The one acquisition path. `wait` is how long to keep trying before the bail,
+/// and it is NAMED in the timeout message: a reader of that error has to be able
+/// to tell which bound produced it, or the two bounds are indistinguishable in
+/// the field.
+fn lock_graph_waiting(graph: &Path, wait: std::time::Duration) -> Result<GraphLockGuard> {
     let lock = lock_path(graph);
     if let Some(parent) = lock.parent() {
         fs::create_dir_all(parent)
@@ -1005,7 +1081,7 @@ pub fn lock_graph(graph: &Path) -> Result<GraphLockGuard> {
         });
     }
 
-    let deadline = std::time::Instant::now() + LOCK_WAIT;
+    let deadline = std::time::Instant::now() + wait;
     let mut backoff = std::time::Duration::from_millis(5);
     loop {
         match fs::OpenOptions::new()
@@ -1027,9 +1103,10 @@ pub fn lock_graph(graph: &Path) -> Result<GraphLockGuard> {
                 }
                 if std::time::Instant::now() >= deadline {
                     anyhow::bail!(
-                        "timed out after {}s waiting for the graph lock {} — another base process \
-                         is writing this graph. Nothing was written.",
-                        LOCK_WAIT.as_secs(),
+                        "timed out after {}s ({} bound) waiting for the graph lock {} — another \
+                         base process is writing this graph. Nothing was written.",
+                        wait.as_secs(),
+                        if wait == LOCK_WAIT_BULK { "bulk" } else { "hot-path" },
                         lock.display()
                     );
                 }

--- a/tests/changelog_test.rs
+++ b/tests/changelog_test.rs
@@ -193,7 +193,15 @@ fn deltaless_writes_are_logged_with_a_kind_not_dropped() {
     let graph_path = ws.join(".base").join("graph.nq");
 
     let store = oxigraph::store::Store::new().unwrap();
-    base::store::write_back(&store, &graph_path, Change::Op("graph.compact")).unwrap();
+    base::store::write_back_seamed(
+        &store,
+        &graph_path,
+        Change::Op("graph.compact"),
+        |f| f,
+        None,
+        None,
+    )
+    .unwrap();
 
     let recs = lines(&ws);
     assert_eq!(recs.len(), 1, "a silent write would be worse than an unlabelled one");

--- a/tests/doctor_schema_test.rs
+++ b/tests/doctor_schema_test.rs
@@ -78,6 +78,7 @@ fn an_unmigrated_tier_says_so_and_counts_its_orphans() {
         warnings: vec![],
         config_errors: vec![],
         trigger_faults: vec![],
+        seam: base::store::LOCK_SEAM_MARKER,
     };
     let human = base::doctor::format_human(&report);
     assert!(human.contains("schema: not migrated"), "{human}");
@@ -104,6 +105,7 @@ fn a_migrated_tier_reports_its_schema_version_and_no_orphans() {
         warnings: vec![],
         config_errors: vec![],
         trigger_faults: vec![],
+        seam: base::store::LOCK_SEAM_MARKER,
     };
     let human = base::doctor::format_human(&report);
     assert!(human.contains("schema: domain-1"), "{human}");

--- a/tests/lock_identity_test.rs
+++ b/tests/lock_identity_test.rs
@@ -1,0 +1,281 @@
+//! Acceptance for #87 step 3, the runtime identity backstop.
+//!
+//! Five legs, and each one exists because a different way of being wrong would
+//! otherwise pass. The first four are the ones the design binds; the fifth is
+//! the absent-at-load case, which section 2.4 states as refused and which no leg
+//! covered.
+//!
+//! * **Reach (law 26).** A guard is only proven by a test that REACHES it. The
+//!   assertion here is on the BYTES of the target file, never on a refusal
+//!   message printing and never on an exit code — an error proves the code
+//!   stopped somewhere, it does not prove where.
+//! * **Void-FAIL control (law 24).** The same interleaving with the identity NOT
+//!   recorded must be ACCEPTED. Without it, a refusal and a harness that cannot
+//!   write at all share a result. The control arm is reached through
+//!   `write_back_seamed`, which is `#[cfg(feature = "isolation-guard")]` and so
+//!   exists in test builds and in nothing else: a safety guard with a runtime
+//!   off switch is the next defect, and the seam for turning it off in a test
+//!   already existed.
+//! * **Masking twin i (law 25).** A fix needs a leg that separates "repaired"
+//!   from "silenced". A guard that refused EVERY write would pass the reach leg
+//!   identically, so a plain sequential load-then-write with no second writer
+//!   must still succeed.
+//! * **Masking twin ii.** Two writes from the SAME `LockedGraph` must both
+//!   succeed, which is what makes the post-write identity refresh load-bearing.
+//!   A guard that skipped the refresh would refuse the second write of a
+//!   perfectly legitimate writer.
+//!
+//! Leg ii is an acceptance for a case NO current caller reaches: measured on this
+//! tree, 0 of the 9 Tier C sites write twice within one `LockedGraph`. It stays
+//! in on those terms — it fixes the semantics for the first writer that does,
+//! and saying so here is the difference between a forward guarantee and a
+//! hypothetical presented as a measurement.
+//!
+//! Every path is inside the test's own tempdir. Two `lock_and_load_graph` calls
+//! on one path from one thread RE-ENTER rather than deadlock (`HELD_LOCKS` is
+//! thread-local and keyed per path), which is what makes the interleaving
+//! expressible in-process at all.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base::changelog::Change;
+use base::store;
+use oxigraph::model::{GraphName, Literal, NamedNode, Quad};
+
+/// `<root>/ws/.base/graph.nq`, with the directory made — the shape of a real tier.
+fn graph_path(root: &Path) -> PathBuf {
+    let base = root.join("ws").join(".base");
+    fs::create_dir_all(&base).unwrap();
+    base.join("graph.nq")
+}
+
+/// One distinct quad per tag, so "whose bytes landed" is decidable by substring.
+fn quad(tag: &str) -> Quad {
+    Quad::new(
+        NamedNode::new(format!("http://test.local/s/{tag}")).unwrap(),
+        NamedNode::new("http://test.local/p").unwrap(),
+        Literal::new_simple_literal(tag),
+        GraphName::NamedNode(NamedNode::new("http://test.local/g").unwrap()),
+    )
+}
+
+/// Write a starting graph the honest way, so every test begins from a real file
+/// with a real identity rather than from an absent one.
+fn seed(path: &Path) {
+    let s = oxigraph::store::Store::new().unwrap();
+    s.insert(&quad("seed")).unwrap();
+    // Through the seam entry rather than `write_back`, which goes PRIVATE when the
+    // nine Tier C sites migrate. `write_back_seamed` is the test-only entry and
+    // stays reachable, so these legs do not have to be rewritten by that commit.
+    store::write_back_seamed(&s, path, Change::Op("test.seed"), |f| f, None, None).unwrap();
+    assert!(path.exists(), "the seed write must leave a file to have an identity of");
+}
+
+fn body(path: &Path) -> String {
+    fs::read_to_string(path).unwrap()
+}
+
+// ─── leg 1: reach ────────────────────────────────────────────
+
+#[test]
+fn identity_guard_refuses_a_stale_snapshot_overwrite() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    seed(&path);
+
+    // Two writers, each having loaded the SAME file, which is the shape that
+    // loses updates: both hold a pre-write snapshot and both write the whole file.
+    let first = store::lock_and_load_graph(&path).unwrap();
+    let second = store::lock_and_load_graph(&path).unwrap();
+    assert_eq!(
+        first.identity(),
+        second.identity(),
+        "both writers must start from the same identity, or this is not the \
+         interleaving under test"
+    );
+
+    first.store().insert(&quad("first")).unwrap();
+    first.write(Change::Op("test.first")).unwrap();
+
+    // The bytes after the correctly-ordered write. This, and not an error
+    // message, is what the guard has to protect.
+    let after_first = fs::read(&path).unwrap();
+    assert!(
+        body(&path).contains("/s/first"),
+        "the first writer's change must be on disk before the second writer runs"
+    );
+
+    second.store().insert(&quad("second")).unwrap();
+    let refused = second.write(Change::Op("test.second"));
+
+    assert!(
+        refused.is_err(),
+        "the second writer overwrote a file that changed under its snapshot"
+    );
+
+    // THE acceptance: the file is byte-identical to what the first writer left.
+    assert_eq!(
+        fs::read(&path).unwrap(),
+        after_first,
+        "the refused write still changed the file — the guard fired late or not \
+         at all, and the first writer's change is gone"
+    );
+    assert!(
+        body(&path).contains("/s/first"),
+        "the first writer's change was erased by a write that reported failure"
+    );
+    assert!(
+        !body(&path).contains("/s/second"),
+        "the second writer's bytes reached the file despite the refusal"
+    );
+
+    // Diagnostic quality, deliberately NOT the acceptance: a refusal nobody can
+    // triage is a bad refusal, but a message is not evidence that the bytes
+    // survived — the assertions above are.
+    let msg = format!("{:#}", refused.unwrap_err());
+    assert!(
+        msg.contains("changed while this writer held the lock"),
+        "the refusal must say what happened, got: {msg}"
+    );
+    assert!(
+        msg.contains(store::LOCK_SEAM_MARKER),
+        "the refusal must name the seam so a harness can attribute it, got: {msg}"
+    );
+}
+
+// ─── leg 2: void-FAIL control ────────────────────────────────
+
+#[test]
+fn the_same_interleaving_with_no_identity_recorded_is_accepted() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    seed(&path);
+
+    let first = store::lock_and_load_graph(&path).unwrap();
+    let second = store::lock_and_load_graph(&path).unwrap();
+
+    first.store().insert(&quad("first")).unwrap();
+    first.write(Change::Op("test.first")).unwrap();
+
+    // Identical interleaving, identical stale snapshot, one variable changed:
+    // `expect` is None, so no identity is recorded and there is nothing to
+    // compare. This write MUST land. If it did not, leg 1's refusal would be
+    // indistinguishable from a harness that cannot write in this state at all.
+    second.store().insert(&quad("second")).unwrap();
+    store::write_back_seamed(
+        second.store(),
+        &path,
+        Change::Op("test.second-unchecked"),
+        |file| file,
+        None,
+        None,
+    )
+    .expect("with no identity recorded there is nothing to refuse, so this must land");
+
+    assert!(
+        body(&path).contains("/s/second"),
+        "the control arm did not write, so leg 1 proves nothing about the guard"
+    );
+    // And it demonstrates the damage the guard prevents, from the same fixture:
+    // the stale snapshot's whole-file write erased the first writer's change,
+    // and nothing failed on either side.
+    assert!(
+        !body(&path).contains("/s/first"),
+        "the unchecked write was expected to erase the first writer's change — if \
+         it did not, the fixture is not reproducing the lost update and leg 1 is \
+         guarding nothing"
+    );
+}
+
+// ─── leg 3: masking twin i ───────────────────────────────────
+
+#[test]
+fn a_lone_writer_with_no_second_writer_succeeds() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    seed(&path);
+
+    // The ordinary case. A guard that refused everything would pass leg 1
+    // identically and fail here, which is the whole point of having this leg.
+    let only = store::lock_and_load_graph(&path).unwrap();
+    only.store().insert(&quad("only")).unwrap();
+    only.write(Change::Op("test.only"))
+        .expect("a writer with no competitor must not be refused");
+
+    assert!(body(&path).contains("/s/only"), "the lone writer's change is on disk");
+    assert!(body(&path).contains("/s/seed"), "and it did not lose the seed");
+}
+
+// ─── leg 4: masking twin ii ──────────────────────────────────
+
+#[test]
+fn two_writes_from_one_locked_graph_both_succeed() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    seed(&path);
+
+    // A guard that recorded the identity at load and never refreshed it would
+    // accept the first write and refuse the second — refusing a writer that is
+    // its own most recent writer. No current caller does this; the semantics are
+    // fixed here for the first one that does.
+    let g = store::lock_and_load_graph(&path).unwrap();
+
+    g.store().insert(&quad("one")).unwrap();
+    g.write(Change::Op("test.one")).expect("first write");
+    let after_one = g.identity();
+
+    g.store().insert(&quad("two")).unwrap();
+    g.write(Change::Op("test.two"))
+        .expect("the second write from the same LockedGraph must be legal — the \
+                 post-write identity refresh is what makes it so");
+
+    assert_ne!(
+        after_one,
+        g.identity(),
+        "the identity did not move across the second write, so the refresh is not \
+         happening and this leg passed for the wrong reason"
+    );
+    let text = body(&path);
+    assert!(text.contains("/s/one"), "the first write survived the second");
+    assert!(text.contains("/s/two"), "the second write landed");
+    assert!(text.contains("/s/seed"), "and neither lost the seed");
+}
+
+// ─── the absent-at-load case, which is its own refusal ───────
+
+#[test]
+fn a_graph_created_after_an_absent_load_is_refused() {
+    let root = tempfile::tempdir().unwrap();
+    let path = graph_path(root.path());
+    // Deliberately NOT seeded: the writer loads a tier that has no graph file,
+    // which is a real state and not an error.
+    let writer = store::lock_and_load_graph(&path).unwrap();
+    assert_eq!(
+        writer.identity(),
+        store::FileIdentity::Absent,
+        "a tier with no graph file must record Absent, not a zero-length Present"
+    );
+
+    // Someone else creates it while we hold our absent snapshot.
+    let other = oxigraph::store::Store::new().unwrap();
+    other.insert(&quad("other")).unwrap();
+    store::write_back_seamed(&other, &path, Change::Op("test.other"), |f| f, None, None).unwrap();
+    let after_other = fs::read(&path).unwrap();
+
+    writer.store().insert(&quad("ours")).unwrap();
+    let refused = writer.write(Change::Op("test.ours"));
+
+    assert!(refused.is_err(), "absent at load and present at write must be refused");
+    assert_eq!(
+        fs::read(&path).unwrap(),
+        after_other,
+        "the refused write changed a graph it never loaded"
+    );
+    assert!(
+        !body(&path).contains("/s/ours"),
+        "our bytes reached a file we had no snapshot of"
+    );
+    let msg = format!("{:#}", refused.unwrap_err());
+    assert!(msg.contains("absent"), "the refusal must say it started from absent, got: {msg}");
+}

--- a/tests/lock_tripwire_test.rs
+++ b/tests/lock_tripwire_test.rs
@@ -71,9 +71,20 @@ const FS_PRIMITIVES: [&str; 7] = [
 ];
 
 /// Anything that puts the graph lock in scope for the enclosing function.
-const LOCK_TOKENS: [&str; 5] = [
+///
+/// `"lock_graph_bulk("` is a SEPARATE entry and it has to be. These are
+/// substring tests, and `"lock_graph_bulk("` does not contain `"lock_graph("` --
+/// the `_bulk` sits before the paren, exactly as `_inner` does in
+/// `write_back_inner`. #87 introduced `lock_graph_bulk` and the guard could not
+/// see it: the tree was correctly locked and the tripwire still reported
+/// `migrate_trig_to_nq` as an unlocked writer. A fix that introduces a spelling
+/// its own guard cannot read is the false-RED twin of the false-PASS this file
+/// exists to prevent, so [`every_lock_token_actually_clears_the_flag`] now fails
+/// the suite for any entry here that has no effect.
+const LOCK_TOKENS: [&str; 6] = [
     "with_graph_lock(",
     "lock_graph(",
+    "lock_graph_bulk(",
     "locked_update(",
     "lock_and_load(",
     "mutate_file_if_holds(",
@@ -91,9 +102,28 @@ const LOCK_TOKENS: [&str; 5] = [
 /// The rest are the resolvers a graph path arrives through. `lock_path(`
 /// deliberately is NOT here: the relay has a `lock_path` of its own over its
 /// spool, and including it flagged `relay::with_lock`, which touches no graph.
-const GRAPH_SIGNALS: [&str; 10] = [
+///
+/// `"nq_path"` and `"trig_path"` were added by #87, and the reason is a
+/// MEASUREMENT rather than a tidy-up. Rule 2 could not see site ten at all.
+/// `migrate_trig_to_nq` calls `fs::remove_file` twice over graph files and names
+/// its paths `nq_path` and `trig_path`; its only `.nq` spellings live in comment
+/// lines, which `code_only` strips before any signal is tested. So the function
+/// was invisible to Rule 2 and only Rule 1's `write_back(` ever saw it -- two
+/// rules meant as defence in depth, one of them blind to the highest-ranked site
+/// in the issue. Measured on this tree with the site unlocked and these two
+/// entries present: graph-signalled fs-primitive functions 9 to 10, flagged 1,
+/// and site ten is caught by BOTH rules. With the site locked they flag nothing
+/// new, so the cost at this head is zero and the gain is a second independent
+/// detector.
+///
+/// `"trig_path"` is not a legacy curiosity: it is the dominant spelling for a
+/// graph path in this tree -- 97 occurrences across 14 files, including
+/// `crud::lock_and_load`, where the variable named `trig_path` holds `graph.nq`.
+const GRAPH_SIGNALS: [&str; 12] = [
     ".nq",
     "\"nq.",
+    "nq_path",
+    "trig_path",
     "graph_path",
     "dest_path",
     "source_path",
@@ -619,6 +649,109 @@ fn the_widened_rule_sees_the_unlocked_fs_writers() {
         missed.join("\n  "),
         seen.len()
     );
+}
+
+/// Law 31, turned on [`LOCK_TOKENS`]: every entry must actually clear the flag.
+///
+/// This leg exists because #87 added `lock_graph_bulk` and the guard kept
+/// reporting a correctly-locked function as an offender: `"lock_graph_bulk("`
+/// does not contain `"lock_graph("`, so the new spelling read as no lock at all.
+/// A token that has no effect is indistinguishable from a token that is absent,
+/// and the failure direction is a false RED -- loud, but it also trains a reader
+/// to add files back to an allow-list, which re-blinds the files under repair.
+///
+/// The list comes from the constant, so a spelling added without effect fails
+/// here rather than being discovered by the next builder.
+#[test]
+fn every_lock_token_actually_clears_the_flag() {
+    let no_files: BTreeSet<&str> = BTreeSet::new();
+    let no_fns: BTreeSet<(&str, &str)> = BTreeSet::new();
+
+    let scan = |src: &str| -> Vec<Finding> {
+        let mut c = Counts::default();
+        scan_file("src/probe.rs", src, &no_files, &no_fns, &no_fns, &mut c)
+    };
+
+    // Control first: with NO lock token, this exact body must be flagged by both
+    // rules. Without this arm a rule that flagged nothing would pass every
+    // assertion below.
+    let unlocked = "fn writes_a_graph(nq_path: &Path) -> Result<()> {\n    \
+                    let tmp = nq_path.with_extension(\"nq.tmp\");\n    \
+                    std::fs::rename(&tmp, nq_path)?;\n    \
+                    write_back(&store, nq_path, change)?;\n    Ok(())\n}\n";
+    let control = scan(unlocked);
+    assert!(
+        control.iter().any(|f| f.rule == Rule::FsPrimitive),
+        "the control body is not flagged by rule 2, so this leg proves NOTHING \
+         about any token:\n{unlocked}"
+    );
+    assert!(
+        control.iter().any(|f| f.rule == Rule::WriteCall),
+        "the control body is not flagged by rule 1, so this leg proves NOTHING \
+         about any token:\n{unlocked}"
+    );
+
+    for tok in LOCK_TOKENS {
+        // Every token is a call spelling ending in '(' except none today; build a
+        // realistic use either way.
+        let call = format!("let _g = store::{tok}nq_path)?;");
+        let src = format!(
+            "fn writes_a_graph(nq_path: &Path) -> Result<()> {{\n    {call}\n    \
+             let tmp = nq_path.with_extension(\"nq.tmp\");\n    \
+             std::fs::rename(&tmp, nq_path)?;\n    \
+             write_back(&store, nq_path, change)?;\n    Ok(())\n}}\n"
+        );
+        let found = scan(&src);
+        assert!(
+            found.is_empty(),
+            "LOCK_TOKENS entry {tok:?} does not clear the flag — it is in the list \
+             and has no effect, which is the shape that made #87's own fix read as \
+             unlocked. Findings:\n  {}\nBody:\n{src}",
+            report(&found)
+        );
+    }
+}
+
+/// Law 31, turned on [`GRAPH_SIGNALS`]: every entry must actually reach rule 2.
+///
+/// The mirror of the token leg. A signal in the list that matches nothing is a
+/// silent hole, and site ten was exactly that: two `fs::remove_file` calls over
+/// graph files in a function whose only `.nq` spellings were in comments.
+#[test]
+fn every_graph_signal_reaches_rule_two() {
+    let no_files: BTreeSet<&str> = BTreeSet::new();
+    let no_fns: BTreeSet<(&str, &str)> = BTreeSet::new();
+
+    let scan = |src: &str| -> Vec<Finding> {
+        let mut c = Counts::default();
+        scan_file("src/probe.rs", src, &no_files, &no_fns, &no_fns, &mut c)
+    };
+
+    // Control: the same primitive with NO signal must NOT be flagged, or the
+    // positive arms below are satisfied by a rule that flags everything.
+    let no_signal = "fn writes_a_log(p: &Path) -> Result<()> {\n    \
+                     std::fs::rename(&tmp, p)?;\n    Ok(())\n}\n";
+    assert!(
+        scan(no_signal).is_empty(),
+        "a primitive with no graph signal is flagged — rule 2 is flagging \
+         everything, which is indistinguishable from working"
+    );
+
+    for sig in GRAPH_SIGNALS {
+        // Put the signal in a position that is code, not a comment: code_only
+        // strips comment lines, which is how site ten stayed invisible.
+        let src = format!(
+            "fn writes_a_graph(p: &Path) -> Result<()> {{\n    \
+             let target = resolve(\"{sig}\", p);\n    \
+             std::fs::rename(&tmp, &target)?;\n    Ok(())\n}}\n"
+        );
+        let found = scan(&src);
+        assert!(
+            found.iter().any(|f| f.rule == Rule::FsPrimitive),
+            "GRAPH_SIGNALS entry {sig:?} does not reach rule 2 — it is in the list \
+             and matches nothing. Body:\n{src}"
+        );
+    }
 }
 
 /// Law 31: prove the rule REACHES every shape of the thing it claims to guard,

--- a/tests/lock_tripwire_test.rs
+++ b/tests/lock_tripwire_test.rs
@@ -81,12 +81,14 @@ const FS_PRIMITIVES: [&str; 7] = [
 /// its own guard cannot read is the false-RED twin of the false-PASS this file
 /// exists to prevent, so [`every_lock_token_actually_clears_the_flag`] now fails
 /// the suite for any entry here that has no effect.
-const LOCK_TOKENS: [&str; 6] = [
+const LOCK_TOKENS: [&str; 8] = [
     "with_graph_lock(",
     "lock_graph(",
     "lock_graph_bulk(",
+    "lock_for_rebuild(",
     "locked_update(",
     "lock_and_load(",
+    "lock_and_load_workspace(",
     "mutate_file_if_holds(",
 ];
 
@@ -143,22 +145,18 @@ const GRAPH_SIGNALS: [&str; 12] = [
 /// exempted `migrate_trig_to_nq`, whose unlocked `write_back` at `store.rs:74`
 /// is site TEN of #87's own table, and would have exempted the next one added
 /// beside it. The three real seam writers are named in [`ALLOW_WRITE_FNS`].
-const ALLOW_FILES: [(&str, &str); 11] = [
+/// The nine `(#87)` entries that used to sit here are GONE, and their absence is
+/// the acceptance leg for the migration. Each named a Tier C writer that reached
+/// the seam's whole-file write from a pre-lock snapshot; all nine now go through
+/// `LockedGraph`, and `write_back` is private, so no caller outside `store.rs`
+/// can reach it whatever this list says.
+const ALLOW_FILES: [(&str, &str); 2] = [
     (
         "src/dashboard/api.rs",
         "the dashboard holds a long-lived in-memory Store (server.rs:62,68) that these mutate \
          and write back, so reload-under-lock would diverge that cache from the file. It is \
          being deprecated and is not getting the lock (Chris, 2026-09-07)",
     ),
-    ("src/extract/mod.rs", "one-shot bulk rebuild (#87)"),
-    ("src/extract/paul_toml.rs", "one-shot bulk rebuild (#87)"),
-    ("src/extension/ingest.rs", "one-shot bulk ingest (#87)"),
-    ("src/standards/sync.rs", "one-shot bulk sync (#87)"),
-    ("src/domain/sync.rs", "one-shot bulk sync (#87)"),
-    ("src/apply_ops.rs", "remote op application, bulk (#87)"),
-    ("src/doctor.rs", "doctor.repair, whole-file rebuild (#87)"),
-    ("src/graph.rs", "graph.compact, whole-file rebuild (#87)"),
-    ("src/migrate.rs", "migration, one-shot (#87)"),
     ("src/hook/session_start.rs", "no graph write; listed if a call appears"),
 ];
 
@@ -202,7 +200,7 @@ const ALLOW_WRITE_FNS: [(&str, &str, &str); 3] = [
 /// naming a graph path. **Every reason names the file the function actually
 /// writes** — an exemption that cannot say what it writes is not an exemption,
 /// it is a hole.
-const ALLOW_FNS: [(&str, &str, &str); 9] = [
+const ALLOW_FNS: [(&str, &str, &str); 8] = [
     (
         "src/store.rs",
         "write_back_inner",
@@ -225,12 +223,6 @@ const ALLOW_FNS: [(&str, &str, &str); 9] = [
         "restore_tier",
         "#87: fs::copy + fs::rename straight over the graph. Takes the lock with the migration; \
          this entry is removed then",
-    ),
-    (
-        "src/doctor.rs",
-        "repair_tier",
-        "writes the .quarantine-<stamp> sidecar, NOT the graph. Its graph write is write_back \
-         at :793 and is Rule 1's (#87)",
     ),
     (
         "src/graph.rs",

--- a/tests/lock_tripwire_test.rs
+++ b/tests/lock_tripwire_test.rs
@@ -31,14 +31,20 @@
 //! So:
 //!
 //! * **Rule 1 — write calls.** A function reaching the store seam's write must
-//!   hold the lock, unless its FILE is on [`ALLOW_FILES`]. File scope is right
-//!   here: `src/dashboard/api.rs` is one deliberate entry covering 17 sites.
+//!   hold the lock, unless its FILE is on [`ALLOW_FILES`] or, for the seam
+//!   file itself, the (FILE, FUNCTION) pair is on [`ALLOW_WRITE_FNS`]. File
+//!   scope is right for `src/dashboard/api.rs`, one deliberate entry covering
+//!   17 sites. It was WRONG for `src/store.rs`, whose reason -- "the seam
+//!   itself: it defines the lock and the write" -- is true of `write_back` and
+//!   false of `migrate_trig_to_nq` sitting beside it. That entry silently
+//!   absorbed site TEN of #87 and would have absorbed the next one too.
 //! * **Rule 2 — filesystem primitives.** A function that puts bytes over a path
 //!   it names as a graph must hold the lock, unless the (FILE, FUNCTION) pair is
 //!   on [`ALLOW_FNS`]. Measured on `610636e`: 157 primitive sites in non-test
 //!   functions, 9 of them in a function that names a graph and takes no lock.
 //!
-//! **Rule 2's exemptions are function-scoped and that is load-bearing.** A
+//! **Exemptions are function-scoped wherever the file is not homogeneous, and
+//! that is load-bearing.** A
 //! file-scoped exemption is precisely what would have let `restore_tier` ship
 //! unlocked inside `doctor.rs` while the tripwire certified that same file green.
 //! Repeating file scope in the wider rule would rebuild the hole one level up.
@@ -100,8 +106,14 @@ const GRAPH_SIGNALS: [&str; 10] = [
 
 /// Rule 1: files allowed to reach the seam's write without holding the lock.
 /// Every entry is a deliberate exemption, not an oversight.
-const ALLOW_FILES: [(&str, &str); 12] = [
-    ("src/store.rs", "the seam itself: it defines the lock and the write"),
+///
+/// `src/store.rs` is NOT here any more. It sat at index 0 with the reason "the
+/// seam itself: it defines the lock and the write", which is true of
+/// `write_back` and false of every other function in that file -- so the entry
+/// exempted `migrate_trig_to_nq`, whose unlocked `write_back` at `store.rs:74`
+/// is site TEN of #87's own table, and would have exempted the next one added
+/// beside it. The three real seam writers are named in [`ALLOW_WRITE_FNS`].
+const ALLOW_FILES: [(&str, &str); 11] = [
     (
         "src/dashboard/api.rs",
         "the dashboard holds a long-lived in-memory Store (server.rs:62,68) that these mutate \
@@ -118,6 +130,42 @@ const ALLOW_FILES: [(&str, &str); 12] = [
     ("src/graph.rs", "graph.compact, whole-file rebuild (#87)"),
     ("src/migrate.rs", "migration, one-shot (#87)"),
     ("src/hook/session_start.rs", "no graph write; listed if a call appears"),
+];
+
+/// Rule 1: (file, function) pairs allowed to reach the seam's write without
+/// holding the lock, for files where a whole-FILE exemption would be a lie.
+///
+/// These three are flagged by their own SIGNATURE lines, not by their bodies:
+/// `functions()` appends the `fn` line to the body it opens, so `fn write_back(`
+/// is a `WRITE_CALLS` hit on `write_back(` from the definition alone. That is a
+/// property of the parser, deliberately preserved, and it is why the seam's own
+/// definitions need naming here at all.
+///
+/// `write_back_inner` is absent on purpose and its absence is MEASURED, not
+/// assumed: `write_back_inner(` does not contain the substring `write_back(`
+/// (the `_inner` sits before the paren), so Rule 1 never sees it. It is on
+/// [`ALLOW_FNS`] for Rule 2 instead, where its temp+rename does get seen.
+const ALLOW_WRITE_FNS: [(&str, &str, &str); 3] = [
+    (
+        "src/store.rs",
+        "write_back",
+        "the seam's write itself: flagged by its own signature line. Every locked \
+         write in the tree ends here",
+    ),
+    (
+        "src/store.rs",
+        "update_and_write",
+        "the dashboard's unlocked whole-file route, flagged by its own signature. \
+         The dashboard holds a long-lived in-memory Store it mutates and writes \
+         back, so reload-under-lock would diverge that cache from the file; it is \
+         being deprecated and is not getting the lock (Chris, 2026-09-07)",
+    ),
+    (
+        "src/store.rs",
+        "mutate_and_write",
+        "same dashboard route as `update_and_write`, and it calls `write_back` in \
+         its body as well as matching its own signature",
+    ),
 ];
 
 /// Rule 2: (file, function) pairs allowed to call a filesystem primitive while
@@ -349,6 +397,7 @@ fn scan_file(
     rel: &str,
     src: &str,
     allow_files: &BTreeSet<&str>,
+    allow_write_fns: &BTreeSet<(&str, &str)>,
     allow_fns: &BTreeSet<(&str, &str)>,
     counts: &mut Counts,
 ) -> Vec<Finding> {
@@ -363,12 +412,13 @@ fn scan_file(
         let locked = first_match(&code, &LOCK_TOKENS).is_some();
         let site = format!("{rel}::{}", f.name);
 
-        // Rule 1 — the seam's write calls, exempted by FILE.
+        // Rule 1 — the seam's write calls, exempted by FILE, or by
+        // (FILE, FUNCTION) where a whole-file exemption would be a lie.
         if let Some(tok) = first_match(&code, &WRITE_CALLS)
             && !allow_files.contains(rel)
         {
             counts.write_call_functions_checked += 1;
-            if !locked {
+            if !locked && !allow_write_fns.contains(&(rel, f.name.as_str())) {
                 found.push(Finding {
                     site: site.clone(),
                     rule: Rule::WriteCall,
@@ -404,6 +454,7 @@ fn scan_file(
 
 fn scan_tree(
     allow_files: &BTreeSet<&str>,
+    allow_write_fns: &BTreeSet<(&str, &str)>,
     allow_fns: &BTreeSet<(&str, &str)>,
 ) -> (Vec<Finding>, Counts) {
     let root = repo_root();
@@ -421,7 +472,14 @@ fn scan_tree(
             .replace('\\', "/");
         let src = std::fs::read_to_string(path).unwrap_or_default();
         counts.files_scanned += 1;
-        found.extend(scan_file(&rel, &src, allow_files, allow_fns, &mut counts));
+        found.extend(scan_file(
+            &rel,
+            &src,
+            allow_files,
+            allow_write_fns,
+            allow_fns,
+            &mut counts,
+        ));
     }
     (found, counts)
 }
@@ -432,6 +490,10 @@ fn allow_file_set() -> BTreeSet<&'static str> {
 
 fn allow_fn_set() -> BTreeSet<(&'static str, &'static str)> {
     ALLOW_FNS.iter().map(|(f, n, _)| (*f, *n)).collect()
+}
+
+fn allow_write_fn_set() -> BTreeSet<(&'static str, &'static str)> {
+    ALLOW_WRITE_FNS.iter().map(|(f, n, _)| (*f, *n)).collect()
 }
 
 fn report(found: &[Finding]) -> String {
@@ -447,11 +509,19 @@ fn report(found: &[Finding]) -> String {
 #[test]
 fn every_graph_writer_outside_the_allow_list_takes_the_lock() {
     let allow_files = allow_file_set();
+    let allow_write_fns = allow_write_fn_set();
     let allow_fns = allow_fn_set();
 
     println!("rule 1 allow-list — {} FILES, each an explicit exemption:", ALLOW_FILES.len());
     for (f, why) in ALLOW_FILES {
         println!("  {f}\n      {why}");
+    }
+    println!(
+        "rule 1 allow-list — {} (FILE, FUNCTION) pairs, for files a whole-file exemption would lie about:",
+        ALLOW_WRITE_FNS.len()
+    );
+    for (f, n, why) in ALLOW_WRITE_FNS {
+        println!("  {f}::{n}\n      {why}");
     }
     println!(
         "rule 2 allow-list — {} (FILE, FUNCTION) pairs, each naming what it actually writes:",
@@ -461,7 +531,7 @@ fn every_graph_writer_outside_the_allow_list_takes_the_lock() {
         println!("  {f}::{n}\n      {why}");
     }
 
-    let (found, counts) = scan_tree(&allow_files, &allow_fns);
+    let (found, counts) = scan_tree(&allow_files, &allow_write_fns, &allow_fns);
 
     println!("tripwire: {} files scanned under src/", counts.files_scanned);
     println!("tripwire: {} non-test functions visited", counts.functions_visited);
@@ -503,8 +573,8 @@ fn every_graph_writer_outside_the_allow_list_takes_the_lock() {
         found.is_empty(),
         "these write a graph without taking the lock, and are not on an allow-list:\n  {}\n\
          Either take the lock (store::with_graph_lock / lock_graph / crud::lock_and_load) or add \
-         the entry to ALLOW_FILES (rule 1) or ALLOW_FNS (rule 2) in this test, with a reason that \
-         names what it writes.",
+         the entry to ALLOW_FILES or ALLOW_WRITE_FNS (rule 1) or ALLOW_FNS (rule 2) in this test, \
+         with a reason that names what it writes.",
         report(&found)
     );
 }
@@ -520,7 +590,7 @@ fn every_graph_writer_outside_the_allow_list_takes_the_lock() {
 fn the_widened_rule_sees_the_unlocked_fs_writers() {
     let no_files: BTreeSet<&str> = BTreeSet::new();
     let no_fns: BTreeSet<(&str, &str)> = BTreeSet::new();
-    let (found, counts) = scan_tree(&no_files, &no_fns);
+    let (found, counts) = scan_tree(&no_files, &no_fns, &no_fns);
 
     assert!(
         counts.functions_visited > 0,
@@ -572,7 +642,7 @@ fn every_fs_primitive_shape_reaches_the_rule() {
 
     let scan = |src: &str| -> Vec<Finding> {
         let mut c = Counts::default();
-        scan_file("src/probe.rs", src, &no_files, &no_fns, &mut c)
+        scan_file("src/probe.rs", src, &no_files, &no_fns, &no_fns, &mut c)
     };
 
     // Positive: every primitive, in a function that names a graph path.

--- a/tests/ontology_test.rs
+++ b/tests/ontology_test.rs
@@ -137,7 +137,15 @@ fn test_round_trip() {
     // Write to temp file
     let tmp_dir = tempfile::tempdir().unwrap();
     let tmp_path = tmp_dir.path().join("roundtrip.nq");
-    base::store::write_back(&store, &tmp_path, base::changelog::Change::Op("test")).unwrap();
+    base::store::write_back_seamed(
+        &store,
+        &tmp_path,
+        base::changelog::Change::Op("test"),
+        |f| f,
+        None,
+        None,
+    )
+    .unwrap();
 
     // Reload from written file
     let store2 = base::store::load_graph(&tmp_path).unwrap();
@@ -223,7 +231,15 @@ fn test_atomic_write_no_corrupt() {
     let out_path = tmp_dir.path().join("atomic.nq");
 
     // Write
-    base::store::write_back(&store, &out_path, base::changelog::Change::Op("test")).unwrap();
+    base::store::write_back_seamed(
+        &store,
+        &out_path,
+        base::changelog::Change::Op("test"),
+        |f| f,
+        None,
+        None,
+    )
+    .unwrap();
 
     // Verify file exists
     assert!(

--- a/tests/write_back_test.rs
+++ b/tests/write_back_test.rs
@@ -72,7 +72,8 @@ fn round_trips(n: usize) {
     let path = graph_path(root.path());
     let store = store_with(n);
 
-    store::write_back(&store, &path, Change::Op("test.round-trip")).unwrap();
+    store::write_back_seamed(&store, &path, Change::Op("test.round-trip"), |f| f, None, None)
+        .unwrap();
 
     let reloaded = store::load_graph(&path).unwrap();
     assert_eq!(reloaded.len().unwrap(), n, "{n} quads written must parse back as {n} quads");
@@ -109,7 +110,7 @@ fn the_written_file_is_byte_identical_to_the_raw_serializer_output() {
     let path = graph_path(root.path());
     let store = store_with(60_000);
 
-    store::write_back(&store, &path, Change::Op("test.bytes")).unwrap();
+    store::write_back_seamed(&store, &path, Change::Op("test.bytes"), |f| f, None, None).unwrap();
 
     let on_disk = fs::read(&path).unwrap();
     let reference = raw_dump(&store);
@@ -137,7 +138,8 @@ fn a_stale_temp_file_is_reaped_and_a_fresh_one_is_left_alone() {
     let fresh = dir.join("graph.nq.tmp.998");
     fs::write(&fresh, "fresh").unwrap();
 
-    store::write_back(&store_with(3), &path, Change::Op("test.sweep")).unwrap();
+    store::write_back_seamed(&store_with(3), &path, Change::Op("test.sweep"), |f| f, None, None)
+        .unwrap();
 
     assert_eq!(
         tmp_files(dir),
@@ -151,8 +153,10 @@ fn a_rewrite_replaces_the_previous_file_completely() {
     let root = tempfile::tempdir().unwrap();
     let path = graph_path(root.path());
 
-    store::write_back(&store_with(1_000), &path, Change::Op("test.first")).unwrap();
-    store::write_back(&store_with(5), &path, Change::Op("test.second")).unwrap();
+    store::write_back_seamed(&store_with(1_000), &path, Change::Op("test.first"), |f| f, None, None)
+        .unwrap();
+    store::write_back_seamed(&store_with(5), &path, Change::Op("test.second"), |f| f, None, None)
+        .unwrap();
 
     assert_eq!(store::load_graph(&path).unwrap().len().unwrap(), 5, "the second write wins in full");
     assert_eq!(fs::read(&path).unwrap(), raw_dump(&store_with(5)));
@@ -166,9 +170,11 @@ fn every_write_appends_exactly_one_changelog_record() {
     let path = graph_path(root.path());
 
     assert_eq!(log_lines(&path), 0);
-    store::write_back(&store_with(2), &path, Change::Op("test.log-1")).unwrap();
+    store::write_back_seamed(&store_with(2), &path, Change::Op("test.log-1"), |f| f, None, None)
+        .unwrap();
     assert_eq!(log_lines(&path), 1);
-    store::write_back(&store_with(2), &path, Change::Op("test.log-2")).unwrap();
+    store::write_back_seamed(&store_with(2), &path, Change::Op("test.log-2"), |f| f, None, None)
+        .unwrap();
     assert_eq!(log_lines(&path), 2);
 }
 
@@ -199,7 +205,8 @@ impl<W: std::io::Write> std::io::Write for FailAfter<W> {
 /// A seeded graph on disk: (path, its bytes, its mtime, its changelog length).
 fn seeded(root: &Path) -> (PathBuf, Vec<u8>, SystemTime, usize) {
     let path = graph_path(root);
-    store::write_back(&store_with(200), &path, Change::Op("test.seed")).unwrap();
+    store::write_back_seamed(&store_with(200), &path, Change::Op("test.seed"), |f| f, None, None)
+        .unwrap();
     let bytes = fs::read(&path).unwrap();
     let mtime = fs::metadata(&path).unwrap().modified().unwrap();
     (path.clone(), bytes, mtime, log_lines(&path))
@@ -271,8 +278,13 @@ fn a_quad_count_mismatch_is_an_error_naming_both_counts_and_the_original_survive
     assert_original_survived(&path, &bytes, mtime, log, "count");
 }
 
+/// The name used to say "behaves exactly like `write_back`" while the body
+/// compared against `raw_dump` and never called `write_back` at all. Since #87
+/// made `write_back` private, an integration test cannot reach it, so the
+/// entry-point equivalence is pinned by `the_two_entry_points_write_identical_bytes`
+/// inside `store.rs`, which can. This one asserts what it actually asserts.
 #[test]
-fn the_seam_with_no_injection_behaves_exactly_like_write_back() {
+fn the_seam_with_no_injection_writes_the_raw_serializer_bytes() {
     let root = tempfile::tempdir().unwrap();
     let path = graph_path(root.path());
     store::write_back_seamed(&store_with(1_000), &path, Change::Op("test.identity"), |file| file, None, None).unwrap();

--- a/tests/write_back_test.rs
+++ b/tests/write_back_test.rs
@@ -227,6 +227,7 @@ fn a_sink_that_fails_mid_dump_is_an_error_and_the_original_survives() {
             Change::Op("test.fail"),
             |file| FailAfter { inner: file, left: limit },
             None,
+            None,
         );
 
         let err = result.expect_err("a failed write must surface as an error");
@@ -250,6 +251,7 @@ fn a_flush_failure_after_a_clean_dump_is_an_error_and_the_original_survives() {
         Change::Op("test.flush"),
         |file| FailAfter { inner: file, left: 0 },
         None,
+        None,
     );
 
     let msg = format!("{:#}", result.expect_err("the flush error must propagate"));
@@ -262,7 +264,7 @@ fn a_quad_count_mismatch_is_an_error_naming_both_counts_and_the_original_survive
     let root = tempfile::tempdir().unwrap();
     let (path, bytes, mtime, log) = seeded(root.path());
 
-    let result = store::write_back_seamed(&store_with(1_000), &path, Change::Op("test.count"), |file| file, Some(999));
+    let result = store::write_back_seamed(&store_with(1_000), &path, Change::Op("test.count"), |file| file, Some(999), None);
 
     let msg = format!("{:#}", result.expect_err("a short file must not be renamed into place"));
     assert!(msg.contains("999") && msg.contains("1000"), "both counts are named, got: {msg}");
@@ -273,7 +275,7 @@ fn a_quad_count_mismatch_is_an_error_naming_both_counts_and_the_original_survive
 fn the_seam_with_no_injection_behaves_exactly_like_write_back() {
     let root = tempfile::tempdir().unwrap();
     let path = graph_path(root.path());
-    store::write_back_seamed(&store_with(1_000), &path, Change::Op("test.identity"), |file| file, None).unwrap();
+    store::write_back_seamed(&store_with(1_000), &path, Change::Op("test.identity"), |file| file, None, None).unwrap();
     assert_eq!(fs::read(&path).unwrap(), raw_dump(&store_with(1_000)));
     assert_eq!(log_lines(&path), 1);
 }


### PR DESCRIPTION
Closes #87 — **rank:01**, the highest-ranked open bug in the 0.14.3 round.

Built by `condor` on 2026-09-08 at `994ea29`, six commits, red-first. The branch has been
on the remote at this sha and has simply had no PR open, so the round's top-ranked item was
invisible in review all day. Opening it to correct that.

## What it does
The nine Tier C writers take the graph lock, `write_back` goes private, and
`migrate_trig_to_nq` takes the lock on a new bulk wait bound. A `LockedGraph` /
`lock_and_load_graph` pair plus a runtime identity backstop closes the seam.

## Commits
- `a46f33e4` red-first: narrow rule 1's `src/store.rs` file exemption to three named seam writers
- `7d3dca93` step 3 acceptance: five legs for the identity backstop, with a mutation arm
- `b9d44629` steps 2+3: `LockedGraph`, `lock_and_load_graph`, runtime identity backstop
- `6e3db59b` teach the tripwire the fix's lock spelling and the two graph-path names
- `c3510274` site ten: `migrate_trig_to_nq` takes the graph lock on a new bulk wait bound
- `994ea290` the nine Tier C writers take the lock, and `write_back` goes private

## State on opening — read this before grading
`git compare` against `main` at `0acd6e85` reports **diverged, 6 ahead / 6 behind**, 17 files.
The branch was rebased onto `3b736901`; main has moved six commits since. **It needs a rebase
onto current main before merge**, and CI on this head measures the older base.

Not yet graded. G2 has not been requested.
