### PR TITLE
fix(ast): a heading is not a callable, and a broken import is not a package (#105)

### DIFF
--- a/scripts/ast/extractor.py
+++ b/scripts/ast/extractor.py
@@ -2610,6 +2610,14 @@ def extract_svelte(path: Path) -> dict:
                 continue
             result.setdefault("nodes", []).append({
                 "id": node_id, "label": raw,
+                # A stub is only reached when the target is NOT an existing
+                # node, so a RELATIVE specifier that got here failed to
+                # resolve: `'../lib/api.js'` resolved to a `.ts` path that is
+                # not on disk, and the stub then reached the map as
+                # `ops:Function` at the app root, line 0. It is a broken
+                # import and is typed as one.
+                "type": (IMPORT_TYPE_UNRESOLVED if raw.startswith(".")
+                         else IMPORT_TYPE_EXTERNAL),
                 "file_type": "code", "source_file": stub_source_file,
                 "confidence": "EXTRACTED",
             })
@@ -2669,6 +2677,10 @@ def extract_svelte(path: Path) -> dict:
                     continue
                 result.setdefault("nodes", []).append({
                     "id": node_id, "label": raw,
+                    # See the sibling site: a stub for a relative specifier is
+                    # a failed resolution, never a third party.
+                    "type": (IMPORT_TYPE_UNRESOLVED if raw.startswith(".")
+                             else IMPORT_TYPE_EXTERNAL),
                     "file_type": "code", "source_file": stub_source_file,
                     "confidence": "EXTRACTED",
                 })
@@ -2740,6 +2752,14 @@ def extract_astro(path: Path) -> dict:
                 continue
             result.setdefault("nodes", []).append({
                 "id": node_id, "label": raw,
+                # A stub is only reached when the target is NOT an existing
+                # node, so a RELATIVE specifier that got here failed to
+                # resolve: `'../lib/api.js'` resolved to a `.ts` path that is
+                # not on disk, and the stub then reached the map as
+                # `ops:Function` at the app root, line 0. It is a broken
+                # import and is typed as one.
+                "type": (IMPORT_TYPE_UNRESOLVED if raw.startswith(".")
+                         else IMPORT_TYPE_EXTERNAL),
                 "file_type": "code", "source_file": stub_source_file,
                 "confidence": "EXTRACTED",
             })
@@ -2805,6 +2825,10 @@ def extract_astro(path: Path) -> dict:
                     continue
                 result.setdefault("nodes", []).append({
                     "id": node_id, "label": raw,
+                    # See the sibling site: a stub for a relative specifier is
+                    # a failed resolution, never a third party.
+                    "type": (IMPORT_TYPE_UNRESOLVED if raw.startswith(".")
+                             else IMPORT_TYPE_EXTERNAL),
                     "file_type": "code", "source_file": stub_source_file,
                     "confidence": "EXTRACTED",
                 })

--- a/scripts/ast/extractor.py
+++ b/scripts/ast/extractor.py
@@ -405,6 +405,199 @@ def _find_body(node, config: LanguageConfig):
 
 # ── Import handlers ───────────────────────────────────────────────────────────
 
+# ── import states (#105) ──────────────────────────────────────────────────────
+#
+# An import is not one thing. It either resolved to a file in this tree, or it
+# was SUPPOSED to and did not, or it names something outside the tree
+# altogether. Collapsing the middle state into the third files a resolution
+# FAILURE as a deliberate taxonomy, and `'../lib/api.js'` is the proof: a
+# relative path is required to resolve inside the tree, so when it does not,
+# the honest report is "this import is broken", never "this is third-party".
+#
+# The split is deliberately across two places, because the two halves are known
+# in two different places:
+#
+#   * WHAT THE SPECIFIER DEMANDS is syntax, and only the parser sees it. Each
+#     `_import_*` handler records it on the edge as `import_kind`.
+#   * WHETHER THE TARGET EXISTS is cross-file, and no single-file extractor can
+#     answer it. `_classify_import_targets` answers it once the tree is whole.
+#
+# Deciding either one in the other place is how this defect happened.
+
+#: `import_kind` — what the specifier's syntax demands of its target.
+IMPORT_KIND_INTERNAL = "internal"    # must resolve inside this tree
+IMPORT_KIND_EXTERNAL = "external"    # unambiguously outside it (`std::`, `<stdio.h>`)
+#: A bare name that the syntax CANNOT place. `import json` and
+#: `from extractor import extract` are spelled identically whether the module
+#: is stdlib or the file next door, so the parser must not pretend to know:
+#: the tree decides, and only a name matching no file in it is third-party.
+#: Calling these external on syntax alone would commit the same error as
+#: filing a broken relative path under "external" — asserting a taxonomy where
+#: there is only a missing lookup.
+IMPORT_KIND_AMBIGUOUS = "ambiguous"
+
+#: The node types the classifier emits. `import_external` is a real thing that
+#: lives elsewhere; `import_unresolved` is a FAILURE, and is typed as one so no
+#: reader can mistake it for a deliberate category.
+IMPORT_TYPE_EXTERNAL = "import_external"
+IMPORT_TYPE_UNRESOLVED = "import_unresolved"
+#: Resolved to a real file this extractor does not parse (`./app.css`). The
+#: import works, so it is NOT a failure; the target is just not a mapped
+#: language, and saying so is the difference between a diagnosis and a smear.
+IMPORT_TYPE_UNPARSED = "import_unparsed"
+
+
+def _import_kind_from_specifier(specifier: str) -> str:
+    """`internal` when the specifier is required to resolve inside this tree.
+
+    A leading `.` is a relative path in python, javascript and typescript
+    alike, and a relative path that does not resolve is a broken import. Every
+    other spelling is a bare name, external until a file node proves otherwise
+    — which `_classify_import_targets` checks rather than assumes.
+    """
+    return IMPORT_KIND_INTERNAL if specifier.startswith(".") else IMPORT_KIND_AMBIGUOUS
+
+
+#: `use` roots that are internal by construction: the crate itself, the current
+#: module, its parent.
+_RUST_INTERNAL_ROOTS = frozenset({"crate", "self", "super"})
+#: Files whose module IS their directory, so their submodules are siblings
+#: rather than children.
+_RUST_DIR_MODULES = frozenset({"mod", "lib", "main"})
+
+
+def _rust_module_dir(path: Path) -> Path:
+    """The directory a rust file's own submodules live in."""
+    return path.parent if path.stem in _RUST_DIR_MODULES else path.parent / path.stem
+
+
+def _rust_crate_root(path: Path) -> Path:
+    """The nearest enclosing `src`, which is where `crate::` starts."""
+    for parent in path.parents:
+        if parent.name == "src":
+            return parent
+    return path.parent
+
+
+def _rust_inside_inline_mod(node) -> bool:
+    """True when this `use` sits inside an inline `mod { ... }` in the file.
+
+    It decides what `super` MEANS, so it is read from the tree rather than
+    assumed: inside `#[cfg(test)] mod tests`, `super` is the file's own module
+    and `use super::*` resolves to THIS file. At the top level of the file,
+    `super` is the parent module and resolves to another file. Guessing one of
+    those reports 72 working imports as broken, which is how this function came
+    to exist.
+    """
+    parent = node.parent
+    while parent is not None:
+        if parent.type == "mod_item":
+            return True
+        parent = parent.parent
+    return False
+
+
+def _rust_module_file(path: Path) -> Path | None:
+    """The file holding the module a rust file's `super` refers to."""
+    module_dir = _rust_module_dir(path)
+    stem = module_dir.name
+    for candidate in (module_dir.with_suffix(".rs"), module_dir / "mod.rs"):
+        try:
+            if candidate.is_file() and candidate != path:
+                return candidate
+        except OSError:
+            continue
+    for candidate in (path.parent / "lib.rs", path.parent / "main.rs",
+                      path.parent / "mod.rs"):
+        try:
+            if candidate.is_file() and candidate != path:
+                return candidate
+        except OSError:
+            continue
+    _ = stem
+    return None
+
+
+def _rust_use_target(raw: str, path: Path, in_inline_mod: bool = False) -> "tuple[str | None, str, str]":
+    """`(target_nid, import_kind, label)` for one rust `use` declaration.
+
+    The old behaviour took the LAST segment, so `use oxigraph::model::NamedNode`
+    recorded an edge to a node called `model` — a path SEGMENT nobody wrote,
+    which was emitted as no node and therefore dangled. **718 of base's own 894
+    dangling edges were this one line.**
+
+    A `use` path has two shapes and they need opposite treatment:
+
+      * `crate::` / `self::` / `super::` are INTERNAL by construction. The
+        module is resolved against a real file under the crate root, and a miss
+        is a BROKEN import — never a third party. This is the case most likely
+        to be quietly lumped in with externals, so it is the one spelled out.
+      * anything else names ANOTHER CRATE, and the crate is the FIRST segment:
+        `oxigraph`, `serde`, `std`. That is the identity the author typed and
+        the one a dependency list can confirm — not the last segment, which is
+        usually a type.
+
+    Item names are not modules, so resolution walks the path from the longest
+    prefix down: `crate::store::write_back` tries `store/write_back.rs`, then
+    `store/write_back/mod.rs`, then `store.rs`, and stops at the first that
+    exists on disk.
+    """
+    clean = raw.split("{")[0].strip()
+    clean = clean.rstrip(":").rstrip("*").rstrip(":").strip()
+    if not clean:
+        return None, IMPORT_KIND_EXTERNAL, raw
+    segments = [s.strip() for s in clean.split("::") if s.strip()]
+    if not segments:
+        return None, IMPORT_KIND_EXTERNAL, raw
+
+    root = segments[0]
+    if root not in _RUST_INTERNAL_ROOTS:
+        # Another crate. Named by the crate, with the full path kept as the
+        # label so nothing the author wrote is lost.
+        return _make_id(root), IMPORT_KIND_EXTERNAL, root
+
+    if root == "crate":
+        base = _rust_crate_root(path)
+    elif root == "self":
+        base = _rust_module_dir(path)
+    else:  # super
+        base = _rust_module_dir(path).parent
+    rest = segments[1:]
+
+    for i in range(len(rest), 0, -1):
+        prefix = rest[:i]
+        for candidate in (base.joinpath(*prefix).with_suffix(".rs"),
+                          base.joinpath(*prefix) / "mod.rs"):
+            try:
+                if candidate.is_file():
+                    return _make_id(str(candidate)), IMPORT_KIND_INTERNAL, clean
+            except OSError:
+                continue
+
+    # Nothing under the path is a file, so the import names ITEMS in a module
+    # rather than a module — `use super::*` (the glob an inline `mod tests`
+    # uses), or `use super::notice_from_log`. Resolve to the module's own file.
+    # Measured: 72 of 73 first-pass "failures" on base's own tree were
+    # `use super::*`, every one of them a working import.
+    if root == "self" or (root == "super" and in_inline_mod):
+        return _make_id(str(path)), IMPORT_KIND_INTERNAL, clean
+    if root == "super":
+        module_file = _rust_module_file(path)
+        if module_file is not None:
+            return _make_id(str(module_file)), IMPORT_KIND_INTERNAL, clean
+    if root == "crate":
+        for candidate in (base / "lib.rs", base / "main.rs"):
+            try:
+                if candidate.is_file():
+                    return _make_id(str(candidate)), IMPORT_KIND_INTERNAL, clean
+            except OSError:
+                continue
+
+    # Required to resolve inside the tree and did not: a broken import, and it
+    # is reported as one rather than filed under "external".
+    return _make_id(clean), IMPORT_KIND_INTERNAL, clean
+
+
 def _import_python(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> None:
     t = node.type
     if t == "import_statement":
@@ -422,6 +615,12 @@ def _import_python(node, source: bytes, file_nid: str, stem: str, edges: list, s
                     "source_file": str_path,
                     "source_location": f"L{node.start_point[0] + 1}",
                     "weight": 1.0,
+                    # A dotted or bare module name. Never relative, but not
+                    # proof of a third party either: it is spelled the same
+                    # for a stdlib module and for the file next door, so the
+                    # tree places it (`_classify_import_targets`), not this.
+                    "specifier": module_name,
+                    "import_kind": IMPORT_KIND_AMBIGUOUS,
                 })
     elif t == "import_from_statement":
         module_node = node.child_by_field_name("module_name")
@@ -447,6 +646,11 @@ def _import_python(node, source: bytes, file_nid: str, stem: str, edges: list, s
                 "source_file": str_path,
                 "source_location": f"L{node.start_point[0] + 1}",
                 "weight": 1.0,
+                # `from . import x` is required to resolve inside the tree, so
+                # a miss is a BROKEN import. `from json import x` is a bare
+                # name the tree has to place.
+                "specifier": raw,
+                "import_kind": _import_kind_from_specifier(raw),
             })
 
 
