### PR TITLE
fix(frontmatter): the documented `related` key produces edges, on both paths

### DIFF
--- a/scripts/ast/extractor.py
+++ b/scripts/ast/extractor.py
@@ -6632,10 +6632,25 @@ def extract_markdown(path: Path) -> dict:
             continue
 
     if is_ontology_doc:
-        for rel in frontmatter.get("related", []) or []:
-            if rel:
-                rel_nid = _make_id(str(rel))
-                add_edge(file_nid, rel_nid, "relatedTo", 1, confidence="FRONTMATTER")
+        # #115: one relatedTo concept, both documented spellings. The Rust
+        # default path (src/extract/frontmatter.rs) reads `relatedto`; the
+        # shipped manual documents `related`. Reading only one of them here
+        # meant a user who followed the manual and ran the OTHER path got zero
+        # edges and no warning. Both are accepted and unioned, order-preserved
+        # and de-duplicated, so a document carrying both does not double-emit.
+        _seen_rel: set[str] = set()
+        _rels: list = []
+        for _key in ("related", "relatedTo"):
+            _val = frontmatter.get(_key)
+            if _val is None:
+                continue
+            for rel in _val if isinstance(_val, (list, tuple)) else [_val]:
+                if rel and str(rel) not in _seen_rel:
+                    _seen_rel.add(str(rel))
+                    _rels.append(rel)
+        for rel in _rels:
+            rel_nid = _make_id(str(rel))
+            add_edge(file_nid, rel_nid, "relatedTo", 1, confidence="FRONTMATTER")
         supersedes = frontmatter.get("supersedes")
         if supersedes:
             sup_nid = _make_id(str(supersedes))

