### PR TITLE
fix(ast): a read never crosses out of the app it started in

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -134,17 +134,70 @@ pub fn resolve_ast_ttl(target: &Path) -> PathBuf {
     }
 }
 
+/// Pure: may a read that started at `start` take the map sitting at `dir`?
+///
+/// Home is both a map holder and the usual workspace, so from anywhere beneath
+/// it an unbounded walk lands there and answers with the operator's whole
+/// profile. [`resolve_ast_ttl`] refuses exactly this on the WRITE side; the read
+/// side had no equivalent, which is what let `base ast query` answer a question
+/// about the code in front of you with a different project's code — silently,
+/// at exit 0. Measured 2026-09-08 from a clone with no map of its own: 13 rows
+/// of an unrelated tool, and `--contains` on a symbol defined in that very tree
+/// reported no match.
+///
+/// Home stays valid when it IS the start directory, so an intentional
+/// workspace-wide map still answers for someone standing in it.
+///
+/// Deliberately takes `home` as a parameter rather than calling
+/// [`crate::home::home_root`]: that function resolves differently in a test
+/// binary than in the shipped one (`home.rs:41-44` is `cfg`-gated), so a rule
+/// that consulted it could not be tested for what it actually does in
+/// production. A pure function has no feature-gated input.
+pub fn ast_map_admissible(start: &Path, dir: &Path, home: Option<&Path>) -> bool {
+    home != Some(dir) || dir == start
+}
+
 /// Find the AST map to READ from `cwd`, walking up: prefers `<root>/.base-ast/ast.ttl`,
 /// falling back to a legacy `<root>/.base/ast.ttl` (the pre-sidecar workspace map).