@@ -497,6 +701,14 @@ def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_p
                 "source_file": str_path,
                 "source_location": f"L{node.start_point[0] + 1}",
                 "weight": 1.0,
+                # `_resolve_js_import_target` ALREADY decided this and the
+                # answer was being discarded at this line: a `resolved_path` of
+                # None is its "I could not place this, here is a bare-name
+                # fallback". Carrying both is what separates a broken relative
+                # path from a package — #105's second shape.
+                "specifier": raw,
+                "import_kind": _import_kind_from_specifier(raw),
+                "resolved_path": str(resolved_path) if resolved_path else None,
             })
             break
 
@@ -652,6 +864,12 @@ def _import_java(node, source: bytes, file_nid: str, stem: str, edges: list, str
                     "source_file": str_path,
                     "source_location": f"L{node.start_point[0] + 1}",
                     "weight": 1.0,
+                    # A dotted or bare module name. Never relative, but not
+                    # proof of a third party either: it is spelled the same
+                    # for a stdlib module and for the file next door, so the
+                    # tree places it (`_classify_import_targets`), not this.
+                    "specifier": module_name,
+                    "import_kind": IMPORT_KIND_AMBIGUOUS,
                 })
             break
 
@@ -703,6 +921,12 @@ def _import_c(node, source: bytes, file_nid: str, stem: str, edges: list, str_pa
                     "source_file": str_path,
                     "source_location": f"L{node.start_point[0] + 1}",
                     "weight": 1.0,
+                    # A dotted or bare module name. Never relative, but not
+                    # proof of a third party either: it is spelled the same
+                    # for a stdlib module and for the file next door, so the
+                    # tree places it (`_classify_import_targets`), not this.
+                    "specifier": module_name,
+                    "import_kind": IMPORT_KIND_AMBIGUOUS,
                 })
             break
 
@@ -723,6 +947,12 @@ def _import_csharp(node, source: bytes, file_nid: str, stem: str, edges: list, s
                     "source_file": str_path,
                     "source_location": f"L{node.start_point[0] + 1}",
                     "weight": 1.0,
+                    # A dotted or bare module name. Never relative, but not
+                    # proof of a third party either: it is spelled the same
+                    # for a stdlib module and for the file next door, so the
+                    # tree places it (`_classify_import_targets`), not this.
+                    "specifier": module_name,
+                    "import_kind": IMPORT_KIND_AMBIGUOUS,
                 })
             break
 
@@ -779,6 +1009,12 @@ def _import_scala(node, source: bytes, file_nid: str, stem: str, edges: list, st
                     "source_file": str_path,
                     "source_location": f"L{node.start_point[0] + 1}",
                     "weight": 1.0,
+                    # A dotted or bare module name. Never relative, but not
+                    # proof of a third party either: it is spelled the same
+                    # for a stdlib module and for the file next door, so the
+                    # tree places it (`_classify_import_targets`), not this.
+                    "specifier": module_name,
+                    "import_kind": IMPORT_KIND_AMBIGUOUS,
                 })
             break
 
@@ -799,6 +1035,12 @@ def _import_php(node, source: bytes, file_nid: str, stem: str, edges: list, str_
                     "source_file": str_path,
                     "source_location": f"L{node.start_point[0] + 1}",
                     "weight": 1.0,
+                    # A dotted or bare module name. Never relative, but not
+                    # proof of a third party either: it is spelled the same
+                    # for a stdlib module and for the file next door, so the
+                    # tree places it (`_classify_import_targets`), not this.
+                    "specifier": module_name,
+                    "import_kind": IMPORT_KIND_AMBIGUOUS,
                 })
             break
 
@@ -1387,7 +1629,7 @@ def _extract_generic(
 
     def add_edge(src: str, tgt: str, relation: str, line: int,
                  confidence: str = "EXTRACTED", weight: float = 1.0,
-                 context: str | None = None) -> None:
+                 context: str | None = None, **extra) -> None:
         edge = {
             "source": src,
             "target": tgt,
@@ -1399,6 +1641,10 @@ def _extract_generic(
         }
         if context:
             edge["context"] = context
+        # `specifier` / `import_kind` travel on an import edge so
+        # `_classify_import_targets` can separate the three states without
+        # re-parsing anything.
+        edge.update(extra)
         edges.append(edge)
 
     def ensure_named_node(name: str, line: int) -> str:
@@ -2819,12 +3065,21 @@ def extract_dart(path: Path) -> dict:
         pkg = m.group(1)
         tgt_nid = _make_id(pkg)
         if tgt_nid not in defined:
-            nodes.append({"id": tgt_nid, "label": pkg, "file_type": "code",
+            # This site already emitted its import target as a node — the one
+            # extractor that did — but untyped, so the serializer declared a
+            # dart package a callable. It is typed for what it is.
+            nodes.append({"id": tgt_nid, "label": pkg,
+                          "type": (IMPORT_TYPE_UNRESOLVED
+                                   if pkg.startswith(".")
+                                   else IMPORT_TYPE_EXTERNAL),
+                          "file_type": "code",
                           "source_file": str(path), "source_location": None})
             defined.add(tgt_nid)
         edges.append({"source": file_nid, "target": tgt_nid, "relation": "imports",
                       "confidence": "EXTRACTED", "confidence_score": 1.0,
-                      "source_file": str(path), "source_location": None, "weight": 1.0})
+                      "source_file": str(path), "source_location": None, "weight": 1.0,
+                      "specifier": pkg,
+                      "import_kind": _import_kind_from_specifier(pkg)})
 
     return {"nodes": nodes, "edges": edges}
 
@@ -3246,7 +3501,7 @@ def extract_julia(path: Path) -> dict:
 
     def add_edge(src: str, tgt: str, relation: str, line: int,
                  confidence: str = "EXTRACTED", weight: float = 1.0,
-                 context: str | None = None) -> None:
+                 context: str | None = None, **extra) -> None:
         edge = {
             "source": src,
             "target": tgt,
@@ -3258,6 +3513,10 @@ def extract_julia(path: Path) -> dict:
         }
         if context:
             edge["context"] = context
+        # `specifier` / `import_kind` travel on an import edge so
+        # `_classify_import_targets` can separate the three states without
+        # re-parsing anything.
+        edge.update(extra)
         edges.append(edge)
 
     file_nid = _make_id(str(path))
@@ -3498,7 +3757,7 @@ def extract_fortran(path: Path) -> dict:
 
     def add_edge(src: str, tgt: str, relation: str, line: int,
                  confidence: str = "EXTRACTED", weight: float = 1.0,
-                 context: str | None = None) -> None:
+                 context: str | None = None, **extra) -> None:
         edge = {
             "source": src,
             "target": tgt,
@@ -3510,6 +3769,10 @@ def extract_fortran(path: Path) -> dict:
         }
         if context:
             edge["context"] = context
+        # `specifier` / `import_kind` travel on an import edge so
+        # `_classify_import_targets` can separate the three states without
+        # re-parsing anything.
+        edge.update(extra)
         edges.append(edge)
 
     file_nid = _make_id(str(path))
@@ -3670,7 +3933,7 @@ def extract_go(path: Path) -> dict:
 
     def add_edge(src: str, tgt: str, relation: str, line: int,
                  confidence: str = "EXTRACTED", weight: float = 1.0,
-                 context: str | None = None) -> None:
+                 context: str | None = None, **extra) -> None:
         edge = {
             "source": src,
             "target": tgt,
@@ -3682,6 +3945,10 @@ def extract_go(path: Path) -> dict:
         }
         if context:
             edge["context"] = context
+        # `specifier` / `import_kind` travel on an import edge so
+        # `_classify_import_targets` can separate the three states without
+        # re-parsing anything.
+        edge.update(extra)
         edges.append(edge)
 
     file_nid = _make_id(str(path))
@@ -3898,7 +4165,7 @@ def extract_rust(path: Path) -> dict:
 
     def add_edge(src: str, tgt: str, relation: str, line: int,
                  confidence: str = "EXTRACTED", weight: float = 1.0,
-                 context: str | None = None) -> None:
+                 context: str | None = None, **extra) -> None:
         edge = {
             "source": src,
             "target": tgt,
@@ -3910,6 +4177,10 @@ def extract_rust(path: Path) -> dict:
         }
         if context:
             edge["context"] = context
+        # `specifier` / `import_kind` travel on an import edge so
+        # `_classify_import_targets` can separate the three states without
+        # re-parsing anything.
+        edge.update(extra)
         edges.append(edge)
 
     file_nid = _make_id(str(path))
@@ -3963,11 +4234,16 @@ def extract_rust(path: Path) -> dict:
             arg = node.child_by_field_name("argument")
             if arg:
                 raw = _read_text(arg, source)
-                clean = raw.split("{")[0].rstrip(":").rstrip("*").rstrip(":")
-                module_name = clean.split("::")[-1].strip()
-                if module_name:
-                    tgt_nid = _make_id(module_name)
-                    add_edge(file_nid, tgt_nid, "imports_from", node.start_point[0] + 1, context="import")
+                tgt_nid, kind, label = _rust_use_target(
+                    raw, path, _rust_inside_inline_mod(node))
+                # A `use super::*` inside an inline `mod tests` resolves to
+                # this very file. That is not an inter-file dependency, so no
+                # self-loop is written; `test_import_states.py` pins the
+                # absence so it stays a decision rather than an accident.
+                if tgt_nid and tgt_nid != file_nid:
+                    add_edge(file_nid, tgt_nid, "imports_from",
+                             node.start_point[0] + 1, context="import",
+                             specifier=label, import_kind=kind)
             return
 
         for child in node.children:
@@ -4111,8 +4387,12 @@ def extract_zig(path: Path) -> dict:
                             module_name = raw.split("/")[-1].split(".")[0]
                             if module_name:
                                 tgt_nid = _make_id(module_name)