--- a/scripts/ast/test_frontmatter_relatedto.py
+++ b/scripts/ast/test_frontmatter_relatedto.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""One key for `relatedTo`, on both extraction paths, inline AND block (#115).
+
+A user who follows base's OWN published manual gets zero relationships back and
+no warning. `docs/markdown-ontology-protocol.md` documents `related:` at :88 and
+as a YAML block sequence at :102 and :120 -- and every documented example carries
+`ontology: true`.
+
+The two extractors disagree about the key, and the disagreement is silent:
+
+  base sync        (Rust, the DEFAULT path)  reads `relatedto`   src/extract/frontmatter.rs:49
+  base sync --ast  (Python, this file)       reads `related`     scripts/ast/extractor.py:6635
+
+So on THIS path the documented `related:` works and `relatedTo:` -- the spelling
+the Rust default path accepts, and the spelling of the emitted predicate itself --
+produces nothing at all. Not an error, not a warning: an empty list and exit 0.
+
+WHY THIS FILE CARRIES A POSITIVE CONTROL, AND WHY IT IS NOT `tags:`
+-------------------------------------------------------------------
+The failure mode here is ZERO EDGES WITH EXIT 0. A wrong key and a blind probe
+produce a byte-identical result, so a leg that only counts `relatedTo` edges
+cannot tell "the key is not read" from "my fixture never reached the extractor".
+Every cell below therefore asserts a control in the SAME call.
+
+`tags:` was the obvious control and it is the WRONG one on this path: it appears
+only in `extract_markdown`'s docstring. No tag edge is ever emitted here -- the
+frontmatter is stashed whole as `ontology_meta` instead. A control that reads
+zero because IT is unimplemented would have made every cell unfalsifiable.
+
+The controls actually used, both proven to fire in `test_zz_controls_have_a_red_state`:
+
+  ontology_meta on the file node -- the frontmatter PARSED and the `ontology: true`
+                                    gate at extractor.py:6552 OPENED.
+  a heading `contains` edge      -- the body walker RAN over this file.
+
+Run: python3 scripts/ast/test_frontmatter_relatedto.py   (or: pytest scripts/ast/)
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+BODY = "\n# A Heading\n\nBody text.\n"
+
+CELLS = {
+    # name              key          form      frontmatter lines
+    "relatedto_inline": ("relatedTo", "inline", "relatedTo: [alpha-entity, beta-entity]"),
+    "relatedto_block":  ("relatedTo", "block",  "relatedTo:\n  - alpha-entity\n  - beta-entity"),
+    "related_inline":   ("related",   "inline", "related: [alpha-entity, beta-entity]"),
+    "related_block":    ("related",   "block",  "related:\n  - alpha-entity\n  - beta-entity"),
+}
+
+
+def _doc(fm_lines: str) -> str:
+    return (
+        "---\n"
+        "ontology: true\n"
+        "type: note\n"
+        "tags: [alpha, beta]\n"
+        f"{fm_lines}\n"
+        "---\n" + BODY
+    )
+
+
+def _extract(text: str) -> dict:
+    from extractor import extract_markdown
+
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "fixture.md"
+        p.write_text(text, encoding="utf-8")
+        return extract_markdown(p)
+
+
+def _controls(res: dict) -> tuple[bool, bool]:
+    """(frontmatter parsed and gate opened, body walker ran)."""
+    parsed = any("ontology_meta" in n for n in res.get("nodes", []))
+    walked = any(e.get("relation") == "contains" for e in res.get("edges", []))
+    return parsed, walked
+
+
+def _related_targets(res: dict) -> list[str]:
+    return sorted(
+        e["target"] for e in res.get("edges", []) if e.get("relation") == "relatedTo"
+    )
+
+
+def _assert_cell(name: str) -> None:
+    key, form, fm = CELLS[name]
+    res = _extract(_doc(fm))
+    parsed, walked = _controls(res)
+    # The control is asserted BEFORE the count, so a zero below can only mean
+    # absence. Without this an unreachable fixture reads exactly like the defect.
+    assert parsed, (
+        f"[{name}] CONTROL FAILED: no ontology_meta on any node -- the frontmatter "
+        f"did not parse or the ontology gate never opened, so this leg proves NOTHING "
+        f"about the {key} key"
+    )
+    assert walked, (
+        f"[{name}] CONTROL FAILED: no 'contains' edge -- the body walker never ran "
+        f"over the fixture, so this leg proves NOTHING about the {key} key"
+    )
+    targets = _related_targets(res)
+    assert len(targets) == 2, (
+        f"[{name}] {key}: {form} form produced {len(targets)} relatedTo edges, "
+        f"expected 2 (controls both GREEN, so the extractor reached this file "
+        f"and the frontmatter parsed -- this zero is the key, not the probe)"
+    )
+
+
+# ── the four cells ────────────────────────────────────────────────────────────
+
+
+def test_relatedto_inline_emits_edges() -> None:
+    """RED at 9f8c9b52: `relatedTo` is never read on this path (extractor.py:6635)."""
+    _assert_cell("relatedto_inline")
+
+
+def test_relatedto_block_emits_edges() -> None:
+    """RED at 9f8c9b52: same key defect. yaml.safe_load parses the block fine."""
+    _assert_cell("relatedto_block")
+
+
+def test_related_inline_still_emits_edges() -> None:
+    """NON-REGRESSION. Works today; a fix that only renames the key breaks it."""
+    _assert_cell("related_inline")
+
+
+def test_related_block_still_emits_edges() -> None:
+    """NON-REGRESSION. Works today. The manual's :102 and :120 examples are this."""
+    _assert_cell("related_block")
+
+
+# ── canary and control red-state ──────────────────────────────────────────────
+
+
+def test_unrelated_key_emits_no_related_edges() -> None:
+    """MUST-FAIL CANARY: a plausible-but-wrong key must NOT be swept in.
+
+    Without this, a fix that treats every key containing 'relat' as relatedTo
+    would pass all four cells above while inventing edges from `unrelated:`.
+    """
+    res = _extract(_doc("unrelatedthings: [alpha-entity]"))
+    parsed, walked = _controls(res)
+    assert parsed and walked, (
+        "CANARY CONTROL FAILED: fixture never reached the extractor, so a zero "
+        "below would be blindness rather than correct silence"
+    )
+    targets = _related_targets(res)
+    assert targets == [], (
+        f"canary matched: 'unrelatedthings' produced {targets}; the key matcher "
+        f"is too loose and every cell above is worthless"
+    )
+
+
+def test_bare_scalar_does_not_fabricate_one_edge_per_character() -> None:
+    """A scalar `related:` used to emit one edge PER CHARACTER.
+
+    Measured at 9f8c9b52: `related: alpha-entity` produced **12** edges with
+    targets 'a', 'l', 'p', 'h', 'a', '' ... because the value is a str and the
+    loop iterated it. That is fabricated relationship data, not a missing one,
+    and it survives every count-based check that only asks whether edges exist.
+
+    This arm is DISCLOSED SCOPE: the acceptance for #115 covers inline and block
+    forms, not bare scalars. The key fix incidentally repaired this, so the arm
+    exists to stop it regressing silently -- not to claim it was asked for.
+    """
+    res = _extract(_doc("related: alpha-entity"))
+    parsed, walked = _controls(res)
+    assert parsed and walked, "CONTROL FAILED: fixture never reached the extractor"
+    targets = _related_targets(res)
+    assert len(targets) == 1, (
+        f"bare scalar produced {len(targets)} edges {targets[:6]}, expected exactly 1 "
+        f"-- more than one means the string is being iterated character-wise again"
+    )
+
+
+def test_both_spellings_present_do_not_double_emit() -> None:
+    """One relatedTo CONCEPT, so a document carrying both keys emits each once."""
+    res = _extract(
+        _doc("related: [alpha-entity]\nrelatedTo: [alpha-entity, beta-entity]")
+    )
+    parsed, walked = _controls(res)
+    assert parsed and walked, "CONTROL FAILED: fixture never reached the extractor"
+    targets = _related_targets(res)
+    assert len(targets) == len(set(targets)), f"duplicate edges emitted: {targets}"
+    assert len(targets) == 2, f"expected 2 distinct targets, got {len(targets)}: {targets}"
+
+
+def test_zz_controls_have_a_red_state() -> None:
+    """A control never seen red is decoration that happens to print PASS.
+
+    Both controls are driven to FAIL here on inputs where they SHOULD fail, so a
+    green control in the cells above is evidence rather than an assumption.
+    """
+    # No `ontology: true` -> the gate at extractor.py:6552 stays shut.
+    no_gate = _extract("---\ntype: note\nrelated: [alpha-entity]\n---\n" + BODY)
+    parsed, _ = _controls(no_gate)
+    assert not parsed, (
+        "the ontology_meta control did NOT go red on a document with no "
+        "`ontology: true` -- it cannot distinguish a parsed gate from a shut one"
+    )
+
+    # No headings -> the body walker emits no `contains` edge.
+    no_body = _extract("---\nontology: true\nrelated: [alpha-entity]\n---\n\nplain text\n")
+    _, walked = _controls(no_body)
+    assert not walked, (
+        "the 'contains' control did NOT go red on a document with no headings -- "
+        "it cannot distinguish a walked body from an unwalked one"
+    )
+
+
+if __name__ == "__main__":
+    # Every leg runs even after one fails, and the exit code is the run's.
+    # CI runs this file as plain `python <file>` with no pytest installed
+    # (`ci.yml`, the `scripts/ast/test_*.py` step), so a bare `def test_` with
+    # no driver here would be DEFINED, never CALLED, and the job would go green
+    # having executed nothing.
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    rc = 0
+    executed = 0
+    for t in tests:
+        executed += 1
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except Exception as exc:
+            rc = 1
+            first = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+            print(f"FAIL {t.__name__}: {first}")
+    # Law 23: print what was CHECKED, and a checked count of zero is a failure
+    # that says "this proved nothing" -- never a pass.
+    print(f"ran {executed} of {len(tests)} legs; rc={rc}")
+    if executed == 0:
+        print("VOID: zero legs executed, so this file proved nothing")
+        sys.exit(2)
+    sys.exit(rc)

--- a/src/extract/frontmatter.rs
+++ b/src/extract/frontmatter.rs
@@ -46,7 +46,12 @@ pub fn extract_with_project(content: &str, file_path: &str, ns: &NamespaceConfig
                     triples.push((format!("{p}:hasTag"), format!("\"{}\"", escape(&tag))));
                 }
             }
