### PR TITLE
fix(cli): run base on an 8 MB thread so Windows debug builds reach product code (#129)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,50 @@ mod cli;
 #[cfg(test)]
 mod help_docs;
 
+/// Startup stack for the thread that runs the CLI (#129).
+///
+/// **Why this exists at all.** `clap`'s derive-generated `Command` tree is built in full
+/// *before* any argument is dispatched, so the cost is paid by `--version` as much as by
+/// real work. At `opt-level = 0` none of those builder frames are inlined, and the 24
+/// `#[derive(Subcommand)]` enums in `cli.rs` need **more startup stack than Windows gives
+/// the main thread by default** — every invocation of a debug build aborted with
+/// `STATUS_STACK_OVERFLOW` before reaching a line of product code.
+///
+/// **Measured at `2e5d2a4a`, debug profile, one binary with only the size varied** (so the
+/// parameter is demonstrably in effect, not merely present here): **1152 KB still aborts,
+/// 1168 KB runs clean**, bisected to 16 KB. The requirement is ~1.14 MB against a Windows
+/// default of 1 MB — it fails by about 14%, which is why it looked profile-specific rather
+/// than structural.
+///
+/// **Why 8 MB and not the ~1.2 MB that would just fit.** 8 MB is exactly the Linux
+/// main-thread default (`ulimit -s` = 8192 KB), and Linux is the platform where this never
+/// reproduced — all four CI jobs are `ubuntu-latest`, which is precisely why CI stayed
+/// green while every Windows debug run died. This gives Windows parity with the platform
+/// base is already tested on, plus ~7x the measured requirement, so adding a 25th
+/// subcommand cannot quietly re-break it. Sizing it to the measurement instead would put
+/// the margin back at 14%.
+///
+/// This states the requirement rather than masking it: `[profile.dev] opt-level = 1` also
+/// stops the abort (measured), but only by shrinking the frames until they fit, which
+/// leaves release depending on inlining happening to fit under 1 MB.
+const STARTUP_STACK_BYTES: usize = 8 * 1024 * 1024;
+
 fn main() {
-    cli::run();
+    let worker = std::thread::Builder::new()
+        .name("base-main".to_string())
+        .stack_size(STARTUP_STACK_BYTES)
+        .spawn(cli::run)
+        .expect("spawning the base worker thread");
+
+    // `cli::run` signals failure with `std::process::exit`, which terminates the whole
+    // process from any thread, so ordinary exit codes still propagate untouched.
+    //
+    // A PANIC does not: it unwinds the worker and leaves `join` returning `Err`, and a
+    // `main` that ignored that would return normally and **exit 0**. Every failing command
+    // would then report success — the same "could not run is indistinguishable from
+    // passed" defect that #129 itself creates, reintroduced by the fix for it. 101 is the
+    // code rustc's own harness uses for a panicking process.
+    if worker.join().is_err() {
+        std::process::exit(101);
+    }
 }


### PR DESCRIPTION
Fixes #129.

Fix B makes `base.exe` run on Windows debug builds, where every invocation previously aborted with `STATUS_STACK_OVERFLOW` before reaching product code. **8** integration test files launch `base.exe` as a child in source; **7** execute it on Windows, because `tests/ast_extractor_notices_test.rs:69` gates its child call behind `#[cfg(unix)]`. Those 7 hold **35** `#[test]` functions: under #129, **27 fail** across **6** binaries, and **2 report PASS on a dead child** — `doctor_hook_failures_test::session_start_is_silent_about_a_hook_that_has_recovered` and `outside_workspace_test::inside_a_workspace_nothing_is_added`, both negative assertions satisfied by the absence of the product. The six failing binaries hold **28** `#[test]` functions, 27 failing and 1 greenwashing; the remaining 6 tests in `doctor_hook_failures_test` are library-only and pass legitimately. The other **60** files are library-only, so this fix cannot reach them and #129's mechanism cannot reach them either.

> **Blast-radius sentence corrected 2026-09-09 by `auk` on `condor`'s S6 FAIL, text as `condor` measured it.** The original said *"**6** of those 7 fail under #129 (**27** `#[test]` functions across them), and the **7th reports PASS on a dead child**"*. Two figures were wrong: **27 is the failure count, not the population** — the six failing binaries hold **28** test functions, because `outside_workspace_test` is 2 failed / 1 passed — and the greenwash is **two individual tests, not one whole binary**, one of which sits inside the *failing* set. **This edit changes no commit**, so the head, the merge ref and the G2 stamp on S1-S5 and S7 are untouched.

## The defect

Every invocation of a Windows debug `base.exe` aborted with `STATUS_STACK_OVERFLOW` (`0xC000_00FD`) before reaching a line of product code, `--version` included, because clap builds the whole `Command` tree before it can answer anything.

base needs **1152–1168 KB** of startup stack, bisected to **16 KB** on one binary with only the size varied — which is what proves the parameter was in effect rather than merely present. Windows gives the main thread **1 MB**; Linux gives **8192 KB**. **All four CI jobs are `ubuntu-latest`**, which is the complete reason CI stayed green while every Windows debug run died. It fails by ~14%, which is why it read as profile-specific rather than structural.

## The fix, and why the `join` line is load-bearing

`cli::run` now runs on a thread with `STARTUP_STACK_BYTES = 8 * 1024 * 1024` — **Linux parity**, not a round number picked by feel.

```rust
if worker.join().is_err() { std::process::exit(101) }
```

`cli::run` signals failure with `std::process::exit` in **36** places and those propagate from any thread, but a **panic** only sets `join() == Err`, and a `main` ignoring it would **exit 0** — turning every failing command into a pass. That is the exact defect #129 creates, reintroduced by its own fix. So the harness asserts `rc == 101` on a gated panic probe rather than merely asserting nonzero.

**`[profile.dev] opt-level = 1` also stops the abort** (4/4 survive, binary 37.5 → 24.0 MB) and is deliberately **not shipped**: it masks the invariant instead of stating it. `Cargo.toml` carries no `[profile]` section, and the harness asserts that.

## Acceptance — 10/10 at `cbb375b2`, re-measured on this branch

Every number below was measured at `cbb375b2` (this PR's merge base). Earlier runs at `2e5d2a4a`, `273fce98` and `9f8c9b52` were discarded rather than carried forward: when `main` moves, the evidence expires.

| leg | result | what it proves |
|---|---|---|
| `G_debug_all_four_invocations_clean` | PASS | `--version`, `--help`, `ast list`, `ast query` all run on the debug binary |
| `G_release_all_four_invocations_clean` | PASS | release unaffected and still clean |
| `G2_clap_parse_error_still_nonzero` | PASS | a clap parse error still exits nonzero through the thread |
| `G3_product_error_still_nonzero` | PASS | two read-only product-error paths still exit 1 from a cwd with no workspace and no map |
| `G3c_control_nothread_binary_genuinely_fails` | PASS | the **control** — a stock release binary with no worker thread exits 1 on the same two commands, so "nonzero" is not an artefact of the fix |
| `G5_control_success_reads_zero` | PASS | a successful command still reads 0, so the detector is not stuck nonzero |
| `G6_panic_still_fails_process` | PASS | a gated panic probe exits **exactly 101** via the `join().is_err()` path |
| `G6b_probe_absent_from_shipping_binaries` | PASS | the probe did **not** ship — byte search, paired with a control that fires |
| `G0_shipping_binaries_contain_fixB_control_does_not` | PASS | provenance: both shipping binaries contain the fix literal, the control does not |
| `G7_binary_under_test_is_not_an_isolation_guard_build` | PASS | the measured binary is the shipping product, not a `cargo test` build |

**`LEGS 10/10 PASS  fail=0  void=0  ACCEPT_RC=0`**

### The instrument was shown to fail

A 10/10 from an instrument never shown to fail means nothing. Same harness, one variable changed (stock `main.rs`, debug rebuilt): **4/9, 5 FAIL, `ACCEPT_RC=1`**, and the five are exactly the debug-arm legs.

### The defect reproduces at this merge base

Standing-order-6 re-verify at `cbb375b2`, stock debug built from a clean tree:

| arm | binary md5 | numeric detector | stderr detector |
|---|---|---|---|
| **RED** stock debug | `3eadc33b3a8e7109e75dfe71f41d1799` | **4/4** | **4/4** |
| **CONTROL** fix-B debug | `8075233e11e1b377891dd90a5ce817c4` | **0/4** | **0/4** |

Red stderr on all four: `thread 'main' (<pid>) has overflowed its stack`, rc `3221225725`. On the control, `--version` and `--help` exit 0 while `ast list` and `ast query` **legitimately exit 1** — and both detectors still read **0**. That discrimination is the leg: a detector keyed on `rc != 0` would have read 2/4 there and called the fixed binary broken.

## Two traps worth carrying out of this

**Crash spellings are language-scoped.** Rust `status.code()` hands you `Option<i32>` → signed **`-1073741571`**; Python `subprocess.returncode` hands you unsigned **`3221225725`**. Same bit pattern `0xC000_00FD`. A Python probe following the signed rule read **0 of 4** overflows on a binary that dies **4 of 4** — it did not report `#129` stale only because it ran **two detectors whose failure modes differ** and refused to report when they disagreed. A single detector cannot tell you it is wrong.

**`cargo test` swaps the product under the shipping path.** `Cargo.toml`'s `[dev-dependencies]` holds a self-dev-dependency, `base = { path = ".", features = ["isolation-guard"] }`. Feature unification turns `isolation-guard` on for the lib, and the bin built for `CARGO_BIN_EXE_base` links it, so `home::home_root()` returns `test_root()` and the binary cannot resolve any workspace by design. It surfaces as a *different answer*, not a crash, with both overflow detectors reading false. Leg `G7` asserts against it and names its own remedy: rebuild with `cargo build --bin base`.

## Separate, real, and NOT part of this PR

`hook_output_channel_test::the_events_that_deliver_plain_stdout_still_use_it` fails on the **fixed** binary — an assertion at `tests/hook_output_channel_test.rs:191`. **No overflow detector fired.** #129 was masking it: the test could not run at all before. Not folded in here.