+                                # `@import("std")` is a third party;
+                                # `@import("./foo.zig")` must resolve here.
                                 add_edge(file_nid, tgt_nid, "imports_from",
-                                         node.start_point[0] + 1)
+                                         node.start_point[0] + 1,
+                                         specifier=raw,
+                                         import_kind=_import_kind_from_specifier(raw))
                             return
             elif child.type == "field_expression":
                 _extract_import(child)
@@ -4520,6 +4800,146 @@ def _rewire_unique_stub_nodes(nodes: list[dict], edges: list[dict]) -> None:
             edge["target"] = remap[str(edge["target"])]
 
     nodes[:] = [node for node in nodes if node.get("id") not in drop_ids]
+
+
+#: The relations whose target names a module. Not derived from
+#: `relations.RELATIONS`: that vocabulary is every relation the extractor can
+#: emit, and only these five name an import target. Counted from the tree, not
+#: assumed — `test_import_states.py` pins this set against the vocabulary so a
+#: sixth import relation cannot join it without someone saying which side it
+#: belongs on.
+_IMPORT_RELATIONS = frozenset({
+    "imports", "imports_from", "dynamic_import", "re_exports", "includes",
+})
+
+
+def _classify_import_targets(
+    nodes: list[dict], edges: list[dict]
+) -> dict[str, int]:
+    """Separate the three import states, and emit the target each edge names.
+
+    Every `_import_*` handler is handed `edges` but NOT `nodes`, so it cannot
+    emit the target it names: the edge gets written, the node never does, and
+    the map is left with an edge pointing at nothing. All 894 dangling edges on
+    base's own tree at `0acd6e85` were that one shape, and zero nodes carried
+    an external type because there was nowhere for one to come from.
+
+    This runs where the whole tree is known, which is the only place the
+    question can be answered honestly:
+
+      * target is already a node   -> RESOLVED, emit nothing.
+      * absent, specifier internal -> FAILED TO RESOLVE. A node typed
+                                      `import_unresolved`, counted, and
+                                      reported — a failure reported AS a
+                                      failure, not filed as third-party.
+      * absent, specifier external -> genuinely THIRD PARTY, typed
+                                      `import_external`.
+      * absent, no kind recorded   -> UNCLASSIFIED: counted and reported, never
+                                      guessed into one of the three.
+
+    Returns the per-state counts. They are reported by `base sync --ast`,
+    because a single dangling total cannot tell a fix from a suppression: an
+    extractor that stopped emitting scores the same zero as one that resolved
+    everything.
+    """
+    existing = {n["id"] for n in nodes}
+
+    # A bare specifier is placed by the TREE, not by the parser — and only when
+    # the name matches EXACTLY ONE file. Binding a bare name that several files
+    # share is the #66 collapse (`mod.rs`, `index.ts`, `__init__.py` all
+    # colliding onto whichever was extracted last), so a name with two
+    # candidates is never silently bound to one of them.
+    stems: dict[str, list[str]] = {}
+    for n in nodes:
+        label = str(n.get("label") or "")
+        suffix = Path(label).suffix.lower()
+        if suffix and suffix in _DISPATCH:
+            stems.setdefault(Path(label).stem.lower(), []).append(n["id"])
+
+    counts = {"resolved": 0, "failed": 0, "external": 0, "resolved_unparsed": 0,
+              "ambiguous_multi": 0, "unclassified": 0}
+    emit: dict[str, dict] = {}
+
+    for edge in edges:
+        if edge.get("relation") not in _IMPORT_RELATIONS:
+            continue
+        target = edge.get("target")
+        if not target:
+            continue
+        if target in existing:
+            counts["resolved"] += 1
+            continue
+
+        kind = edge.get("import_kind")
+        specifier = edge.get("specifier") or ""
+
+        if kind == IMPORT_KIND_AMBIGUOUS:
+            # The module is the LAST segment of a dotted or slashed specifier:
+            # `os.path` -> `path`, `@scope/pkg` -> `pkg`.
+            leaf = specifier.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+            if "." in leaf:
+                leaf = leaf.rsplit(".", 1)[-1]
+            candidates = stems.get(leaf.lower(), [])
+            if len(candidates) == 1:
+                # The tree placed it: this is a first-party import that the
+                # syntax could not distinguish from a third-party one.
+                edge["target"] = candidates[0]
+                counts["resolved"] += 1
+                continue
+            if len(candidates) > 1:
+                # Two files could be meant and nothing here can choose. Counted
+                # in its own bucket and reported, then carried as third-party so
+                # the edge still names something that exists.
+                counts["ambiguous_multi"] += 1
+            kind = IMPORT_KIND_EXTERNAL
+
+        if kind == IMPORT_KIND_INTERNAL:
+            # An import can resolve to a real file that this extractor does not
+            # parse — `import './app.css'`. The import WORKS; the target is
+            # simply not a mapped language. Reporting that as a broken import
+            # would be a fresh false claim of exactly the kind this change
+            # exists to remove, so it is counted as resolved and the target is
+            # emitted for what it is.
+            on_disk = edge.get("resolved_path") or ""
+            if on_disk and Path(on_disk).suffix.lower() not in _DISPATCH:
+                counts["resolved"] += 1
+                counts["resolved_unparsed"] = counts.get("resolved_unparsed", 0) + 1
+                node_type = IMPORT_TYPE_UNPARSED
+            else:
+                counts["failed"] += 1
+                node_type = IMPORT_TYPE_UNRESOLVED
+        elif kind == IMPORT_KIND_EXTERNAL:
+            counts["external"] += 1
+            node_type = IMPORT_TYPE_EXTERNAL
+        else:
+            counts["unclassified"] += 1
+            continue
+
+        prev = emit.get(target)
+        if prev is None:
+            emit[target] = {
+                "id": target,
+                "label": specifier or target,
+                "type": node_type,
+                "file_type": "import",
+                # The IMPORTING file, never the app root. `'../lib/api.js'`
+                # was filed against the app root at line 0 precisely because
+                # nothing carried the importer's own provenance this far.
+                "source_file": edge.get("source_file") or "",
+                "source_location": edge.get("source_location"),
+                "confidence": "EXTRACTED",
+            }
+        elif (prev["type"] == IMPORT_TYPE_EXTERNAL
+                and node_type == IMPORT_TYPE_UNRESOLVED):
+            # A broken import must never be hidden by another file importing
+            # the same name successfully as a third party.
+            prev["type"] = IMPORT_TYPE_UNRESOLVED
+            if specifier:
+                prev["label"] = specifier
+
+    nodes.extend(emit.values())
+    counts["nodes_emitted"] = len(emit)
+    return counts
 
 
 def _js_source_path(source_file: str, root: Path) -> Path | None:
@@ -5895,7 +6315,10 @@ def extract_elixir(path: Path) -> dict:
             module_name = _get_alias_text(arguments_node)
             if module_name:
                 tgt_nid = _make_id(module_name)
-                add_edge(file_nid, tgt_nid, "imports", line, context="import")
+                # An elixir alias is a bare module name; the tree places it.
+                add_edge(file_nid, tgt_nid, "imports", line, context="import",
+                         specifier=module_name,
+                         import_kind=IMPORT_KIND_AMBIGUOUS)
             return
 
         for child in node.children:
@@ -6142,7 +6565,10 @@ def extract_markdown(path: Path) -> dict:
                     if first_line:
                         label = f"{label} ({first_line})"
                 cb_nid = _make_id(stem, f"codeblock_{code_block_count}")
-                add_node(cb_nid, label, code_block_start)
+                # A fenced block is a code SAMPLE, not a definition. Untyped it
+                # reached the map as `ops:Function`, so `ast query --contains`
+                # answered with 214 of them on base's own docs.
+                add_node(cb_nid, label, code_block_start, type="code_block")
                 # Attach to nearest heading or file
                 parent = heading_stack[-1][1] if heading_stack else file_nid
                 add_edge(parent, cb_nid, "contains", code_block_start)
@@ -6161,7 +6587,11 @@ def extract_markdown(path: Path) -> dict:
             # Avoid duplicate heading IDs by appending line number
             if h_nid in seen_ids:
                 h_nid = _make_id(stem, title, str(line_num))
-            add_node(h_nid, title, line_num)
+            # #105's first shape: a heading is a section of prose, and it was
+            # reaching the map untyped, so the serializer declared it callable
+            # — `fn Need an official Svelte framework?`. 591 of them on base's
+            # own tree.
+            add_node(h_nid, title, line_num, type="heading")
 
             # Pop headings at same or deeper level
             while heading_stack and heading_stack[-1][0] >= level:
@@ -7344,14 +7774,21 @@ def extract_json(path: Path) -> dict:
         "optionalDependencies", "bundleDependencies", "bundledDependencies",
     })
 
-    def add_node(nid: str, label: str, line: int) -> None:
+    def add_node(nid: str, label: str, line: int,
+                 node_type: str = "property") -> None:
         if nid and nid not in seen_ids:
             seen_ids.add(nid)
-            nodes.append({"id": nid, "label": label, "file_type": "code",
+            # A JSON key is a PROPERTY of an object. It was reaching the map
+            # with no type at all, so the serializer's default declared it a
+            # callable: `fn node_modules/@esbuild/aix-ppc64` from a
+            # `package-lock.json` key, one of #105's four shapes. Whatever a
+            # key is, it is never a function.
+            nodes.append({"id": nid, "label": label, "type": node_type,
+                          "file_type": "code",
                           "source_file": str_path, "source_location": f"L{line}"})
 
     def add_edge(src: str, tgt: str, relation: str, line: int,
-                 context: str | None = None) -> None:
+                 context: str | None = None, **extra) -> None:
         if not src or not tgt or src == tgt:
             return
         edge = {"source": src, "target": tgt, "relation": relation,
@@ -7359,10 +7796,11 @@ def extract_json(path: Path) -> dict:
                 "source_location": f"L{line}", "weight": 1.0}
         if context:
             edge["context"] = context
+        edge.update(extra)
         edges.append(edge)
 
     file_nid = _make_id(str(path))
-    add_node(file_nid, path.name, 1)
+    add_node(file_nid, path.name, 1, node_type="module")
 
     def _key_text(pair_node) -> str | None:
         """Extract the string content of a pair's key."""
@@ -7440,7 +7878,13 @@ def extract_json(path: Path) -> dict:
                 elif parent_key in _DEP_KEYS and val_text:
                     dep_nid = _make_id(key)
                     if dep_nid:
-                        add_edge(key_nid, dep_nid, "imports", line, context="import")
+                        # A dependency block entry IS a third party by
+                        # definition — that is what the block declares — so it
+                        # is the one import site that can say `external`
+                        # outright rather than letting the tree decide.
+                        add_edge(key_nid, dep_nid, "imports", line,
+                                 context="import", specifier=key,
+                                 import_kind=IMPORT_KIND_EXTERNAL)
 
     # Entry: find root document → object
     doc = root
@@ -7942,9 +8386,16 @@ def extract(
         where=f"{len(all_edges)} edges from {len(paths)} files under {root}",
     )
 
+    # #105: LAST, after every pass that can add an import edge — the cross-file
+    # resolvers above among them. Running it earlier would classify a tree that
+    # is still growing and leave the late arrivals dangling, which is the
+    # failure it exists to remove.
+    import_states = _classify_import_targets(all_nodes, all_edges)
+
     return {
         "nodes": all_nodes,
         "edges": all_edges,
+        "import_states": import_states,
         "input_tokens": 0,
         "output_tokens": 0,
     }

--- a/scripts/ast/extractor.py
+++ b/scripts/ast/extractor.py
@@ -4262,8 +4262,11 @@ def extract_rust(path: Path) -> dict:
                     raw, path, _rust_inside_inline_mod(node))
                 # A `use super::*` inside an inline `mod tests` resolves to
                 # this very file. That is not an inter-file dependency, so no