+///
+/// The walk is BOUNDED, by the same two rules the write path already applies:
+/// it climbs no further than the app root ([`ast_app_root`]), and it never
+/// adopts home's map from below ([`ast_map_admissible`]). Walking up *within* an
+/// app is kept — a query from `src/crud/` must still answer from the repo's map.
+///
+/// The app-root stop is evaluated OUTSIDE the `isolation-guard` block on
+/// purpose. That guard exists only in test builds, so a boundary that depended
+/// on it would be a boundary the shipped binary does not have, and a green test
+/// would say nothing about production.
 pub fn find_ast_ttl(cwd: &Path) -> Option<PathBuf> {
-    walk_up(cwd, |dir| {
-        let sidecar = dir.join(".base-ast").join("ast.ttl");
-        if sidecar.is_file() {
-            return Some(sidecar);
+    let app_root = ast_app_root(cwd);
+    let home = crate::home::home_root();
+    let mut dir = cwd.to_path_buf();
+    loop {
+        #[cfg(feature = "isolation-guard")]
+        if !crate::home::within_sandbox(&dir) {
+            return None;
         }
-        let legacy = dir.join(".base").join("ast.ttl");
-        legacy.is_file().then_some(legacy)
-    })
+        if ast_map_admissible(cwd, &dir, home.as_deref()) {
+            let sidecar = dir.join(".base-ast").join("ast.ttl");
+            if sidecar.is_file() {
+                return Some(sidecar);
+            }
+            let legacy = dir.join(".base").join("ast.ttl");
+            if legacy.is_file() {
+                return Some(legacy);
+            }
+        }
+        // Stop AT the app root. A read never crosses into another app's map:
+        // that is the difference between this and #37, which is about letting a
+        // read span several maps DELIBERATELY.
+        if app_root.as_deref() == Some(dir.as_path()) {
+            return None;
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
 }
 
 // ─── Namespace Config ────────────────────────────────────────

--- a/src/crud/ast_query.rs
+++ b/src/crud/ast_query.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use oxigraph::sparql::QueryResults;
@@ -9,7 +9,7 @@ use crate::crud;
 /// Query AST entities by label (case-insensitive substring match).
 /// Returns: file, line, type, calls, called-by for each match.
 pub fn contains(cwd: &Path, ns: &NamespaceConfig, name: &str) -> Result<()> {
-    let store = load_ast_store(cwd)?;
+    let store = load_ast_store_reporting(cwd)?;
     let pfx = ast_prefixes(ns);
     let name_lower = crud::escape_sparql_literal(&name.to_lowercase());
 
@@ -76,7 +76,7 @@ pub fn contains(cwd: &Path, ns: &NamespaceConfig, name: &str) -> Result<()> {
 
 /// List all entities in a source file with their relationships.
 pub fn file(cwd: &Path, ns: &NamespaceConfig, file_path: &str) -> Result<()> {
-    let store = load_ast_store(cwd)?;
+    let store = load_ast_store_reporting(cwd)?;
     let pfx = ast_prefixes(ns);
 
     // Normalize: accept "src/cli.rs" or "cli.rs" — match by CONTAINS on sourceFile.
@@ -156,7 +156,7 @@ pub fn file(cwd: &Path, ns: &NamespaceConfig, file_path: &str) -> Result<()> {
 
 /// Find all callers of a named entity.
 pub fn calls(cwd: &Path, ns: &NamespaceConfig, name: &str) -> Result<()> {
-    let store = load_ast_store(cwd)?;
+    let store = load_ast_store_reporting(cwd)?;
     let pfx = ast_prefixes(ns);
     let name_lower = crud::escape_sparql_literal(&name.to_lowercase());
 
@@ -217,7 +217,7 @@ pub fn calls(cwd: &Path, ns: &NamespaceConfig, name: &str) -> Result<()> {
 
 /// Find all files that import from a given file/module.
 pub fn imports(cwd: &Path, ns: &NamespaceConfig, file_path: &str) -> Result<()> {
-    let store = load_ast_store(cwd)?;
+    let store = load_ast_store_reporting(cwd)?;
     let pfx = ast_prefixes(ns);
     let file_lower = crud::normalize_path_sep(file_path)
         .trim_start_matches("src/")
@@ -601,11 +601,42 @@ pub fn list(cwd: &Path, ns: &NamespaceConfig) -> Result<()> {
     Ok(())
 }
 
-fn load_ast_store(cwd: &Path) -> Result<oxigraph::store::Store> {
-    let ast_path = crate::config::find_ast_ttl(cwd)
-        .ok_or_else(|| anyhow::anyhow!("No ast.ttl found. Run `base sync --ast` first."))?;
+/// The map that answers for `cwd`, and where it came from.
+///
+/// The error names the directory. "No ast.ttl found" described the tool's own
+/// bookkeeping; the reader needs to know WHICH directory has no map, because
+/// the answer to that is what tells them whether to map it or to stand
+/// somewhere else.
+fn resolve_ast_store(cwd: &Path) -> Result<(oxigraph::store::Store, PathBuf)> {
+    let ast_path = crate::config::find_ast_ttl(cwd).ok_or_else(|| {
+        anyhow::anyhow!(
+            "No code map covers {}. Run `base sync --ast --target {}` to map it.",
+            cwd.display(),
+            cwd.display()
+        )
+    })?;
     let store = oxigraph::store::Store::new()?;
     crate::store::load_turtle_into(&store, &ast_path)?;
+    Ok((store, ast_path))
+}
+
+fn load_ast_store(cwd: &Path) -> Result<oxigraph::store::Store> {
+    Ok(resolve_ast_store(cwd)?.0)
+}
+
+/// As [`load_ast_store`], and says which map answered when it is not `cwd`'s own.
+///
+/// Climbing to the app root is intended — a query from `src/crud/` answers from
+/// the repo's map — but it must not be SILENT, or a reader cannot tell whose
+/// code they are being shown. On stderr, so a caller parsing rows from stdout is
+/// unaffected. The banner is provenance for the legitimate case; it is not what
+/// makes the resolution correct, which is [`crate::config::find_ast_ttl`]'s
+/// boundary.
+fn load_ast_store_reporting(cwd: &Path) -> Result<oxigraph::store::Store> {
+    let (store, ast_path) = resolve_ast_store(cwd)?;
+    if ast_path.parent().and_then(Path::parent) != Some(cwd) {
+        eprintln!("map: {}", ast_path.display());
+    }
     Ok(store)
 }
 
@@ -776,7 +807,7 @@ fn relation_key(name: &str) -> String {
 
 /// Query one relation in both directions for a named entity.
 pub fn relation(cwd: &Path, ns: &NamespaceConfig, rel: &str, name: &str) -> Result<()> {
-    let store = load_ast_store(cwd)?;
+    let store = load_ast_store_reporting(cwd)?;
     let pfx = ast_prefixes(ns);
 
     let present = map_relations(&store, ns);

--- a/tests/ast_map_resolution_test.rs
+++ b/tests/ast_map_resolution_test.rs
@@ -1,0 +1,85 @@
+//! Which map may answer a read, as a rule — with no filesystem and no real home.
+//!
+//! `base ast query` answered from a different project's map. From any unmapped
+//! directory under the user profile the read walked up into `~/.base-ast` and
+//! returned that map's entities: exit 0, no warning, nothing naming the source.
+//! Measured 2026-09-08 inside base's own clone — `--contains parakeet` returned
+//! 13 rows of an unrelated tool, and `--contains find_ast_ttl` reported no match
+//! for a function defined in that very tree.
+//!
+//! The WRITE path already refused this (`resolve_ast_ttl`'s home filter, added
+//! 2026-08-14 after mapping app B erased app A on Windows and Linux). The READ
+//! path never got the same rule. That asymmetry is the whole defect.
+//!
+//! Why these legs pass `home` as a VALUE rather than letting the code call
+//! `home::home_root()`: that function resolves differently in a test binary than
+//! in the shipped one, in FOUR `cfg(feature = "isolation-guard")` places —
+//! `home.rs:26-29` (a per-thread root returned BEFORE `BASE_HOME`),
+//! `home.rs:41-44` (a synthetic `test_root()` instead of the OS home),
+//! `home.rs:62` (`isolation_active`), and `config.rs:76-77` (`walk_up`'s sandbox
+//! ceiling). A leg that consulted it would measure the feature, not the rule —
+//! and the `thread_home` branch can be left set by an earlier leg in the same
+//! binary, which reads as a clean pass and does not reproduce when run alone.
+//! A pure function has no feature-gated input, so there is nothing to leak.
+
+use std::path::Path;
+
+use base::config::ast_map_admissible;
+
+/// U1 — the defect. A read standing below home must not take home's map.
+#[test]
+fn home_map_is_not_adopted_from_below() {
+    let home = Path::new("C:/Users/someone");
+    let start = Path::new("C:/Users/someone/.cache/a-clone");
+
+    assert!(
+        !ast_map_admissible(start, home, Some(home)),
+        "a read from {start:?} must not adopt home's map — this is rank 01"
+    );
+}
+
+/// U2 — the masking twin (law 24). A rule that refused home ALWAYS would pass
+/// U1 identically and would break the intentional workspace-wide map.
+#[test]
+fn home_still_answers_when_home_is_where_you_are_standing() {
+    let home = Path::new("C:/Users/someone");
+
+    assert!(
+        ast_map_admissible(home, home, Some(home)),
+        "standing IN home, home's own map is exactly the right answer"
+    );
+}
+
+/// U3 — a directory's own map is always admissible.
+#[test]
+fn a_directory_may_always_take_its_own_map() {
+    let home = Path::new("C:/Users/someone");
+    let start = Path::new("C:/Users/someone/dev/app");
+
+    assert!(ast_map_admissible(start, start, Some(home)));
+}
+
+/// U4 — no home known. The rule must not start refusing things off-Windows or
+/// wherever the home lookup returns nothing; that would be a silent behaviour
+/// change dressed as a fix.
+#[test]
+fn with_no_home_known_nothing_is_refused() {
+    let start = Path::new("/srv/app");
+
+    assert!(ast_map_admissible(start, Path::new("/srv"), None));
+    assert!(ast_map_admissible(start, start, None));
+}
+
+/// U5 — this rule is ONLY about home. Refusing a non-home ancestor is the app
+/// boundary's job, in `find_ast_ttl`; keeping the two separate is what stops
+/// one of them quietly doing the other's work and both looking correct.
+#[test]
+fn a_non_home_ancestor_is_not_this_rules_business() {
+    let home = Path::new("C:/Users/someone");
+    let start = Path::new("C:/work/suite/app");
+
+    assert!(
+        ast_map_admissible(start, Path::new("C:/work/suite"), Some(home)),
+        "the app boundary refuses this one, not the home rule"
+    );
+}

--- a/tests/ast_query_map_boundary_test.rs
+++ b/tests/ast_query_map_boundary_test.rs
@@ -1,0 +1,191 @@
+//! A read never crosses out of the app it started in.
+//!
+//! `tests/ast_map_resolution_test.rs` pins the home rule as a pure rule. These
+//! legs pin the BOUNDARY on a real filesystem: an app with no map of its own
+//! must not answer from the map of the app above it.
+//!
+//! ## Why every fixture is built entirely under `env::temp_dir()`
+//!
+//! `walk_up` carries a `cfg(feature = "isolation-guard")` early return on
+//! `within_sandbox` (`config.rs:76-77`), and that feature is ON in every test
+//! binary and OFF in the shipped one (`Cargo.toml:33,36`). So a fixture whose
+//! parent sat OUTSIDE the sandbox would give `None` because the walk left the
+//! sandbox — and that `None` would read as proof the app boundary works while
+//! the shipped binary, which has no such line, kept walking and found the map.
+//! A green test and a broken product would be indistinguishable.
+//!
+//! Putting the parent map inside the sandbox removes the confound by
+//! construction: `within_sandbox` is TRUE for every directory these legs
+//! traverse, so it cannot be what stops the walk. Each leg asserts that, and
+//! prints the chain, rather than leaving it to be re-derived by a reader.
+
+use std::path::{Path, PathBuf};
+
+use base::config::find_ast_ttl;
+
+/// Assert the sandbox guard cannot be the thing producing a `None`, and show
+/// the reader the chain it was asserted over. A leg that visited nothing has
+/// proved nothing (law 23), so a zero-length chain is a failure.
+fn assert_chain_inside_sandbox(from: &Path, upto: &Path) {
+    let mut visited = 0;
+    let mut dir = from.to_path_buf();
+    loop {
+        visited += 1;
+        let inside = base::home::within_sandbox(&dir);
+        let has_map = dir.join(".base-ast").join("ast.ttl").is_file();
+        println!("  [{visited}] {} map:{has_map} within_sandbox:{inside}", dir.display());
+        assert!(
+            inside,
+            "{} is outside the sandbox, so a None from this fixture could be the \
+             isolation-guard ceiling rather than the app boundary — the fixture is \
+             the wrong shape, not the product",
+            dir.display()
+        );
+        if dir == upto {
+            break;
+        }
+        assert!(dir.pop(), "walked past the filesystem root without reaching {}", upto.display());
+    }
+    assert!(visited > 0, "visited 0 directories — this leg proved NOTHING");
+    println!("  directories visited: {visited}");
+}
+
+fn write_map(dir: &Path) -> PathBuf {
+    let base_ast = dir.join(".base-ast");
+    std::fs::create_dir_all(&base_ast).unwrap();
+    let map = base_ast.join("ast.ttl");
+    // Enough Turtle to be a real map rather than an empty file, so "the map
+    // exists" is a claim about content and not about a zero-byte placeholder.
+    std::fs::write(
+        &map,
+        "@prefix ops: <https://ops.example/> .\n\
+         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+         <urn:e1> a ops:Function ; rdfs:label \"marker_entity\" .\n",
+    )
+    .unwrap();
+    map
+}
+
+fn mark_app_root(dir: &Path) {
+    // `.git` as a plain directory: `ast_app_root` tests for existence only.
+    std::fs::create_dir_all(dir.join(".git")).unwrap();
+}
+
+/// I1 — the boundary. An app with no map does not borrow the parent's.
+///
+/// The ancestry assertions are the point: without them a `None` here is
+/// indistinguishable from a fixture whose parent map was never created. condor
+/// measured `C:/Windows/Temp` — unmapped with no mapped ancestor — already
+/// returning the named error on the UNFIXED binary, so fixture ancestry, not
+/// the fix, is what decides red from green.
+#[test]
+fn an_unmapped_app_does_not_borrow_its_parents_map() {
+    let tmp = tempfile::tempdir().unwrap();
+    let suite = tmp.path();
+    let app = suite.join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    mark_app_root(&app);
+
+    let parent_map = write_map(suite);
+
+    // C-3: the ancestor exists, by path and with real content.
+    assert!(parent_map.is_file(), "parent map absent — a None below would prove nothing");
+    let bytes = std::fs::metadata(&parent_map).unwrap().len();
+    assert!(bytes > 0, "parent map is empty — a None below would prove nothing");
+    println!("parent map: {} ({bytes} bytes)", parent_map.display());
+
+    // C-5: and it is reachable, so the sandbox ceiling is not the cause.
+    assert_chain_inside_sandbox(&app, suite);
+
+    assert_eq!(
+        find_ast_ttl(&app),
+        None,
+        "an app with no map of its own must not answer from {}",
+        parent_map.display()
+    );
+}
+
+/// I2 — the same tree, one file different: the app's own map wins.
+///
+/// This is what separates "the boundary works" from "every query now fails".
+#[test]
+fn an_apps_own_map_answers_and_is_preferred_over_the_parents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let suite = tmp.path();
+    let app = suite.join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    mark_app_root(&app);
+
+    let parent_map = write_map(suite);
+    let own_map = write_map(&app);
+    assert!(parent_map.is_file() && own_map.is_file());
+
+    assert_eq!(
+        find_ast_ttl(&app).as_deref(),
+        Some(own_map.as_path()),
+        "the app's own map must answer, not the parent's"
+    );
+}
+
+/// I3 — walking up WITHIN an app is kept. A query from a source subdirectory
+/// still answers from the repo's map; the fix bounds the walk, it does not
+/// remove it.
+#[test]
+fn a_subdirectory_still_walks_up_to_its_own_app_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let suite = tmp.path();
+    let app = suite.join("app");
+    let deep = app.join("src").join("crud");
+    std::fs::create_dir_all(&deep).unwrap();
+    mark_app_root(&app);
+
+    write_map(suite);
+    let own_map = write_map(&app);
+
+    assert_eq!(
+        find_ast_ttl(&deep).as_deref(),
+        Some(own_map.as_path()),
+        "a read from src/crud/ must reach the app's map at the repo root"
+    );
+}
+
+/// I4 — the legacy `<root>/.base/ast.ttl` still resolves inside the app.
+#[test]
+fn the_legacy_workspace_map_still_resolves_within_the_app() {
+    let tmp = tempfile::tempdir().unwrap();
+    let suite = tmp.path();
+    let app = suite.join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    mark_app_root(&app);
+
+    write_map(suite);
+    let legacy_dir = app.join(".base");
+    std::fs::create_dir_all(&legacy_dir).unwrap();
+    let legacy = legacy_dir.join("ast.ttl");
+    std::fs::write(&legacy, "@prefix ops: <https://ops.example/> .\n").unwrap();
+
+    assert_eq!(
+        find_ast_ttl(&app).as_deref(),
+        Some(legacy.as_path()),
+        "the pre-sidecar map must keep working for anyone who has not re-synced"
+    );
+}
+
+/// I5 — a directory that is not an app at all, with a map above it, still
+/// resolves upward. The boundary is the APP root; it is not "never walk up".
+#[test]
+fn a_plain_directory_with_no_app_marker_still_resolves_upward() {
+    let tmp = tempfile::tempdir().unwrap();
+    let suite = tmp.path();
+    mark_app_root(suite);
+    let map = write_map(suite);
+
+    let plain = suite.join("notes").join("drafts");
+    std::fs::create_dir_all(&plain).unwrap();
+
+    assert_eq!(
+        find_ast_ttl(&plain).as_deref(),
+        Some(map.as_path()),
+        "an ordinary subdirectory of a mapped app answers from that app"
+    );
+}


### PR DESCRIPTION
## `base ast query` answered from a different project's map

From any directory with no `.base-ast` of its own, `base ast query` walked up and answered from
whatever map it met first — in practice the **home directory's**, because `~` carries both
`.base-ast` and `.base` and is therefore an app root and a map holder at once. Exit 0. No warning.
Nothing in the output naming the source.

### The claim this makes false is in the binary, not on the website

```
-t, --target <TARGET>  Query a specific app's map by path (e.g. apps/foo) instead of the cwd's map
```
— `src/cli.rs:685`

"instead of the cwd's map" asserts that without `--target` the command reads **the cwd's map**. In
a clone with no map there is no cwd map, and it answered anyway.

### It fails in both directions, and the quieter one is worse

Run from base's own source tree — the directory that contains `src/config.rs`:

| command | rc | output |
|---|---|---|
| `base ast query --contains "find_ast_ttl"` | **0** | `No AST entities matching 'find_ast_ttl'.` |
| `base ast query --contains "parakeet"` | **0** | 13 rows from `C:\Users\…\Tools\parakeet-stt-patch` |

`find_ast_ttl` is defined at `src/config.rs:139` of that very tree. So it **denies code that is
present** and **affirms code that is absent**, in the same directory, seconds apart. A developer
who gets "no match" concludes the symbol is gone; nobody suspects the tool read another project.

### It is also passive

`find_ast_ttl` has a second consumer — `ast_graph_populated` at `src/hook/pre_tool_use.rs:352`.
So the same foreign map was advertised to an agent automatically, through hook injection, with
nobody typing a command.

## Root cause

`src/config.rs` holds two halves of one resolution and only one was guarded.

**Write — guarded.** `resolve_ast_ttl` ends on a home filter (`config.rs:130`) whose comment
records *"Verified 2026-08-14 on Windows AND Linux: mapping app B erased app A."*

**Read — unguarded.** `find_ast_ttl` was a bare `walk_up`: first `.base-ast/ast.ttl`, else legacy
`.base/ast.ttl`, first hit wins, all the way to the filesystem root.

`walk_up`'s own doc comment said the quiet part out loud: *"Production is unaffected: the check
compiles out entirely, so a machine whose home IS a workspace still resolves it."*

## The fix

The read now obeys the two rules the write already did:

1. **The walk stops at the app root** (`ast_app_root`, markers `.git`/`.paul`/`.base-ast`/`.base`).
   A read never crosses out of the app it started in. Walking up *within* an app is kept — a query
   from `src/crud/` still answers from the repo's map.
2. **Home's map is never adopted from below** — admissible only when the start directory *is* home,
   mirroring `config.rs:130`. An intentional workspace-wide map still answers for someone in it.

Unresolvable now produces a named error that says which directory:

```
No code map covers <dir>. Run `base sync --ast --target <dir>` to map it.
```

And when an ancestor inside the same app answers, that is printed to **stderr** (`map: <path>`),
so stdout stays a clean data channel for callers parsing rows.

### Intended visible change, declared

`ast_graph_populated` inherits the bounded resolver, so **the "AST graph available" hook hint stops
firing in unmapped directories** and says "not yet populated" with the remedy instead. This is
deliberate, not a side effect: the hint was making rank 01's false claim automatically. A control
leg proves the hint **still fires in a genuinely mapped directory**.

## Why the core rule is a pure function

`home_root()` and the walk resolve differently in a test binary than in the shipped one, at four
`cfg(feature = "isolation-guard")` sites:

| # | site | test binary | shipped binary |
|---|---|---|---|
| 1 | `config.rs:76-77` (`walk_up`) | returns `None` once the walk leaves `within_sandbox` | **line absent** — walks to the root |
| 2 | `home.rs:62` (`isolation_active`) | true by feature alone | true only with `BASE_HOME` set |
| 3 | `home.rs:41-44` (fall-through) | synthetic `test_root()` | `real_home()` |
| 4 | `home.rs:26-29` (`thread_home`) | per-thread root, returned **before** `BASE_HOME` | **branch absent** |

Divergence 1 is the trap for this PR specifically: a fixture whose parent map sat outside the
sandbox would return `None` because the walk left the sandbox, and that `None` would read as proof
the app boundary works while the shipped binary — which has no such line — kept walking. **A green
test and a broken product would be indistinguishable.**

So `ast_map_admissible` takes `home` as a parameter and never calls `home_root()`: a pure function
has no feature-gated input. Every integration fixture is built entirely under `env::temp_dir()`,
each leg asserts `within_sandbox` is **true** for every directory it traverses, and prints the
chain — so the sandbox cannot be what produced the result. Coverage splits cleanly: **feature-ON**
by the unit and integration legs, **feature-OFF** end-to-end by release CLI legs.

## Evidence

**Red first.** With `src/config.rs` stashed, the boundary leg fails on the real defect:

```
  [1] …\.tmpfmD6mY\app  map:false  within_sandbox:true
  [2] …\.tmpfmD6mY      map:true   within_sandbox:true
  directories visited: 2
assertion `left == right` failed
  left: Some("…\\.tmpfmD6mY\\.base-ast\\ast.ttl")
 right: None
```

Both traversed directories are in-sandbox, so the `cfg`-gated ceiling provably was not the cause.
The other four legs stayed green unfixed — they are regression guards.

**New legs:** `tests/ast_map_resolution_test.rs` (5, pure) and
`tests/ast_query_map_boundary_test.rs` (5, temp fixtures) — 10/10 green, 0 warnings.

**CLI acceptance** ran on **release** binaries built from this branch, each printing profile, md5
and a discriminating symbol (`ast_map_admissible`: absent pre-fix, present post-fix). The version
string cannot separate them — `Cargo.toml` reads `0.14.2` on both — so the symbol is the
load-bearing check. Fixtures are real directories, and the unmapped one's ancestry is asserted
(map exists, 25,903 entities) with a borrowed-term probe, because an unmapped directory with *no*
mapped ancestor already errored before this change.

## Note for reviewers on Windows

`cargo test` on Windows **debug** shows 27 pre-existing failures across 6 targets. They are #129:
the child dies with `STATUS_STACK_OVERFLOW` (`-1073741571` = `0xC00000FD`) before running anything.
Proven unrelated by control — the same 6 targets with this change **stashed** produce the identical
27 failing test names, symmetric difference zero in both directions. Ubuntu CI is the acceptance
surface; a release build runs normally.