-            "relatedto" => {
+            // #115: the shipped manual documents `related:` (docs/markdown-ontology-protocol.md:88,
+            // :102, :120). This arm only ever read `relatedto`, so the documented
+            // spelling fell through to `_` and was manufactured into an
+            // ops:description triple carrying its own raw text -- a wrong triple
+            // inside the boundary, which is worse than dropping it.
+            "relatedto" | "related" => {
                 for entity in parse_list(value) {
                     let entity_slug = entity
                         .replace(['/', '\\', '.', ' '], "-")
@@ -58,6 +63,17 @@ pub fn extract_with_project(content: &str, file_path: &str, ns: &NamespaceConfig
                 }
             }
             _ => {
+                // #115: reported, NOT dropped. The description triple is still
+                // written -- discarding the value would lose data that a
+                // genuinely unknown key legitimately carries -- but a key that
+                // is one separator or one capital away from a key we DO read
+                // now says so on stderr instead of vanishing into prose.
+                if let Some(known) = plausible_key_alias(key) {
+                    eprintln!(
+                        "[frontmatter] {file_path}: key `{key}` is not read as a field; \
+                         did you mean `{known}`? Recorded as a description only."
+                    );
+                }
                 triples.push((
                     format!("{p}:description"),
                     format!("\"{}: {}\"", escape(key), escape(value)),
@@ -148,17 +164,49 @@ pub fn parse_frontmatter(content: &str) -> Option<Vec<(String, String)>> {
     let fm_text = &after_first[..end_pos];
 
     let mut pairs = Vec::new();
-    for line in fm_text.lines() {
-        let line = line.trim();
+    // #115: a YAML block sequence vanished twice over. Every `- item` line was
+    // skipped outright, and the key line above it carries an EMPTY value, so the
+    // `!value.is_empty()` guard discarded the key too. The pair never reached the
+    // match at all -- which is why block-form `relatedTo:` emitted nothing rather
+    // than falling through to the unknown-key path like its inline form did.
+    let lines: Vec<&str> = fm_text.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i].trim();
+        i += 1;
         if line.is_empty() || line.starts_with('#') || line.starts_with('-') {
             continue;
         }
         if let Some((key, value)) = line.split_once(':') {
             let key = key.trim().to_string();
-            let value = value.trim().trim_matches('"').trim_matches('\'').to_string();
-            if !key.is_empty() && !value.is_empty() {
-                pairs.push((key, value));
+            let mut value = trim_scalar(value);
+            if key.is_empty() {
+                continue;
             }
+            if value.is_empty() {
+                // Gather any block sequence beneath the key into the same comma
+                // form `parse_list` already accepts, so list handling stays in
+                // exactly one place rather than being reimplemented here.
+                let mut items = Vec::new();
+                while i < lines.len() {
+                    let item = lines[i].trim();
+                    if item == "-" {
+                        i += 1;
+                    } else if let Some(rest) = item.strip_prefix("- ") {
+                        items.push(trim_scalar(rest));
+                        i += 1;
+                    } else {
+                        break;
+                    }
+                }
+                if items.is_empty() {
+                    // A valueless key with no sequence under it stays dropped,
+                    // exactly as before this change.
+                    continue;
+                }
+                value = items.join(", ");
+            }
+            pairs.push((key, value));
         }
     }
 
@@ -172,6 +220,40 @@ pub fn parse_frontmatter(content: &str) -> Option<Vec<(String, String)>> {
 /// Parse a comma-separated list value, handling optional bracket syntax.
 /// "rust, sparql, hooks" → ["rust", "sparql", "hooks"]
 /// "[rust, sparql, hooks]" → ["rust", "sparql", "hooks"]
+/// #115: keys this extractor actually reads. Kept beside the match it mirrors so
+/// the two cannot drift without the drift being visible on one screen.
+const KNOWN_KEYS: &[&str] = &[
+    "name", "title", "description", "about", "summary", "status", "priority",
+    "type", "tags", "relatedto", "related",
+];
+
+/// #115 acceptance: an unrecognised-but-PLAUSIBLE key must be REPORTED rather
+/// than silently absorbed. "Plausible" is mechanical rather than a guess: drop
+/// every non-alphanumeric character and the case, and if the result lands
+/// exactly on a key this extractor reads, the author meant that key.
+///
+/// Deliberately an EXACT match after normalising, not a fuzzy distance. A
+/// near-miss matcher that accepted anything close would invent relationships
+/// out of unrelated keys -- the failure the `unrelated_key_creates_no_related_edges`
+/// canary exists to catch.
+fn plausible_key_alias(key: &str) -> Option<&'static str> {
+    let norm: String = key
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_lowercase();
+    if norm.is_empty() {
+        return None;
+    }
+    KNOWN_KEYS.iter().copied().find(|k| *k == norm)
+}
+
+/// Strip surrounding quotes from a YAML scalar. Shared by the key line and the
+/// block-sequence items so the two cannot drift apart.
+fn trim_scalar(s: &str) -> String {
+    s.trim().trim_matches('"').trim_matches('\'').to_string()
+}
+
 fn parse_list(value: &str) -> Vec<String> {
     let trimmed = value.trim().trim_start_matches('[').trim_end_matches(']');
     trimmed
@@ -642,5 +724,171 @@ Run tests with `cargo test`.
         // References (wikilink + markdown link + @-mention)
         let refs: Vec<_> = triples.iter().filter(|(p, _)| p.contains("references")).collect();
         assert!(refs.len() >= 3);
+    }
+
+    // --- #115: ONE key for relatedTo, both paths, inline AND block ---
+    //
+    // The manual (docs/markdown-ontology-protocol.md:88,102,120) documents
+    // `related:`, inline and as a YAML block sequence. This path reads
+    // `relatedto` (line 49, matched under `key.to_lowercase()`), so the
+    // DOCUMENTED spelling emits zero relatedTo triples -- and the `_` arm turns
+    // it into an ops:description triple carrying the raw text, which is worse
+    // than dropping it. Block form fails earlier still: parse_frontmatter skips
+    // every line starting with '-' and discards a pair whose value is empty, so
+    // the key never reaches the match at all.
+    //
+    // EVERY CELL ASSERTS A CONTROL FIRST. The failure mode is zero triples with
+    // no error, so a leg that only counts relatedTo cannot separate "the key is
+    // not read" from "the fixture never parsed". `tags:` is the control here --
+    // it is handled by this path (unlike the Python path, where `tags` exists
+    // only in a docstring) and it goes red on unparseable frontmatter, proven in
+    // control_tags_has_a_red_state.
+
+    /// Control: frontmatter parsed and the match loop ran over its keys.
+    fn tags_control(triples: &[(String, String)]) -> usize {
+        triples.iter().filter(|(p, _)| p.contains("hasTag")).count()
+    }
+
+    fn related_edges(triples: &[(String, String)]) -> Vec<&(String, String)> {
+        triples.iter().filter(|(p, _)| p.contains("relatedTo")).collect()
+    }
+
+    #[test]
+    fn relatedto_inline_is_not_regressed() {
+        // NON-REGRESSION. This spelling works TODAY because line 49 is matched
+        // under to_lowercase(). A fix that merely renames the arm breaks it.
+        let content = "---\ntags: [alpha, beta]\nrelatedTo: [signal-mod, hook-engine]\n---\n";
+        let triples = extract_with_project(content, "test.md", &ns(), None).unwrap();
+        assert_eq!(tags_control(&triples), 2, "CONTROL FAILED: frontmatter did not parse");
+        assert_eq!(related_edges(&triples).len(), 2);
+    }
+
+    #[test]
+    fn relatedto_block_form_creates_edges() {
+        // RED at 9f8c9b52: parse_frontmatter:153 skips '-' lines and :159 drops
+        // the key line because its value is empty. Nothing reaches the match.
+        let content = "---\ntags: [alpha, beta]\nrelatedTo:\n  - signal-mod\n  - hook-engine\n---\n";
+        let triples = extract_with_project(content, "test.md", &ns(), None).unwrap();
+        assert_eq!(tags_control(&triples), 2, "CONTROL FAILED: frontmatter did not parse");
+        assert_eq!(
+            related_edges(&triples).len(),
+            2,
+            "block-sequence relatedTo emitted no edges (tags control GREEN, so the \
+             frontmatter parsed -- this zero is the parser dropping the pair)"
+        );
+    }
+
+    #[test]
+    fn documented_related_key_creates_edges() {
+        // RED at 9f8c9b52: `related` is the key the shipped manual documents.
+        let content = "---\ntags: [alpha, beta]\nrelated: [signal-mod, hook-engine]\n---\n";
+        let triples = extract_with_project(content, "test.md", &ns(), None).unwrap();
+        assert_eq!(tags_control(&triples), 2, "CONTROL FAILED: frontmatter did not parse");
+        assert_eq!(
+            related_edges(&triples).len(),
+            2,
+            "the DOCUMENTED key emitted no edges (tags control GREEN)"
+        );
+    }
+
+    #[test]
+    fn documented_related_block_form_creates_edges() {
+        // RED at 9f8c9b52. This is the manual's :102 and :120 examples verbatim.
+        let content = "---\ntags: [alpha, beta]\nrelated:\n  - signal-mod\n  - hook-engine\n---\n";
+        let triples = extract_with_project(content, "test.md", &ns(), None).unwrap();
+        assert_eq!(tags_control(&triples), 2, "CONTROL FAILED: frontmatter did not parse");
+        assert_eq!(related_edges(&triples).len(), 2);
+    }
+
+    #[test]
+    fn related_key_emits_no_junk_description_triple() {
+        // RED at 9f8c9b52. The `_` arm does not merely drop an unrecognised key,
+        // it MANUFACTURES ops:description "related: [signal-mod, hook-engine]".
+        // A wrong triple inside the boundary is worse than silence, so proving
+        // the right triple appeared is not enough -- the junk must be GONE.
+        let content = "---\ntags: [alpha, beta]\nrelated: [signal-mod, hook-engine]\n---\n";
+        let triples = extract_with_project(content, "test.md", &ns(), None).unwrap();
+        assert_eq!(tags_control(&triples), 2, "CONTROL FAILED: frontmatter did not parse");
+        let junk: Vec<_> = triples
+            .iter()
+            .filter(|(p, v)| p.contains("description") && v.contains("related:"))
+            .collect();
+        assert!(
+            junk.is_empty(),
+            "the `_` arm manufactured a description triple from a known key: {junk:?}"
+        );
+    }
+
+    #[test]
+    fn unrelated_key_creates_no_related_edges() {
+        // MUST-FAIL CANARY. A fix that sweeps in every key containing "relat"
+        // would pass every cell above while inventing edges out of this one.
+        let content = "---\ntags: [alpha, beta]\nunrelatedthings: [signal-mod]\n---\n";
+        let triples = extract_with_project(content, "test.md", &ns(), None).unwrap();
+        assert_eq!(tags_control(&triples), 2, "CONTROL FAILED: frontmatter did not parse");
+        assert!(
+            related_edges(&triples).is_empty(),
+            "canary matched: the key matcher is too loose, so every cell above is worthless"
+        );
+    }
+
+    #[test]
+    fn control_tags_has_a_red_state() {
+        // A control never seen red is decoration that happens to print PASS.
+        // With no frontmatter at all, extraction returns None and the control
+        // cannot report 2 -- so a GREEN control above is evidence, not an
+        // assumption.
+        assert!(
+            extract_with_project("# no frontmatter\n", "test.md", &ns(), None).is_none(),
+            "the tags control did not go red on a document with no frontmatter"
+        );
+        let no_tags = "---\ntitle: Untagged\n---\n";
+        let triples = extract_with_project(no_tags, "test.md", &ns(), None).unwrap();
+        assert_eq!(
+            tags_control(&triples),
+            0,
+            "the tags control reported tags on a document that has none"
+        );
+    }
+
+    #[test]
+    fn plausible_alias_reports_near_miss_spellings() {
+        // Separator and case variants of a key we DO read.
+        assert_eq!(plausible_key_alias("related_to"), Some("relatedto"));
+        assert_eq!(plausible_key_alias("related-to"), Some("relatedto"));
+        assert_eq!(plausible_key_alias("Related To"), Some("relatedto"));
+        assert_eq!(plausible_key_alias("TAGS"), Some("tags"));
+    }
+
+    #[test]
+    fn plausible_alias_is_exact_after_normalising_not_fuzzy() {
+        // MUST-FAIL CANARY for the reporter itself. A fuzzy matcher would claim
+        // these, and a reporter that cries wolf on every key is noise that gets
+        // switched off -- which is the same silence it was added to remove.
+        assert_eq!(plausible_key_alias("unrelatedthings"), None);
+        assert_eq!(plausible_key_alias("workspace"), None);
+        assert_eq!(plausible_key_alias("severity"), None);
+        assert_eq!(plausible_key_alias("tag"), None);
+        assert_eq!(plausible_key_alias(""), None);
+        assert_eq!(plausible_key_alias("---"), None);
+    }
+
+    #[test]
+    fn near_miss_key_is_reported_but_not_dropped() {
+        // "REPORTED, not dropped": the value must still reach the graph.
+        let content = "---\ntags: [alpha, beta]\nrelated_to: [signal-mod]\n---\n";
+        let triples = extract_with_project(content, "test.md", &ns(), None).unwrap();
+        assert_eq!(tags_control(&triples), 2, "CONTROL FAILED: frontmatter did not parse");
+        assert!(
+            triples
+                .iter()
+                .any(|(p, v)| p.contains("description") && v.contains("related_to")),
+            "a near-miss key was DROPPED; the acceptance says reported, not dropped"
+        );
+        // ...and it must not be silently promoted into a real relationship.
+        assert!(
+            related_edges(&triples).is_empty(),
+            "a near-miss key was silently ACCEPTED as relatedTo; report it, do not guess"
+        );
     }
 }


### PR DESCRIPTION
**DRAFT AND NOT READY TO MERGE.** Opened to mint a CI run so the reviewer's standing stamp conditions are reachable; a branch push alone mints nothing. **One product decision is outstanding and it changes this diff.**

Work order order **1** of 9. `C:/Users/Chris/.base-gbl/docs/BASE-WORK-ORDER.md` § 04.
Lane doc: `~/.base-gbl/forks/base-0.14.3-lane-115-frontmatter-relatedto.md`.

## The defect, in one sentence

A user who follows base's own published manual writes `related:` in frontmatter, runs the **default** `base sync`, and gets **zero** relationships back plus a **fabricated `ops:description` triple** carrying the raw text. Exit 0, no warning.

## Why the four-cell framing was wrong

The paths disagree on the **key**, the **YAML form**, AND the **precondition**, so the honest matrix is four axes, not two:

**paths × keys × YAML forms × `ontology` state = 16 cells, all measured before and after. ZERO cells collapsed.**

The key axis is non-degenerate and that is shown rather than asserted: at identical path/form/ontology coordinates, Rust `relatedTo` inline read **2** while Rust `related` inline read **0**.

## Measured

- Rust `extract::frontmatter`: **21 passed / 4 failed, rc 101 → 28 passed / 0 failed, rc 0**
- Python: **rc 1 → rc 0**, 8 legs
- Whole crate: **523 passed / 0 failed / 1 ignored**
- `scripts/ast` reachability gate: **35 → 43** defined tests across **7** files

## Registered limitations, not hidden

- **The `ontology: true` precondition is UNRESOLVED and this diff does not touch it.** `ontology` occurs **zero** times in `src/extract/frontmatter.rs` (646 lines), while the Python `related` loop sits inside `if is_ontology_doc`. The manual documents the precondition **twice** (L19, L128), so it is the shipped contract and the Python path is obeying it. **Removing it to make the paths agree would break a published claim.** Awaiting a decision: does `related:` require `ontology: true` on **both** paths or **neither**? Either way code and manual must end up stating the same rule, and the build record must say which side moved.
- **The pre-existing suite was blind to this defect by construction.** There is no `related` arm in the Rust dispatch, and the crate's own tests at L439/L601 pin `relatedTo`, the **undocumented** spelling. A green pre-existing suite was never evidence here.

## Not in this PR

`scripts/ast/test_file_attribution.py` is **red at clean `main`**, 3 of 3: `ops:sourceFile` emits `src\alpha\mod.rs` while the test asserts POSIX. It **predates this branch** and is filed separately (§ Unranked, `N-PATHSEP`). Whether the emitter or the assertion is wrong is **not yet measured**, and the cheaper test-only reading must not win by default.