-                # self-loop is written; `test_import_states.py` pins the
-                # absence so it stays a decision rather than an accident.
+                # self-loop is written. It costs base's own tree 67
+                # `imports_from` edges, which is why it is pinned by
+                # `test_import_states.py::test_a_super_glob_inside_an_inline_
+                # mod_writes_no_self_loop` rather than left to this comment --
+                # an earlier draft named a test that did not exist yet.
                 if tgt_nid and tgt_nid != file_nid:
                     add_edge(file_nid, tgt_nid, "imports_from",
                              node.start_point[0] + 1, context="import",

--- a/scripts/ast/onto_ast.py
+++ b/scripts/ast/onto_ast.py
@@ -176,6 +176,44 @@ def extract_project(target: Path, project: str, full: bool = False, confirm: boo
         # the BACKGROUND refresh cannot show it to anyone, because both the Stop
         # hook (automap.rs spawn_sync) and the git hook (ast_repo.rs) discard the
         # child's output by design. See the follow-up issue on persisting notices.
+        # #105: the three import states, printed BY THE RUN. A single dangling
+        # total cannot tell a fix from a suppression — an extractor that
+        # stopped emitting scores the same zero as one that resolved
+        # everything — so each state is reported on its own, and a failure is
+        # reported AS a failure rather than filed under "external".
+        states = result.get("import_states") or {}
+        if states:
+            print(
+                "# imports: {resolved} resolved, {failed} failed to resolve, "
+                "{external} third-party".format(
+                    resolved=states.get("resolved", 0),
+                    failed=states.get("failed", 0),
+                    external=states.get("external", 0),
+                ),
+                file=sys.stderr,
+            )
+            if states.get("failed"):
+                print(
+                    f"# {states['failed']} import(s) name a path inside this tree "
+                    f"that does not resolve — these are broken imports, not "
+                    f"third-party packages",
+                    file=sys.stderr,
+                )
+            for key, note in (
+                ("resolved_unparsed", "resolved to a file this extractor does not parse"),
+                ("ambiguous_multi", "bare name matched more than one file; carried as third-party"),
+                ("unclassified", "no import_kind recorded by the extractor that emitted it"),
+            ):
+                if states.get(key):
+                    print(f"#   {states[key]} {note}", file=sys.stderr)
+        untyped = stats.get("untyped_non_code_entities", 0)
+        if untyped:
+            print(
+                f"# {untyped} non-code entit{'y' if untyped == 1 else 'ies'} had no "
+                f"kind and are typed ops:Entity (never ops:Function)",
+                file=sys.stderr,
+            )
+
         orphans = stats.get("app_root_entities", 0)
         if orphans:
             noun = "entity" if orphans == 1 else "entities"

--- a/scripts/ast/test_import_states.py
+++ b/scripts/ast/test_import_states.py
@@ -247,6 +247,27 @@ def test_a_crate_relative_rust_import_resolves_to_the_file():
     )
 
 
+def test_a_super_glob_inside_an_inline_mod_writes_no_self_loop():
+    """`use super::*` there resolves to THIS file, so no edge is written.
+
+    That is a deliberate non-emission and it costs base's own tree 67
+    `imports_from` edges, so it is pinned rather than left to a comment: an
+    inline `mod tests` importing its parent module is not a dependency between
+    two files, and a file that imports itself is not a fact about the tree.
+    `extractor.py` claimed this leg existed before the leg did, which is a
+    false capability claim about a guard and the reason this one is here.
+    """
+    run = _extract(RUST_TREE)
+    loops = [(s, r, t) for s, r, t in _import_edges(run) if s == t]
+    assert not loops, f"a file imports itself: {loops[:3]}"
+    # And the other imports on the same file are still there, so the rule
+    # removed a self-loop rather than the file's import edges.
+    assert len(_import_edges(run)) >= 3, (
+        f"the fixture imports three crates and a module; only "
+        f"{len(_import_edges(run))} import edge(s) survived"
+    )
+
+
 def test_a_super_glob_inside_an_inline_mod_is_not_a_failure():
     """`use super::*` in a `#[cfg(test)] mod tests` is a working import.
 

--- a/scripts/ast/test_import_states.py
+++ b/scripts/ast/test_import_states.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""An import has three states and they are never collapsed to one (#105).
+
+`base ast query` could not tell these apart, because nothing in the pipeline
+carried the difference:
+
+  RESOLVED     the specifier names a file in this tree, and it is there.
+  FAILED       the specifier names a path INSIDE this tree that is not there.
+               A broken import. Reporting it as third-party cements a lookup
+               failure as a deliberate taxonomy, which is #105's second half.
+  THIRD PARTY  the specifier names a package, crate or stdlib module that was
+               never supposed to be in this tree.
+
+Two mechanisms produced the defect and both are pinned here.
+
+  * Every `_import_*` handler is handed `edges` but NOT `nodes`, so it could
+    not emit the target it named. 810 import edges on base's own tree pointed
+    at nothing, and no node anywhere carried an external type -- there was
+    nowhere for one to come from.
+  * `_resolve_js_import_target` already returned whether the specifier
+    resolved, and the caller discarded it.
+
+The FAILED state is proven on a FIXTURE, deliberately. base's own tree has
+zero broken imports, so a suite that only measured base could never tell a
+working classifier from one that never reports a failure at all.
+
+Run: python3 scripts/ast/test_import_states.py   (or: pytest scripts/ast/)
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import namedtuple
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+#: `# imports: N resolved, M failed to resolve, K third-party`, printed by
+#: `onto_ast.py` on STDERR. Each state is read on its own: a single total
+#: cannot tell a fix from a suppression, because an extractor that stopped
+#: emitting scores the same zero as one that resolved everything.
+STATES = re.compile(
+    r"^# imports: (\d+) resolved, (\d+) failed to resolve, (\d+) third-party",
+    re.M,
+)
+
+Run = namedtuple("Run", "ttl notices")
+
+
+def _extract(tree: dict[str, str]) -> Run:
+    """Write `tree` to a fixture repo, extract it, return both raw streams.
+
+    NOT under /tmp: file discovery drops any path with a `tmp` component, so a
+    fixture there extracts to nothing and every assertion below would pass
+    against an empty map.
+    """
+    with tempfile.TemporaryDirectory(prefix="base-ast-i105-", dir=Path.home()) as td:
+        root = Path(td)
+        for rel, body in tree.items():
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+        subprocess.run(["git", "init", "-q"], cwd=str(root), check=True)
+        proc = subprocess.run(
+            [sys.executable, str(HERE / "onto_ast.py"), str(root),
+             "--project", "t", "--full"],
+            capture_output=True, text=True, cwd=str(HERE),
+            env=os.environ.copy(), timeout=300,
+        )
+        assert proc.returncode == 0, f"extraction failed:\n{proc.stderr}"
+        run = Run(proc.stdout, proc.stderr)
+    # Law 24. An empty map must never read as a clean one: "no broken imports"
+    # and "nothing was parsed" are the same output with different meanings.
+    assert "a ops:" in run.ttl, "extraction produced no entities; the fixture never parsed"
+    assert "# Extracting" in run.notices, (
+        "the extractor's notice stream is empty, so every state count below "
+        f"would read a false zero. stderr was:\n{run.notices!r}"
+    )
+    return run
+
+
+def _states(run: Run) -> dict[str, int]:
+    """The three counts, read from the stream whose presence `_extract` proved."""
+    m = STATES.search(run.notices)
+    assert m, (
+        "the run printed no import-state line at all, so no claim about the "
+        f"three states can rest on it. stderr was:\n{run.notices!r}"
+    )
+    return {"resolved": int(m.group(1)), "failed": int(m.group(2)),
+            "external": int(m.group(3))}
+
+
+def _typed(run: Run, ops_type: str) -> list[str]:
+    """Labels of every node the map declares as `ops:<ops_type>`."""
+    out = []
+    for block in run.ttl.split("\n\n"):
+        if f" a ops:{ops_type} ;" not in block:
+            continue
+        m = re.search(r'^    rdfs:label "(.*)" ;$', block, re.M)
+        if m:
+            out.append(m.group(1))
+    return out
+
+
+def _import_edges(run: Run) -> list[tuple[str, str, str]]:
+    return re.findall(
+        r"^(code:\S+) ops:(importsFrom|imports|dynamicImport|reExports|includes) (code:\S+) \.$",
+        run.ttl, re.M,
+    )
+
+
+def _declared(run: Run) -> set[str]:
+    return set(re.findall(r"^(code:\S+) a ops:\w+ ;", run.ttl, re.M))
+
+
+# ─── the three states ────────────────────────────────────────────────────────
+
+PY_BROKEN = {
+    "pkg/__init__.py": "",
+    "pkg/main.py": "from .gone import missing\nimport json\nfrom pkg.helper import thing\n",
+    "pkg/helper.py": "def thing():\n    return 1\n",
+}
+
+
+def test_a_relative_import_that_does_not_resolve_is_reported_as_failed():
+    run = _extract(PY_BROKEN)
+    assert _states(run)["failed"] >= 1, (
+        "`from .gone import missing` names a path inside the tree that is not "
+        "there. That is a broken import and the run must say so; filing it "
+        "under third-party is the defect #105 was opened for"
+    )
+    labels = _typed(run, "UnresolvedImport")
+    assert labels, "no node carries ops:UnresolvedImport, so the failure has no target"
+
+
+def test_a_third_party_import_is_external_and_not_a_failure():
+    run = _extract(PY_BROKEN)
+    assert "json" in [l.rsplit(".", 1)[-1] for l in _typed(run, "ExternalModule")], (
+        "`import json` is stdlib and must be typed as an external module"
+    )
+
+
+def test_a_first_party_bare_import_is_placed_by_the_tree():
+    """`from pkg.helper import thing` is spelled exactly like a third party.
+
+    Syntax cannot tell them apart, so the TREE decides. A classifier that
+    called every bare name external would report this as third-party, which is
+    the same error as calling a broken relative path external.
+    """
+    run = _extract(PY_BROKEN)
+    assert "helper" not in _typed(run, "ExternalModule"), (
+        "`helper` is a file in the fixture, so this import resolved; calling "
+        "it third-party would be a false claim about the tree"
+    )
+
+
+def test_the_three_states_are_separately_countable():
+    """auk's binding condition: never one total. Each state on its own."""
+    run = _extract(PY_BROKEN)
+    s = _states(run)
+    assert s["failed"] >= 1 and s["external"] >= 1 and s["resolved"] >= 1, (
+        f"all three states must be separately non-zero on this fixture, got {s}"
+    )
+
+
+def test_the_fix_cannot_pass_by_dropping_the_edge():
+    """Law 25: the leg that the fix could have MASKED.
+
+    Deleting the offending edge would satisfy "no import target is a callable"
+    and "nothing dangles" identically. So the broken import must still be
+    PRESENT as an edge, and still be counted as a failure.
+    """
+    run = _extract(PY_BROKEN)
+    unresolved = [t for _, _, t in _import_edges(run)
+                  if t in _declared(run)
+                  and any(f"{t} a ops:UnresolvedImport ;" in b
+                          for b in run.ttl.split("\n\n"))]
+    assert unresolved, (
+        "the broken import has no edge left. A fix that drops the edge passes "
+        "every count in this file and loses the finding, which is worse than "
+        "the defect"
+    )
+    assert _states(run)["failed"] >= 1
+
+
+def test_no_import_edge_dangles_after_classification():
+    run = _extract(PY_BROKEN)
+    declared = _declared(run)
+    dangling = [(s, r, t) for s, r, t in _import_edges(run) if t not in declared]
+    assert not dangling, (
+        f"{len(dangling)} import edge(s) still name a target that is emitted as "
+        f"no node: {dangling[:3]}"
+    )
+
+
+# ─── rust: the crate is the identity, not the last path segment ──────────────
+
+RUST_TREE = {
+    "src/main.rs": (
+        "use oxigraph::model::NamedNode;\n"
+        "use serde::Serialize;\n"
+        "use anyhow::Context;\n"
+        "use crate::helper::helped;\n"
+        "fn main() { let _ = helped(); }\n"
+        "#[cfg(test)]\nmod tests {\n    use super::*;\n"
+        "    #[test]\n    fn t() { let _ = helped(); }\n}\n"
+    ),
+    "src/helper.rs": "pub fn helped() -> u8 { 1 }\n",
+}
+
+
+def test_a_rust_use_names_the_crate_not_the_last_segment():
+    """auk's condition 2: assert the NAMES, not just the total.
+
+    `use oxigraph::model::NamedNode` used to record an edge to a node called
+    `model` -- a path segment nobody wrote, which existed as no node and so
+    dangled. 718 of base's own 894 dangling edges were this. A rewire that
+    produced 718 plausible-but-wrong ids would pass a pure count check
+    identically, so the crates are named here.
+    """
+    run = _extract(RUST_TREE)
+    externals = set(_typed(run, "ExternalModule"))
+    for crate in ("oxigraph", "serde", "anyhow"):
+        assert crate in externals, (
+            f"{crate!r} is a crate this fixture imports and must appear as an "
+            f"external module BY NAME; got {sorted(externals)}"
+        )
+    assert "model" not in externals, (
+        "`model` is a path SEGMENT inside oxigraph, not a thing anyone imported"
+    )
+
+
+def test_a_crate_relative_rust_import_resolves_to_the_file():
+    run = _extract(RUST_TREE)
+    assert "crate::helper::helped" not in _typed(run, "UnresolvedImport"), (
+        "`use crate::helper::helped` names src/helper.rs, which exists, so it "
+        "resolved. Item names are not modules: resolution walks the path from "
+        "the longest prefix down"
+    )
+    assert "helper" not in set(_typed(run, "ExternalModule")), (
+        "a `crate::` import is internal by construction and must never be "
+        "filed as third-party"
+    )
+
+
+def test_a_super_glob_inside_an_inline_mod_is_not_a_failure():
+    """`use super::*` in a `#[cfg(test)] mod tests` is a working import.
+
+    Measured while building this: a first pass reported 73 failures on base's
+    own tree and 72 of them were this one line, because stripping the glob
+    leaves no segments to resolve. Reporting 72 working imports as broken
+    would have been a fresh false claim inside the fix.
+    """
+    run = _extract(RUST_TREE)
+    assert _states(run)["failed"] == 0, (
+        f"this fixture has no broken imports, got {_states(run)}"
+    )
+
+
+# ─── resolved, but to a file this extractor does not parse ───────────────────
+
+def test_a_resolved_but_unparsed_target_is_not_a_failure():
+    """`import './style.css'` works. The target is just not a mapped language.
+
+    Calling it broken would be the same class of false claim as filing a
+    broken relative path under external, so it is counted as RESOLVED and the
+    target is emitted for what it is.
+    """
+    run = _extract({
+        "app/main.js": "import './style.css';\nexport function go() { return 1; }\n",
+        "app/style.css": "body { color: red }\n",
+    })
+    assert _states(run)["failed"] == 0, (
+        f"a css import resolves on disk and must not be reported broken, "
+        f"got {_states(run)}"
+    )
+    assert "./style.css" in _typed(run, "UnparsedFile"), (
+        "the target resolved to a real file and must be emitted as one"
+    )
+
+
+# ─── the vocabulary cannot drift away from the classifier ────────────────────
+
+def test_the_import_relation_set_is_pinned_to_the_vocabulary():
+    from extractor import _IMPORT_RELATIONS
+    from relations import _RELATION_NAMES
+
+    unknown = _IMPORT_RELATIONS - _RELATION_NAMES
+    assert not unknown, (
+        f"{sorted(unknown)} is classified as an import relation but is not in "
+        f"the vocabulary; one of the two is wrong"
+    )
+    # A sixth import relation must not be able to join the vocabulary and
+    # quietly skip classification -- that is how 19 relations were silently
+    # dropped in #107.
+    smells = {n for n in _RELATION_NAMES
+              if "import" in n or "include" in n or "export" in n}
+    unclassified = smells - _IMPORT_RELATIONS
+    assert not unclassified, (
+        f"relation(s) {sorted(unclassified)} look like imports but are not in "
+        f"_IMPORT_RELATIONS. Decide: does the relation NAME a module target? "
+        f"Then add it there, so its targets get classified instead of dangling"
+    )
+
+
+# ─── law 24: the control that separates "clean" from "could not run" ─────────
+
+def test_an_empty_extraction_cannot_read_as_a_clean_one():
+    """The harness itself must refuse a run that proved nothing.
+
+    Every assertion in this file is of the form "no import is mis-stated". All
+    of them pass over an empty map. So the guard belongs in the harness, and
+    this leg proves the guard fires rather than assuming it.
+    """
+    try:
+        _extract({"README.txt": "not a parsed language\n"})
+    except AssertionError as exc:
+        # Two gates can catch it and either is a pass: the extractor exits
+        # non-zero on a tree it could not parse, and the harness refuses a map
+        # with no entities. What must NOT happen is the run being accepted.
+        msg = str(exc)
+        assert ("no entities" in msg or "extraction failed" in msg), (
+            f"the harness rejected the empty run for an unrelated reason, so "
+            f"it is not the guard this leg claims to prove: {msg[:200]}"
+        )
+        return
+    raise AssertionError(
+        "an extraction with no entities was accepted; every leg in this file "
+        "would then pass on a map that contains nothing"
+    )
+
+
+if __name__ == "__main__":
+    # Every leg runs even after one fails, and the exit code is the run's.
+    # CI runs this file as plain `python <file>` with no pytest installed
+    # (`ci.yml`, the `scripts/ast/test_*.py` step), so a bare `def test_` with
+    # no driver here would be DEFINED, never CALLED, and the job would go
+    # green having executed nothing.
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    rc = 0
+    executed = 0
+    for t in tests:
+        executed += 1
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except Exception as exc:
+            rc = 1
+            first = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+            print(f"FAIL {t.__name__}: {first}")
+    # Law 23: print what was CHECKED, and a checked count of zero is a failure
+    # that says "this proved nothing" -- never a pass.
+    print(f"ran {executed} of {len(tests)} legs; rc={rc}")
+    if executed == 0:
+        print("VOID: zero legs executed, so this file proved nothing")
+        sys.exit(2)
+    sys.exit(rc)

--- a/scripts/ast/test_node_kinds.py
+++ b/scripts/ast/test_node_kinds.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""A heading is not a callable, prose is not a const, a key is not a function (#105).
+
+`ttl_serializer.py`'s type fallback was the literal `"function"`, and ZERO of
+the 5048 nodes on base's own tree carried the `type` key it reads first. So
+every node no edge could classify was declared `ops:Function`, and
+`ast query --contains` answered with it:
+
+    CHANGELOG.md:1                  fn Changelog
+    dashboard/package-lock.json:19  fn node_modules/@esbuild/aix-ppc64
+    scripts/ast/cache.py:43         const Strip YAML frontmatter from Markdown ...
+
+591 markdown headings, 214 fenced code blocks and 55 lockfile keys on base's
+own docs. The fix is in two halves and BOTH are needed: the extractor that
+parsed the thing says what it is, and the serializer stops inventing
+`function` for everything else.
+
+The direction of the failure is the reason this file exists: every assertion
+here is "X is not declared a callable", and all of them pass over a map that
+contains nothing at all. The law-24 control at the bottom is what makes the
+rest of the file mean anything.
+
+Run: python3 scripts/ast/test_node_kinds.py   (or: pytest scripts/ast/)
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import namedtuple
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+Run = namedtuple("Run", "ttl notices")
+
+FIXTURE = {
+    "README.md": (
+        "# Top Heading\n\n"
+        "Some prose.\n\n"
+        "## Need an official Svelte framework?\n\n"
+        "```bash\ncp -r claude/skills/base-help ~/.claude/skills/\n```\n"
+    ),
+    "package-lock.json": (
+        '{\n  "name": "fixture",\n  "packages": {\n'
+        '    "node_modules/base64-js": { "version": "1.5.1" }\n  },\n'
+        '  "dependencies": { "base64-js": "^1.5.1" }\n}\n'
+    ),
+    "mod.py": (
+        '"""Strip YAML frontmatter from Markdown content, returning only the body."""\n'
+        "def strip_it():\n"
+        '    """Normalize path for consistent cache keys."""\n'
+        "    return 1\n"
+    ),
+}
+
+
+def _extract(tree: dict[str, str]) -> Run:
+    """As `test_file_membership_walk.py`: a real repo, the real entry point.
+
+    NOT under /tmp -- file discovery drops any path with a `tmp` component, so
+    a fixture there extracts to nothing and every leg passes on an empty map.
+    """
+    with tempfile.TemporaryDirectory(prefix="base-ast-k105-", dir=Path.home()) as td:
+        root = Path(td)
+        for rel, body in tree.items():
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+        subprocess.run(["git", "init", "-q"], cwd=str(root), check=True)
+        proc = subprocess.run(
+            [sys.executable, str(HERE / "onto_ast.py"), str(root),
+             "--project", "t", "--full"],
+            capture_output=True, text=True, cwd=str(HERE),
+            env=os.environ.copy(), timeout=300,
+        )
+        assert proc.returncode == 0, f"extraction failed:\n{proc.stderr}"
+        run = Run(proc.stdout, proc.stderr)
+    assert "a ops:" in run.ttl, "extraction produced no entities; the fixture never parsed"
+    assert "# Extracting" in run.notices, (
+        f"the notice stream is empty. stderr was:\n{run.notices!r}"
+    )
+    return run
+
+
+def _blocks(run: Run) -> list[tuple[str, str, str]]:
+    """(iri, ops_type, label) per subject block.
+
+    Read from each subject's OWN block, never by nearest-preceding-line across
+    the file (law 33: proximity is not attribution).
+    """
+    out = []
+    for block in run.ttl.split("\n\n"):
+        m = re.search(r"^(code:\S+) a ops:(\w+) ;", block, re.M)
+        if not m:
+            continue
+        lab = re.search(r'^    rdfs:label "(.*)" ;$', block, re.M)
+        out.append((m.group(1), m.group(2), lab.group(1) if lab else ""))
+    return out
+
+
+def _type_of(run: Run, label: str) -> str:
+    for _, ops_type, lab in _blocks(run):
+        if lab == label:
+            return ops_type
+    raise AssertionError(
+        f"no node in the map is labelled {label!r}, so nothing can be asserted "
+        f"about its type. Labels present: "
+        f"{[l for _, _, l in _blocks(run)][:12]}"
+    )
+
+
+CALLABLE = ("Function", "Method")
+
+
+def test_a_markdown_heading_is_not_a_callable():
+    run = _extract(FIXTURE)
+    for heading in ("Top Heading", "Need an official Svelte framework?"):
+        got = _type_of(run, heading)
+        assert got not in CALLABLE, f"heading {heading!r} is declared ops:{got}"
+        assert got == "Heading", f"heading {heading!r} is declared ops:{got}"
+
+
+def test_the_heading_is_still_emitted_at_all():
+    """Law 25: the leg the fix could have MASKED.
+
+    "No heading is declared a callable" is satisfied perfectly by an extractor
+    that stopped emitting headings. The count must stay, and only the class may
+    change -- `src/hook/automap.rs` counts these entities for its adoption
+    fuse, so dropping them would move a number in an unrelated feature.
+    """
+    run = _extract(FIXTURE)
+    headings = [l for _, t, l in _blocks(run) if t == "Heading"]
+    assert len(headings) >= 2, (
+        f"the fixture has two headings and the map has {len(headings)}; a fix "
+        f"that stops emitting them passes every other leg in this file"
+    )
+
+
+def test_a_fenced_code_block_is_not_a_callable():
+    run = _extract(FIXTURE)
+    blocks = [(t, l) for _, t, l in _blocks(run) if l.startswith("code:")]
+    assert blocks, "the fixture's fenced block produced no node at all"
+    for ops_type, label in blocks:
+        assert ops_type == "CodeBlock", f"{label!r} is declared ops:{ops_type}"
+
+
+def test_a_lockfile_key_is_not_a_callable():
+    """`fn node_modules/base64-js` -- a directory path typed as a function."""
+    run = _extract(FIXTURE)
+    got = _type_of(run, "node_modules/base64-js")
+    assert got not in CALLABLE, f"a lockfile key is declared ops:{got}"
+    assert got == "Property", f"a JSON key is a property, got ops:{got}"
+
+
+def test_docstring_prose_is_not_a_const():
+    """A docstring is prose. It was rendering as `const` in the query.
+
+    The class stays `ops:Rationale` -- the graph legitimately holds these, and
+    they carry `rationale_for` edges. What changed is that the query no longer
+    calls it a constant, and #563 had already established in-tree that
+    rationale labels are not identifiers.
+    """
+    run = _extract(FIXTURE)
+    prose = [(t, l) for _, t, l in _blocks(run)
+             if l.startswith("Strip YAML frontmatter")]
+    assert prose, "the module docstring produced no node"
+    for ops_type, label in prose:
+        assert ops_type == "Rationale", f"{label[:40]!r} is declared ops:{ops_type}"
+        assert ops_type not in CALLABLE
+
+
+def test_a_file_node_is_still_a_module():
+    """The JSON extractor types its keys, and its FILE node must not follow.
+
+    A file's identity comes from `file_map`, which is stronger evidence than
+    any per-node hint, so it wins over an explicit type. Without that, typing
+    JSON keys would have retyped every `.json` file node along with them.
+    """
+    run = _extract(FIXTURE)
+    for name in ("package-lock.json", "README.md", "mod.py"):
+        got = _type_of(run, name)
+        assert got == "Module", f"file node {name!r} is declared ops:{got}"
+
+
+def test_the_serializer_reports_what_it_could_not_type():
+    """"I do not know what this is" and "this is a function" are different claims.
+
+    Only one of them was being made. A non-code node that reaches the
+    serializer with no kind is now `ops:Entity` AND counted, because a
+    fallback nobody counts is how 860 non-symbols came to be callable without
+    anyone noticing.
+    """
+    from ttl_serializer import TYPE_MAP, serialize
+
+    ttl = serialize(
+        {"nodes": [{"id": "x", "label": "mystery", "file_type": "document"}],
+         "edges": []},
+        "t", "t.md", "markdown", file_map={}, stats=(stats := {}),
+    )
+    assert "a ops:Entity ;" in ttl, (
+        f"an untyped non-code node must be declared ops:Entity, got:\n{ttl}"
+    )
+    assert "a ops:Function ;" not in ttl
+    assert stats.get("untyped_non_code_entities") == 1, (
+        f"the fallback must be counted, got {stats!r}"
+    )
+    assert "entity" in TYPE_MAP
+
+
+def test_an_unknown_node_type_fails_loudly_instead_of_defaulting():
+    """#107's ruling, applied to node types: raise where it used to default.
+
+    A silent default is what made every unclassifiable node a function. A type
+    the map has no class for is a programming error in the seam, and it now
+    names the file to edit rather than shipping a wrong class.
+    """
+    from ttl_serializer import serialize
+
+    try:
+        serialize(
+            {"nodes": [{"id": "x", "label": "y", "type": "no_such_kind",
+                        "file_type": "code"}],
+             "edges": []},
+            "t", "t.py", "python", file_map={},
+        )
+    except KeyError as exc:
+        assert "TYPE_MAP" in str(exc), f"the raise must name the fix: {exc}"
+        return
+    # An unknown explicit type currently falls through to the code default,
+    # which is a silent reclassification rather than a loud stop.
+    raise AssertionError(
+        "an unknown node type was serialized without a word; a type with no "
+        "ops: class must stop the run and name TYPE_MAP"
+    )
+
+
+def test_an_empty_extraction_cannot_read_as_a_clean_one():
+    """Law 24. Every other leg here passes over a map containing nothing."""
+    try:
+        _extract({"notes.txt": "not a parsed language\n"})
+    except AssertionError as exc:
+        # Two gates can catch it and either is a pass: the extractor exits
+        # non-zero on a tree it could not parse, and the harness refuses a map
+        # with no entities. What must NOT happen is the run being accepted.
+        msg = str(exc)
+        assert ("no entities" in msg or "extraction failed" in msg), (
+            f"the harness rejected the empty run for an unrelated reason, so "
+            f"it is not the guard this leg claims to prove: {msg[:200]}"
+        )
+        return
+    raise AssertionError(
+        "an extraction with no entities was accepted; 'no callable is a "
+        "heading' is then true of a map with no headings and no callables"
+    )
+
+
+if __name__ == "__main__":
+    # CI runs this as plain `python <file>` with no pytest installed, so the
+    # driver is not optional: bare `def test_` functions would be defined,
+    # called by nothing, and the job would go green having executed zero.
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    rc = 0
+    executed = 0
+    for t in tests:
+        executed += 1
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except Exception as exc:
+            rc = 1
+            first = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+            print(f"FAIL {t.__name__}: {first}")
+    print(f"ran {executed} of {len(tests)} legs; rc={rc}")
+    if executed == 0:
+        print("VOID: zero legs executed, so this file proved nothing")
+        sys.exit(2)
+    sys.exit(rc)

--- a/scripts/ast/ttl_serializer.py
+++ b/scripts/ast/ttl_serializer.py
@@ -74,6 +74,22 @@ TYPE_MAP = {
     "method": "Method",
     "import": "Import",
     "rationale": "Rationale",
+    # #105: the things `ast query` was answering with as if they were symbols.
+    # Each one is emitted with an explicit `type` by the extractor that knows
+    # what it parsed, because nothing downstream can recover the distinction:
+    # a markdown heading, a fenced sample and a JSON key all arrived here
+    # carrying nothing at all, and the fallback declared every one a callable.
+    "heading": "Heading",
+    "code_block": "CodeBlock",
+    "property": "Property",
+    # The three import states, kept apart in the vocabulary itself so no
+    # reader has to infer which one a node stands for.
+    "import_external": "ExternalModule",
+    "import_unresolved": "UnresolvedImport",
+    "import_unparsed": "UnparsedFile",
+    # "I do not know what this is" — a claim the map could not previously
+    # make, which is why it made the stronger and wrong one instead.
+    "entity": "Entity",
 }
 
 # #107: this was a hand-kept table of 8, written 2026-06-01, while `extractor.py`
@@ -403,6 +419,12 @@ def serialize(
             1
             for n in nodes
             if n["id"] not in file_node_ids and n["id"] not in file_membership
+            # An import target has no membership by design and is NOT
+            # app-root attributed: it carries the importing file's path. If it
+            # were counted here the number would report 40 attributions that
+            # do not happen, which is the kind of counter that survives
+            # because nobody re-derives it.
+            and not (n.get("file_type") == "import" and n.get("source_file"))
         )
         stats["app_root_entities"] = orphans
         stats["total_entities"] = len(nodes)
@@ -418,6 +440,12 @@ def serialize(
         known_iris.add(f"code:{project_clean}_{sanitize_iri(node['id'])}")
 
     lines = [_build_prefixes()]
+
+    # Nodes that reached here with no type, no explicit kind and no role, and
+    # whose file_type is not code. They are declared `ops:Entity` rather than
+    # `ops:Function`, and the count is reported: a fallback nobody counts is
+    # how 860 non-symbols came to be declared callable without anyone noticing.
+    untyped_non_code = 0
 
     module_iri = f"code:{project_clean}_{sanitize_iri(source_file)}"
     lines.append(f"{module_iri} a ops:Module ;")
@@ -454,19 +482,66 @@ def serialize(
             lines.append("")
             continue
 
-        # Infer type: explicit node type > role map > fallback to function
+        # Type precedence. Every step is load-bearing:
+        #
+        #   1. A FILE node is a module whatever anyone else says. Its identity
+        #      comes from `file_map` via `_identify_file_nodes`, which is
+        #      stronger evidence than any per-node hint.
+        #   2. Then the extractor's own explicit `type`, for what only the
+        #      emitter can know: a heading, a fenced sample, a JSON key, an
+        #      import target's resolution state.
+        #   3. Then a role inferred from edges (a class that has methods, a
+        #      rationale).
+        #   4. And then NOT "function". This line used to read
+        #      `role_map.get(node["id"], "function")`, and that literal was the
+        #      whole of #105's shapes 1, 1b and 4: 591 markdown headings, 214
+        #      fenced code blocks and 55 lockfile keys declared callable
+        #      because nothing had classified them. An untyped node is called a
+        #      callable only when the extractor says its file_type is code;
+        #      anything else is an `Entity` and is COUNTED, because "I do not
+        #      know what this is" and "this is a function" are different
+        #      claims and only one of them was being made.
         node_type = node.get("type")
-        if not node_type or node_type not in TYPE_MAP:
-            node_type = role_map.get(node["id"], "function")
-        ops_type = TYPE_MAP.get(node_type, "Function")
+        if node["id"] in file_node_ids:
+            node_type = "module"
+        elif not node_type or node_type not in TYPE_MAP:
+            node_type = role_map.get(node["id"])
+        if not node_type:
+            if node.get("file_type") == "code":
+                node_type = "function"
+            else:
+                node_type = "entity"
+                untyped_non_code += 1
+        if node_type not in TYPE_MAP:
+            raise KeyError(
+                f"node type {node_type!r} has no ops: class (node {node['id']!r} "
+                f"from {node.get('source_file')!r}). Add it to TYPE_MAP in "
+                f"ttl_serializer.py — a silent default here is the defect #105 "
+                f"was filed for."
+            )
+        ops_type = TYPE_MAP[node_type]
         iri = f"code:{project_clean}_{sanitize_iri(node['id'])}"
         label = _escape_literal(node.get("label", node["id"]))
         line_num = _extract_line(node)
         signature = node.get("signature", "")
 
-        # Gap 3: resolve per-node sourceFile with relative paths
+        # Gap 3: resolve per-node sourceFile with relative paths.
+        #
+        # #105: an import target has no file MEMBERSHIP by design — an
+        # `imports_from` edge is not containment, and #82 ruled that widening
+        # the membership walk to follow reference relations attributes a symbol
+        # to whatever happens to mention it. So the app-root fallback claimed
+        # them, and `'../lib/api.js'` was filed against the app root at line 0.
+        # It has provenance all the same: the file that imports it, recorded on
+        # the node by `_classify_import_targets`. Where several files import
+        # the same package the first one seen wins, which is an arbitrary
+        # choice between real import sites rather than a directory that
+        # imports nothing.
+        node_fallback = source_file
+        if node.get("file_type") == "import" and node.get("source_file"):
+            node_fallback = node["source_file"]
         node_source = _resolve_source_file(
-            node["id"], file_membership, node_labels, file_map, source_file
+            node["id"], file_membership, node_labels, file_map, node_fallback
         )
         # For file-level Module nodes, also use relative path as label. A module
         # node's own id IS its file-node id, so it resolves uniquely — the bare
@@ -490,6 +565,9 @@ def serialize(
             lines.append(f"    ops:definedIn {parent_iri} ;")
         lines[-1] = lines[-1].rstrip(" ;") + " ."
         lines.append("")
+
+    if stats is not None:
+        stats["untyped_non_code_entities"] = untyped_non_code
 
     for edge in edges:
         relation = edge.get("relation", "calls")

--- a/scripts/ast/ttl_serializer.py
+++ b/scripts/ast/ttl_serializer.py
@@ -501,24 +501,32 @@ def serialize(
         #      anything else is an `Entity` and is COUNTED, because "I do not
         #      know what this is" and "this is a function" are different
         #      claims and only one of them was being made.
-        node_type = node.get("type")
+        explicit = node.get("type")
         if node["id"] in file_node_ids:
             node_type = "module"
-        elif not node_type or node_type not in TYPE_MAP:
+        elif explicit:
+            # An explicit type the map has no class for is a programming error
+            # in this seam, and it STOPS the run naming the file to edit. The
+            # first draft of this block let it fall through to the code
+            # default instead — which is the same silent reclassification the
+            # whole change exists to remove, reintroduced inside the fix.
+            # `test_node_kinds.py` caught it.
+            if explicit not in TYPE_MAP:
+                raise KeyError(
+                    f"node type {explicit!r} has no ops: class (node "
+                    f"{node['id']!r} from {node.get('source_file')!r}). Add it "
+                    f"to TYPE_MAP in ttl_serializer.py — a silent default here "
+                    f"is the defect #105 was filed for."
+                )
+            node_type = explicit
+        else:
             node_type = role_map.get(node["id"])
-        if not node_type:
-            if node.get("file_type") == "code":
-                node_type = "function"
-            else:
-                node_type = "entity"
-                untyped_non_code += 1
-        if node_type not in TYPE_MAP:
-            raise KeyError(
-                f"node type {node_type!r} has no ops: class (node {node['id']!r} "
-                f"from {node.get('source_file')!r}). Add it to TYPE_MAP in "
-                f"ttl_serializer.py — a silent default here is the defect #105 "
-                f"was filed for."
-            )
+            if not node_type:
+                if node.get("file_type") == "code":
+                    node_type = "function"
+                else:
+                    node_type = "entity"
+                    untyped_non_code += 1
         ops_type = TYPE_MAP[node_type]
         iri = f"code:{project_clean}_{sanitize_iri(node['id'])}"
         label = _escape_literal(node.get("label", node["id"]))

--- a/src/crud/ast_query.rs
+++ b/src/crud/ast_query.rs
@@ -651,16 +651,42 @@ fn get_type_str(row: &oxigraph::sparql::QuerySolution, var: &str) -> String {
         .get(var)
         .map(|t| crud::term_display(t.into()))
         .unwrap_or_default();
-    // Strip namespace prefix: "Function" from "ops:Function" or full IRI
-    raw.strip_prefix("Function")
-        .map(|_| "fn")
-        .or_else(|| raw.strip_prefix("Struct").map(|_| "struct"))
-        .or_else(|| raw.strip_prefix("Class").map(|_| "class"))
-        .or_else(|| raw.strip_prefix("Method").map(|_| "method"))
-        .or_else(|| raw.strip_prefix("Module").map(|_| "mod"))
-        .or_else(|| raw.strip_prefix("Rationale").map(|_| "const"))
-        .unwrap_or("entity")
-        .to_string()
+    kind_label(&raw).to_string()
+}
+
+/// The short kind a row prints, from the class the map declares.
+///
+/// #105: this was a chain of `strip_prefix` calls, which is a PREFIX test
+/// doing an EQUALITY job — `Struct` also matches a `Structure`, and on an
+/// exact hit it returns `Some("")` and works by accident. Exact match, so a
+/// class added later cannot be silently absorbed by a shorter name.
+///
+/// `Rationale` used to render as `const`. A docstring is not a constant: it is
+/// prose, and #563 had already established in-tree that rationale labels are
+/// not identifiers. It renders as `note`.
+///
+/// The import kinds are deliberately three different words. A reader has to be
+/// able to tell "this import resolved", "this import is BROKEN" and "this is a
+/// third-party package" apart at a glance, because a map that cannot say which
+/// one it means is the defect this function is part of.
+fn kind_label(raw: &str) -> &'static str {
+    match raw {
+        "Function" => "fn",
+        "Struct" => "struct",
+        "Class" => "class",
+        "Method" => "method",
+        "Module" => "mod",
+        "Rationale" => "note",
+        "Heading" => "heading",
+        "CodeBlock" => "code",
+        "Property" => "prop",
+        "ExternalModule" => "ext",
+        "UnresolvedImport" => "unresolved",
+        "UnparsedFile" => "file",
+        "Import" => "import",
+        "Entity" => "entity",
+        _ => "entity",
+    }
 }
 
 fn query_calls(store: &oxigraph::store::Store, ns: &NamespaceConfig, entity_iri: &str) -> Vec<String> {

--- a/src/hook/automap.rs
+++ b/src/hook/automap.rs
@@ -70,8 +70,10 @@ const NOISE_DIRS: &[&str] = &[
 /// Extensions that make a bare folder a code project worth adopting.
 /// Deliberately narrower than what the extractor parses: a folder whose only
 /// "source" is a config.json is a folder, not an app.
-/// Files the extractor turns into entities that are not code: one `ops:Function` per
+/// Files the extractor turns into entities that are not code: one `ops:Heading` per
 /// markdown heading, so a content workspace counts toward the fuse like a code one (#40).
+/// (#105 retyped these from `ops:Function` — a heading is not a callable. The COUNT
+/// is unchanged, so the fuse behaves exactly as before; only the class is now true.)
 const DOC_EXTS: &[&str] = &["md", "mdx", "markdown"];
 
 const CODE_EXTS: &[&str] = &[


### PR DESCRIPTION
# Limitations and disclosures

Everything that could weaken a number below, stated above the numbers.

**1. An earlier revision of this work pre-registered a 9 → 8 duplicate-IRI side effect. That claim
was false and is retracted.** Measured here at both levels: **distinct colliding ids 9 → 9** and
**excess (sum of occurrences − 1) 17 → 17**, both unchanged. Two different quantities have both
been called "duplicates" in this backlog — 9 is how many ids appear more than once, 17 is the sum
over those ids of (occurrences − 1) — and both are printed on separate labelled lines below.
**#98 / rank 03's residual is 9, and it is not waiting on this merge.**

**2. The import state set is not three.** It is three headline states, a fourth state, and two
sub-buckets that are **not additive**. Declared here rather than folded into a total:

| | |
|---|---|
| headline, disjoint | `resolved` / `failed to resolve` / `third-party` |
| **fourth**, disjoint | `unclassified` — emits **no node**, so its edges **stay dangling** |
| sub-bucket | `resolved_unparsed` (inside `resolved`) |
| sub-bucket | `ambiguous_multi` (inside `external`) |

**3. 27 Rust tests fail on Windows at this head — and identically at main.** 23 are #129
stack-overflow corpses (**VOID, not red**); 4 are real pre-existing reds. The failure sets at
`c1108cb` and `2e5d2a4a` are **identical**, so this change neither widened nor narrowed the
surface. Diff below. The 4 real reds are main's and are filed as findings, not fixed here.

**4. The `--contains` CLI leg is not re-run at this head.** #129 means the Windows *debug* binary
cannot run `ast query` at all, so that leg is VOID on this platform rather than red. CI is
Ubuntu-only, which is the same blind spot that has kept #129 invisible.

**5. Node ids embed the corpus's absolute path.** The same tree measured on two machines yields
different ids for the same node. Counts and sets-by-label are comparable across boxes; raw ids are
not. Two measurement arms therefore had to be normalised before any per-id claim.

**6. Four instrument defects were found in my own measuring harness during this work**, all fixed,
all listed at the bottom. They share one shape and the shape is the finding.

---

## The false claim this removes

`base ast query --contains` returned things that are not symbols, **typed as symbols**. A markdown
heading came back as `fn`, a fenced code block as `fn`, a lockfile key as `fn`, a docstring as
`const`.

```
CHANGELOG.md:1                       fn Changelog
scripts\ast\cache.py:43              const Strip YAML frontmatter from Markdown content, ...
dashboard\package-lock.json:19       fn node_modules/@esbuild/aix-ppc64
<app root>:0                         fn ../lib/api.js
```

after:

```
CHANGELOG.md:1                       heading Changelog
scripts\ast\cache.py:43              note Strip YAML frontmatter from Markdown content, ...
dashboard\package-lock.json:19       prop node_modules/@esbuild/aix-ppc64
<app root>:0                         unresolved ../lib/api.js
```

## Mechanism

**Every `_import_*` handler is handed `edges` but NOT `nodes`, so it physically cannot emit the
target it names.** The edge gets written, the node never does, and the map is left with an edge
pointing at nothing.

And `ttl_serializer.py`'s type fallback was the literal `"function"`. Zero nodes carried the `type`
key it reads first, so anything no edge classified was declared a callable.

An import is not one thing. It either resolved to a file in this tree, or it was *supposed* to and
did not, or it names something outside the tree. Collapsing the middle state into the third files a
resolution FAILURE as a deliberate taxonomy. `'../lib/api.js'` is the proof: a relative path is
required to resolve inside the tree, so when it does not, the honest report is "this import is
broken", never "this is third-party".

The split is deliberate. **What the specifier demands** is syntax and only the parser sees it
(recorded on the edge as `import_kind`); **whether the target exists** is cross-file and is decided
once, in `_classify_import_targets`, after the tree is whole. Deciding either one in the other
place is how this defect happened.

---

# Pre-registered before the after-counts

### A deliberate NON-EMISSION, sized before it was measured

`use super::*` inside an inline `mod` resolves to the file it sits in. A file importing itself is
not a fact about the tree, so **no edge is written**. That is a suppression by design, and a
suppression described only by a comment is indistinguishable from a bug — so it is pinned by
`test_import_states.py::test_a_super_glob_inside_an_inline_mod_writes_no_self_loop`, which asserts
both that no self-loop survives *and* that the file keeps its other import edges.

**Predicted cost: 67 `imports_from` edges.** The census lands on **67**.

**The prediction was then re-opened rather than banked.** A prediction that hits the number can
still have the wrong reason. `use self::x::y` *also* emits no edge — it resolves internally to its
own file and reaches the same suppression — so the non-emission family has **two** members in the
code and all 67 had been attributed to one. Each of the 67 unpaired edges was therefore traced to
its **actual source line on disk**:

| source line | count |
|---|---:|
| `use super::` | **67** |
| `use self::` | 0 |
| `use crate::` | 0 |
| anything else | 0 |

Samples: `src/apply_ops.rs:481`, `src/changelog.rs:469`, `src/command.rs:182`, all `use super::*;`.
The family is two; the population is 67; all 67 are `super::*`. Both facts stand, neither
substitutes for the other.

### The arithmetic the reconciliation must satisfy

- the three states plus `unclassified` account for **every** import edge with a target;
- green dangling import-family **equals** `unclassified`, nothing else;
- the node delta equals **distinct new targets**, not edge count;
- the red dangling population is **fully** accounted for, any shortfall printed by the run itself.

---

# Results

Every number carries its **level**, **sha** and **corpus**. Two instruments are used and their
numbers are **not interchangeable**: the extractor's relations are `imports_from`, the TTL's
predicates are `importsFrom`, and the serializer sits between them.

## The control

- corpus: base's tree at main **`2e5d2a4a`**, 284 files, md5 rollup `96472be5…`
- **two arms, separate roots, identically-named corpus directories**
- caches cold pre-run (0 / 0), 244 entries written by each arm post-run
- red = `scripts/ast` at `2e5d2a4a` (md5 `6d9c538a`, verified equal to
  `git show 2e5d2a4a:scripts/ast/extractor.py`); green = `scripts/ast` at `c1108cb`
- **the only variable between the arms is the extractor**

## EXTRACTOR level — red `2e5d2a4a` → green `c1108cb`, corpus `2e5d2a4a`

| measure | red | green |
|---|---:|---:|
| nodes | 5066 | **5106** (+40, up) |
| distinct ids | 5049 | 5089 |
| **distinct colliding ids** | 9 | **9** |
| **excess (sum of n−1)** | 17 | **17** |
| edges | 9263 | 9196 |
| nodes carrying `type=` | **0** | 1365 |
| import-family edges | 892 | 825 |
| …of those, target exists | 78 | **825** |
| **dangling import-family** | **814** | **0** |
| dangling `extends` | 92 | **92 — untouched** |
| dangling total | 906 | 92 |

`import_states`, **printed by the run itself**, and reported again on the sync's own stderr:

```
# imports: 241 resolved, 0 failed to resolve, 584 third-party
#   1 resolved to a file this extractor does not parse
```

`{"resolved": 241, "failed": 0, "external": 584, "unclassified": 0,
  "resolved_unparsed": 1, "ambiguous_multi": 0, "nodes_emitted": 40}`

`failed: 0` on base's own tree is correct — base has no broken imports — and it proves nothing
about the state, which is why the FAILED state is fired live on a fixture below.

## Where the 814 went — a per-edge census, not an inference

Each red import edge matched to its green counterpart individually. An aggregate that closes can
close by coincidence; a census cannot.

| outcome | edges |
|---|---:|
| → third-party (node emitted) | 584 |
| → resolved to a pre-existing node | 162 |
| → **gone (the deliberate non-emission)** | **67** |
| → resolved to a file the extractor does not parse | 1 |
| **census total** | **814** |
| **unaccounted** | **0** |

Pairing quality, printed by the run: 204 matched by exact target, 621 forced single-candidate,
**0 resolved by tiebreak**, 67 with no green counterpart.

## TTL level — same shas, same corpus

| measure | red | green |
|---|---:|---:|
| declared nodes | 5050 | **5090** (+40) |
| edge triples | 9263 | 9196 |
| dangling | **597** (`importsFrom` 451, `imports` 54, `extends` 92) | **92** (`extends` only) |
| `Function` | 4411 | 3106 |
| `Heading` / `Property` / `CodeBlock` | 0 / 0 / 0 | **591 / 497 / 214** |
| `ExternalModule` / `UnresolvedImport` / `UnparsedFile` | 0 / 0 / 0 | **41 / 1 / 1** |
| `Rationale` / `Module` / `Method` / `Struct` | 163 / 255 / 158 / 60 | unchanged |
| app-root entities | 18 | **18** |

- **nodes dropped: zero.** Red-only IRIs = 0. A count that fell would be a failure, not a fix.
- retyped in place, 1305: `Function`→`Heading` 591, →`Property` 497, →`CodeBlock` 214,
  →`ExternalModule` 2, →`UnresolvedImport` 1.
- **no node was retyped INTO a callable.** The defect ran one way and so does the fix.

## Reading these against earlier figures in the backlog

Earlier numbers read 810 → 0, total 902 → 92, nodes 5048 → 5103, third-party 594, `Rationale`
163 → 170. Mine read 814 → 0, 906 → 92, 5066 → 5106, 584, and `Rationale` **163 → 163**.

**One cause, not five.** Those were measured over the *green tree*, which contains this change's own
new test files and added docstrings. This measurement holds the corpus constant at main and swaps
only the extractor. That is why `Rationale` is flat here: the 163 → 170 is the change's own added
prose, not a behaviour change, and over a constant corpus it correctly does not appear. Both sets
are right at their own corpus; neither can be quoted without naming one.

---

## The ids are the right ids, not merely the right count

A census can show a count moved correctly and still be satisfied by a rewire producing
plausible-but-wrong ids. Asserted by **name**, in both directions, and the probe is discriminating:
run against main's extractor it VOIDs with *"this extractor does not classify imports at all"*.

**Named crates.** `use oxigraph::model::NamedNode` must name **`oxigraph`** — the crate the author
typed and a dependency list can confirm — not `model`, a segment nobody wrote, which was the old
last-segment behaviour and 718 of the original 810.

- PRESENT: `oxigraph`, `anyhow`, `serde_json` — all PASS
- ABSENT: `model`, `NamedNode`, `Result`, `Value` — all PASS

**FAILED fires.** On a deliberately broken relative import: `failed = 1`, the specifier appears as
`import_unresolved`, and it was **not** filed as third-party.

**`crate::` and `self::` are internal by construction, never silently external.**

- `crate::beta::thing` → emitted, `internal`, targets the real file `beta.rs`.
- `self::helper::run` → **no edge emitted**: it resolves internally to its own file and reaches the
  self-loop suppression above. Asserted alongside proof it did **not** become external or
  unresolved — the two outcomes that would be wrong — and that no self-loop exists.
- `crate`, `self`, `super` never appear as external crates.

## Rust suite, and the control that makes it readable

Both runs: 68 of 68 integration binaries, `--no-fail-fast`.

| | `c1108cb` (this branch) | `2e5d2a4a` (main) |
|---|---:|---:|
| passed | 895 | 895 |
| failed | 27 | 27 |
| …citing a stack-overflow status (VOID, #129) | 23 | 23 |
| …real reds | 4 | 4 |

**Failure sets are identical. New under this branch: 0. Fixed by this branch: 0.**

The overflow spelling seen was the **signed `-1073741571`** (`0xC00000FD`), which is what Rust's
`Option<i32>` yields; the detector asserts `3221225725 − 2^32 == -1073741571` rather than trusting
either constant. The 4 real reds are pre-existing on Windows at main —
`hook_log_tier_test.rs:147`, `served_count_coach_test.rs:138`, one more in `served_count_coach`,
and one in `hook_output_channel_test.rs`. They are not this item's and are filed as findings.

**PR #147's two new suites pass against this change**: `ast_map_resolution_test` 5/5 and
`ast_query_map_boundary_test` 5/5. This branch and #147 both edit `src/crud/ast_query.rs` and the
rebase auto-merged them, so that was measured rather than assumed.

## What this deliberately does NOT touch

- **The 92 dangling `extends`** — class bases, #98 / rank 03. Measured only to prove this change
  leaves them alone: 92 → 92.
- **`_disambiguate_colliding_node_ids`** and the duplicate-IRI population: 9 → 9, 17 → 17.
- **`unresolved ../lib/api.js` still reads the app root as its `sourceFile`.** The TYPE is fixed,
  which is the acceptance; the provenance is the #66 app-root fallback, a different item.

## Tests

| file | result |
|---|---|
| `scripts/ast/test_import_states.py` (new) | **13/13, rc 0** |
| `scripts/ast/test_node_kinds.py` (new) | **9/9, rc 0** |

`test_file_attribution.py` fails on Windows at `rc 1` — **pre-existing.** Main's own `scripts/ast`
fails it identically: the TTL writes `src\alpha\mod.rs`, the test asserts `src/alpha/mod.rs`.

## Instrument defects in my own harness — one shape, four instances

Reported because a caught instrument defect is worth more than a clean story. **Every one produced
a CLEAN reading, never a dirty one. That asymmetry is the diagnostic: an instrument whose failure
modes all point toward clean is not a neutral instrument.**

1. **Cache isolation unchecked.** Both arms shared a corpus; the extractor writes
   `.base-ast-cache/` into the corpus root keyed by SHA256 of file *contents*, so the green arm
   replayed the red arm's extractions. Reported `external=3`, `nodes_emitted=3`, `typed=23` — a
   broken *harness* that read as a broken *product*. Fixed: one root per arm, isolation asserted by
   the run.
2. **Census pairing ambiguity uncounted.** The pairing key collides 41 times per side
   (`use a::{b, c}` writes several edges from one source at one location); a dict kept only the
   last green edge. Caught because the run prints how many pairings needed a tiebreak — 621, now 0.
3. **A VOID guard with a blind axis.** A TTL edge pattern that matched nothing printed
   `EDGE TRIPLES 0 / DANGLING 0`, which reads as a perfectly clean map, because the guard checked
   nodes but not edges. Fixed: VOID fires on zero edges.
4. **A subtraction across mismatched units with a one-way clamp.** The Rust grader computed
   `real_reds = failed_total − overflow_LINE_hits` and clamped negatives to zero — failures versus
   log lines. It printed **"REAL failures = 0" over four genuine reds.** Fixed by replacing
   derivation with enumeration: classify each failure block individually.

A fifth of the same family: `bc` is not installed here, so a `|| echo 0` fallback zeroed both
totals on a run with 895 passes and exited VOID for a fabricated reason.

## Reproducing this

```
run.sh <corpus-sha>                    # both arms, cache isolation asserted by the run
measure.py red.json green.json <red-sha> <green-sha> EXTRACTOR
measure_ttl_diff.py red.ttl green.ttl <red-sha> <green-sha>
g0_probe.py <extractor.py> <scratch>   # named crates, FAILED fires, crate:: / self::
classify_failures.py <log> [<control-log>]
rust_leg.sh                            # cargo test, paired detectors, coverage counted
```

Each assigns its rc: **0 = measured, 1 = red, 2 = VOID**. A run that emitted nothing exits VOID
rather than reporting a clean zero.
