### PR TITLE
fix(ast): declare each IRI exactly once in the map (#98)

### DIFF
--- a/scripts/ast/onto_ast.py
+++ b/scripts/ast/onto_ast.py
@@ -214,6 +214,29 @@ def extract_project(target: Path, project: str, full: bool = False, confirm: boo
                 file=sys.stderr,
             )
 
+        # #98: the extractor still hands the serializer one dict per REFERENCE
+        # (`all_nodes.extend` per file, `seen_ids` is per-file), and option C
+        # deliberately did not change that -- it declares each IRI once. Say so
+        # rather than collapsing silently: the count is the tripwire that tells
+        # an operator the upstream duplication is still there, and a dedupe
+        # nobody counts is how the same defect walks back in unnoticed.
+        collapsed = stats.get("duplicate_declarations_dropped", 0)
+        if collapsed:
+            iris = stats.get("duplicate_declaration_iris", 0)
+            rescues = stats.get("duplicate_declaration_line_rescues", 0)
+            print(
+                f"# {collapsed} repeat declaration(s) across {iris} IRI"
+                f"{'' if iris == 1 else 's'} collapsed to one declaration each "
+                f"(the extractor emits one node per reference; #98)",
+                file=sys.stderr,
+            )
+            if rescues:
+                print(
+                    f"#   {rescues} kept a later dict carrying a real source "
+                    f"line over an earlier one with none",
+                    file=sys.stderr,
+                )
+
         orphans = stats.get("app_root_entities", 0)
         if orphans:
             noun = "entity" if orphans == 1 else "entities"

--- a/scripts/ast/test_declaration_dedupe.py
+++ b/scripts/ast/test_declaration_dedupe.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""One IRI, one declaration line (#98).
+
+`extract()` accumulates nodes with `all_nodes.extend(...)` once per file and dedupes ids
+only WITHIN a file (`seen_ids` is per-file, `extractor.py:1610`). A symbol referenced from
+six files therefore arrives at the serializer as six dicts carrying one id, and every one of
+them used to be emitted as its own `code:<id> a ops:<T>` block. Measured on base's own tree
+at `cbb375b2`: 9 IRIs over 17 excess declarations, occurrences [6,6,2,2,2,2,2,2,2]. The map
+held one node per IRI while the TTL declared it many times, so `base ast query` answered with
+a single node standing for several separate sites and said nothing about it.
+
+#98's ruling is option C: deduplicate at emission. This file pins that.
+
+WHY THE FIRST ARM IS A POSITIVE CONTROL AND NOT A COURTESY
+----------------------------------------------------------
+Every other assertion here is of the form "no IRI is declared twice", and all of them pass
+perfectly over a fixture where nothing ever collided -- which is what this file would become
+the moment the fixture stops reproducing the shape. So the extractor layer is asserted
+FIRST and in the opposite direction: `extract()` must still hand back MORE THAN ONE dict for
+some id. That is the collision pressure the fix exists to absorb; option C deliberately did
+not remove it. If that arm goes red, this file has stopped testing anything and says so,
+rather than reporting a clean map (PROCESS laws 24, 25 and 48).
+
+The two layers are also two independent detectors, and each fires on its own mutation
+(law 39): break the dedupe and the TTL arms go red while the extractor arm stays green;
+stop the extractor duplicating and the extractor arm goes red while the TTL arms stay green.
+
+WHY THE DETERMINISM ARM IS THE SHARPEST ONE
+-------------------------------------------
+The obvious dedupe is keep-first, and on the measured tree it is WRONG. 6 of the 9 collisions
+are a real file node meeting an import-target stub for that same file, identical but for the
+source line -- and node order does not agree on which arrives first: `GraphExplorer.svelte`
+had line 0 then 1, `CostAttribution.svelte` had 1 then 0. Keep-first therefore publishes
+`ops:sourceLine 0` for five panels and `1` for the sixth, a coin flip per id, and no arm
+counting declarations can see it. `test_the_survivor_does_not_depend_on_dict_order` feeds
+`_plan_declarations` the same group in both orders and requires the same winner; it fails on
+keep-first and passes on "a real line beats the 0 placeholder, then first-in-order".
+
+Run: python3 scripts/ast/test_declaration_dedupe.py
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter, namedtuple
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+from extractor import extract, collect_files  # noqa: E402
+from ttl_serializer import _plan_declarations, sanitize_iri, serialize  # noqa: E402
+
+Run = namedtuple("Run", "ttl notices")
+
+# Mirrors the shape measured on base's own `dashboard/` tree, which is where all nine
+# collisions live: an App that imports two panels by relative path, panels that each
+# import the same external packages, and a relative import that resolves to nothing.
+# Every collision family #98 names is present:
+#   `svelte` / `d3`      -> one ExternalModule dict per importing file
+#   `../lib/api.js`      -> one UnresolvedImport dict per importing file
+#   `./panels/*.svelte`  -> a real FILE node meeting an import stub for the same file,
+#                           which is the family that carries the source-line conflict
+FIXTURE = {
+    "dashboard/src/App.svelte": (
+        "<script>\n"
+        "  import Alpha from './panels/Alpha.svelte';\n"
+        "  import Beta from './panels/Beta.svelte';\n"
+        "  import { onMount } from 'svelte';\n"
+        "</script>\n"
+        "<main><Alpha /><Beta /></main>\n"
+    ),
+    "dashboard/src/panels/Alpha.svelte": (
+        "<script>\n"
+        "  import { onMount } from 'svelte';\n"
+        "  import * as d3 from 'd3';\n"
+        "  import { getNodes } from '../lib/api.js';\n"
+        "</script>\n"
+        "<div>alpha</div>\n"
+    ),
+    "dashboard/src/panels/Beta.svelte": (
+        "<script>\n"
+        "  import { onDestroy } from 'svelte';\n"
+        "  import * as d3 from 'd3';\n"
+        "  import { getEdges } from '../lib/api.js';\n"
+        "</script>\n"
+        "<div>beta</div>\n"
+    ),
+}
+
+DECL = re.compile(r"^code:(\S+)\s+a\s+ops:(\S+)", re.M)
+
+
+def _fixture_root(td: str) -> Path:
+    root = Path(td)
+    for rel, body in FIXTURE.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=str(root), check=True)
+    return root
+
+
+def _extract_ttl() -> Run:
+    """The real entry point over a real repo.
+
+    NOT under /tmp: file discovery drops any path with a `tmp` component, so a fixture
+    there extracts to nothing and every "no duplicate declarations" leg below passes
+    over an empty map. `test_node_kinds.py` carries the same note for the same reason.
+    """
+    with tempfile.TemporaryDirectory(prefix="base-ast-d98-", dir=Path.home()) as td:
+        root = _fixture_root(td)
+        proc = subprocess.run(
+            [sys.executable, str(HERE / "onto_ast.py"), str(root),
+             "--project", "t", "--full"],
+            capture_output=True, text=True, cwd=str(HERE),
+            env=os.environ.copy(), timeout=300,
+        )
+        assert proc.returncode == 0, f"extraction failed:\n{proc.stderr}"
+        run = Run(proc.stdout, proc.stderr)
+    assert "a ops:" in run.ttl, "extraction produced no entities; the fixture never parsed"
+    return run
+
+
+def _extract_nodes() -> list[dict]:
+    """The raw node dicts, before any serializer sees them."""
+    with tempfile.TemporaryDirectory(prefix="base-ast-d98n-", dir=Path.home()) as td:
+        root = _fixture_root(td)
+        files = collect_files(root)
+        assert files, "collect_files found nothing; the fixture never reached the extractor"
+        return extract(files, cache_root=root)["nodes"]
+
+
+def _declarations(run: Run) -> Counter:
+    """Count declarations per id, anchored at COLUMN 0.
+
+    A TTL repeats the same id inside predicate objects (`ops:definedIn code:<id>`) and
+    inside `rdfs:label` prose. Only `code:<id> a ops:<T>` at column 0 is a declaration;
+    an unanchored match counts references as declarations and inflates every number here.
+    """
+    return Counter(m.group(1) for m in DECL.finditer(run.ttl))
+
+
+def test_the_extractor_still_emits_more_than_one_dict_per_id():
+    """POSITIVE CONTROL. Without this, every arm below passes over a fixture that never
+    collided, and a fixture that stopped reproducing the shape would look like a fix."""
+    nodes = _extract_nodes()
+    per_id = Counter(n["id"] for n in nodes)
+    repeats = {k: v for k, v in per_id.items() if v > 1}
+    assert repeats, (
+        "no id arrives from extract() more than once, so this fixture no longer "
+        "reproduces #98's collision pressure and NOTHING in this file is being "
+        "tested. Fix the fixture, do not delete the arm."
+    )
+
+
+def test_no_iri_is_declared_more_than_once():
+    run = _extract_ttl()
+    counts = _declarations(run)
+    assert counts, "the column-0 declaration anchor matched nothing"
+    dupes = {k: v for k, v in counts.items() if v > 1}
+    assert not dupes, (
+        f"{len(dupes)} IRI(s) declared more than once, {sum(v - 1 for v in dupes.values())} "
+        f"excess declaration(s): {dict(sorted(dupes.items(), key=lambda x: -x[1]))}"
+    )
+
+
+def test_a_shared_external_package_is_declared_once():
+    """`svelte` and `d3` are each imported by more than one fixture file."""
+    run = _extract_ttl()
+    counts = _declarations(run)
+    for pkg in ("t_svelte", "t_d3"):
+        assert counts.get(pkg, 0) == 1, (
+            f"{pkg} is declared {counts.get(pkg, 0)} time(s), expected exactly 1. "
+            f"0 means the fix deleted the node rather than deduplicating its "
+            f"declaration, which this arm exists to separate from a repair."
+        )
+
+
+def test_a_file_that_is_also_an_import_target_is_declared_once():
+    """The family that carries the source-line conflict: a real file node meeting an
+    import-target stub for that same file."""
+    run = _extract_ttl()
+    counts = _declarations(run)
+    panels = [k for k in counts if k.endswith("_svelte") and "panels" in k]
+    assert panels, (
+        "no panel file node in the map, so the file-node-meets-import-stub family "
+        "is not represented and this arm proved nothing"
+    )
+    for p in panels:
+        assert counts[p] == 1, f"{p} is declared {counts[p]} time(s), expected 1"
+
+
+def test_no_iri_is_declared_with_two_different_types():
+    """#98 owns declaration COUNT and must never change a node's rdf:type -- retyping was
+    #105, which is merged and closed. A collapsed group that disagreed on its class and
+    then had a winner picked for it would show up here as one IRI with two classes."""
+    run = _extract_ttl()
+    by_iri = {}
+    for m in DECL.finditer(run.ttl):
+        by_iri.setdefault(m.group(1), set()).add(m.group(2))
+    conflicted = {k: sorted(v) for k, v in by_iri.items() if len(v) > 1}
+    assert not conflicted, f"IRI(s) declared with more than one ops class: {conflicted}"
+
+
+def test_the_survivor_does_not_depend_on_dict_order():
+    """The keep-first regression guard, and the one arm that fails on keep-first.
+
+    Measured on base's own tree: 6 of the 9 collisions are a file node and an import stub
+    for the same file, identical but for the source line, and node order does NOT agree on
+    which arrives first. Keep-first therefore publishes `ops:sourceLine 0` for some and `1`
+    for others -- a coin flip that no declaration count can detect.
+    """
+    stub = {"id": "panels_alpha_svelte", "label": "./panels/Alpha.svelte",
+            "file_type": "code", "type": "import_unresolved"}
+    filenode = {"id": "panels_alpha_svelte", "label": "Alpha.svelte",
+                "file_type": "code", "source_location": "L1"}
+
+    forward, _, _, _ = _plan_declarations([stub, filenode], "t", "code:t_root")
+    reverse, _, _, _ = _plan_declarations([filenode, stub], "t", "code:t_root")
+    iri = f"code:t_{sanitize_iri('panels_alpha_svelte')}"
+
+    assert forward[iri] == 1, (
+        "with the stub first, the dict carrying a real source line (index 1) must win; "
+        f"index {forward[iri]} won, which is keep-first and publishes sourceLine 0"
+    )
+    assert reverse[iri] == 0, (
+        "with the file node first, that same dict (now index 0) must win; "
+        f"index {reverse[iri]} won"
+    )
+    won_forward = [stub, filenode][forward[iri]]
+    won_reverse = [filenode, stub][reverse[iri]]
+    assert won_forward is won_reverse, (
+        "the two orderings chose DIFFERENT dicts, so the survivor depends on the order "
+        "files happened to be walked in"
+    )
+    assert won_forward.get("source_location") == "L1", (
+        "the surviving dict has no real source line, so the declaration will carry the "
+        "0 placeholder and the only line information available was thrown away"
+    )
+
+
+def test_the_module_iri_is_not_declared_twice():
+    """The file/app-root module block is written before the node loop, so it has already
+    spent its IRI's one declaration. A node sharing that IRI must not declare it again."""
+    node = {"id": "root", "label": "root", "file_type": "code"}
+    owner, dup_iris, dropped, _ = _plan_declarations([node], "t", "code:t_root")
+    assert owner["code:t_root"] == -1, (
+        "a node sharing the pre-loop module IRI was granted a declaration, so that IRI "
+        "is declared twice: once by the module block and once by the node loop"
+    )
+    assert dup_iris == 1 and dropped == 1, (
+        f"the collision with the module block must be COUNTED, not silently dropped; "
+        f"got duplicate_iris={dup_iris} dropped={dropped}"
+    )
+
+
+def test_a_type_disagreement_stops_the_run():
+    """#98's required arm, proven by MUTATION rather than by reading (law 38).
+
+    Two dicts, one id, different explicit types. Emission must STOP naming both classes
+    rather than collapse them onto a silently-picked winner -- retyping is #105's
+    territory and it is closed. An arm that only asserted "no type changed" over a tree
+    where none ever disagreed would pass identically with this guard deleted.
+    """
+    a = {"id": "shared", "label": "shared", "file_type": "code",
+         "type": "import_external"}
+    b = {"id": "shared", "label": "shared", "file_type": "code",
+         "type": "import_unresolved"}
+    try:
+        serialize({"nodes": [a, b], "edges": []}, "t", "t.py", "python")
+    except ValueError as exc:
+        msg = str(exc)
+        assert "rdf:type" in msg, f"the refusal does not say what it is protecting: {msg}"
+        assert "ExternalModule" in msg and "UnresolvedImport" in msg, (
+            f"the refusal must name BOTH classes so the disagreement can be found "
+            f"upstream; got: {msg}"
+        )
+        return
+    raise AssertionError(
+        "a type disagreement did NOT stop the run, so the 'no rdf:type changes' arm "
+        "is dead and a collapsed group would publish an arbitrary winner's class"
+    )
+
+
+def test_an_agreeing_group_does_not_trip_the_type_guard():
+    """Law 40's other direction: the naive way to make a guard fire is to key it so
+    loosely that a clean tree goes red. Identical types must collapse silently to one
+    declaration, not raise."""
+    a = {"id": "shared", "label": "shared", "file_type": "code",
+         "type": "import_external"}
+    b = {"id": "shared", "label": "shared", "file_type": "code",
+         "type": "import_external"}
+    ttl = serialize({"nodes": [a, b], "edges": []}, "t", "t.py", "python")
+    decls = [ln for ln in ttl.splitlines() if ln.startswith("code:t_shared ")]
+    assert len(decls) == 1, (
+        f"an agreeing duplicate group produced {len(decls)} declarations, expected 1: "
+        f"{decls}"
+    )
+    assert "ops:ExternalModule" in decls[0], (
+        f"the surviving declaration changed class: {decls[0]}"
+    )
+
+
+def test_the_collapse_is_reported_not_silent():
+    """A dedupe nobody counts is how the same defect walks back in unnoticed. The count
+    is also the tripwire saying the upstream per-reference duplication is still there,
+    which option C deliberately did not change."""
+    run = _extract_ttl()
+    m = re.search(r"# (\d+) repeat declaration\(s\) across (\d+) IRI", run.notices)
+    assert m, (
+        f"the run collapsed declarations without saying so. stderr was:\n{run.notices!r}"
+    )
+    collapsed, iris = int(m.group(1)), int(m.group(2))
+    assert collapsed >= 1 and iris >= 1, (
+        f"the notice reports {collapsed} collapsed across {iris} IRIs, but the fixture "
+        f"is built to collide; a zero here means the notice is decoration"
+    )
+
+
+def test_counts_are_not_reported_over_an_empty_map():
+    """Law 24's control. Every arm above except the first is of the form "nothing is
+    duplicated", and all of them are true of a map with no declarations at all."""
+    run = _extract_ttl()
+    counts = _declarations(run)
+    assert len(counts) >= 5, (
+        f"only {len(counts)} declaration(s) in the whole map, so 'no IRI is declared "
+        f"twice' is true of almost nothing and this file proved nothing"
+    )
+    nodes = _extract_nodes()
+    assert len(nodes) > len(counts) or len(nodes) >= 5, (
+        f"the extractor produced {len(nodes)} node dict(s) against {len(counts)} "
+        f"declared IRIs; the fixture is too thin to test a collapse"
+    )
+
+
+if __name__ == "__main__":
+    # CI runs this as plain `python <file>` with no pytest installed, so the driver is
+    # not optional: bare `def test_` functions would be defined, called by nothing, and
+    # the job would go green having executed zero legs.
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    rc = 0
+    executed = 0
+    for t in tests:
+        executed += 1
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except Exception as exc:
+            rc = 1
+            first = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+            print(f"FAIL {t.__name__}: {first}")
+    print(f"ran {executed} of {len(tests)} legs; rc={rc}")
+    if executed == 0:
+        print("VOID: zero legs executed, so this file proved nothing")
+        sys.exit(2)
+    sys.exit(rc)

--- a/scripts/ast/ttl_serializer.py
+++ b/scripts/ast/ttl_serializer.py
@@ -331,6 +331,84 @@ def _build_file_membership(edges: list[dict], file_nodes: set[str]) -> dict[str,
     return membership
 
 
+def _plan_declarations(
+    nodes: list[dict],
+    project_clean: str,
+    module_iri: str,
+) -> tuple[dict[str, int], int, int, int]:
+    """#98 option C: decide which node dict OWNS each IRI's one declaration.
+
+    `extract()` accumulates `all_nodes` with `all_nodes.extend(...)` per file and
+    dedupes ids only WITHIN a file (`seen_ids` is per-file, extractor.py:1610),
+    so a symbol referenced from six files arrives as six dicts carrying one id.
+    Every one of them was emitted as its own `code:<id> a ops:<T>` block, so the
+    map held one node per IRI while the TTL declared it many times: measured at
+    `cbb375b2`, 9 IRIs over 17 excess declarations, occurrences
+    [6, 6, 2, 2, 2, 2, 2, 2, 2].
+
+    Returns `(owner, duplicate_iris, dropped, line_rescues)` where `owner` maps
+    each IRI to the INDEX of the dict that may declare it. An IRI absent from
+    `owner`, or mapped to -1, is declared by nobody in the node loop.
+
+    WHY THIS RUNS HERE AND NOT EARLIER. Deduping the `nodes` list itself would
+    change more than the declaration count, which is the whole scope of #98:
+    `_build_import_resolver` keys on the cleaned node LABEL with first-match-wins,
+    and the colliding dicts carry DIFFERENT labels ('./panels/X.svelte' from the
+    import site, 'X.svelte' from the file node). Dropping either one moves import
+    edge resolution. The `stats` counters would move too, and #98 rules that
+    counting attributions is still the right tripwire. So every map is built from
+    the full list and only the EMISSION of a repeat declaration is suppressed.
+
+    WHICH DICT WINS, AND WHY IT IS NOT "THE FIRST ONE". Keep-first is arbitrary on
+    the one field that actually differs in the emitted block. Measured at
+    `cbb375b2`: 6 of the 9 collisions are a file node meeting an import-target
+    stub for the same file, identical but for the source line -- and node order
+    does not agree on which arrives first (`GraphExplorer.svelte` had line 0 then
+    1; `CostAttribution.svelte` had 1 then 0). Keep-first would therefore have
+    published `ops:sourceLine 0` for five panels and `1` for the sixth, a coin
+    flip per id. A real line beats the 0 placeholder, then first-in-order breaks
+    the remaining tie. `line_rescues` counts the groups where that first clause
+    changed the outcome, so the rule cannot rot into decoration unnoticed
+    (PROCESS law 38: a clause never seen firing is not a clause).
+    """
+    groups: dict[str, list[int]] = {}
+    for idx, node in enumerate(nodes):
+        iri = f"code:{project_clean}_{sanitize_iri(node['id'])}"
+        groups.setdefault(iri, []).append(idx)
+
+    owner: dict[str, int] = {}
+    duplicate_iris = 0
+    dropped = 0
+    line_rescues = 0
+
+    for iri, idxs in groups.items():
+        # The file/app-root module block is written before the loop, so it has
+        # already spent this IRI's one declaration. No node may declare it again.
+        # Zero nodes hit this at `cbb375b2`; it is here so the invariant is
+        # "every IRI in the map is declared exactly once" with no exception
+        # carved out for the one declaration that is emitted somewhere else.
+        if iri == module_iri:
+            owner[iri] = -1
+            duplicate_iris += 1
+            dropped += len(idxs)
+            continue
+        if len(idxs) == 1:
+            owner[iri] = idxs[0]
+            continue
+        duplicate_iris += 1
+        dropped += len(idxs) - 1
+        win = idxs[0]
+        if _extract_line(nodes[win]) == 0:
+            for i in idxs[1:]:
+                if _extract_line(nodes[i]) > 0:
+                    win = i
+                    line_rescues += 1
+                    break
+        owner[iri] = win
+
+    return owner, duplicate_iris, dropped, line_rescues
+
+
 def _build_import_resolver(
     nodes: list[dict],
     project_clean: str,
@@ -454,10 +532,52 @@ def serialize(
     lines.append(f'    ops:language "{language}" .')
     lines.append("")
 
-    for node in nodes:
+    # #98 option C: one IRI, one declaration. Planned before the loop so the
+    # decision is made over the WHOLE node list rather than by whichever dict
+    # happens to arrive first. Both declaration sites in the loop below (the
+    # ontology-document branch and the code branch) are gated on it -- a guard
+    # covering one branch would have a blind axis, which is how an instrument
+    # comes to report clean over a case it never visits (PROCESS law 41).
+    decl_owner, dup_iris, dup_dropped, dup_line_rescues = _plan_declarations(
+        nodes, project_clean, module_iri
+    )
+    if stats is not None:
+        stats["duplicate_declaration_iris"] = dup_iris
+        stats["duplicate_declarations_dropped"] = dup_dropped
+        stats["duplicate_declaration_line_rescues"] = dup_line_rescues
+
+    # #98's REQUIRED ARM, enforced in the product code rather than only in a
+    # test: this change owns the declaration COUNT and must never change a
+    # node's `rdf:type`. Retyping was #105, which is merged and closed. Every
+    # dict that collapses onto one IRI has its ops class computed as before,
+    # and a disagreement STOPS the run naming both classes -- it cannot reach a
+    # map as a silently-picked winner.
+    declared_ops_type: dict[str, str] = {}
+
+    for idx, node in enumerate(nodes):
+        node_iri = f"code:{project_clean}_{sanitize_iri(node['id'])}"
+        owns_declaration = decl_owner.get(node_iri) == idx
         meta = node.get("ontology_meta")
         if meta and node.get("file_type") == "ontology_document":
-            iri = f"code:{project_clean}_{sanitize_iri(node['id'])}"
+            # Bare class name, the same shape the code branch records, so an
+            # id that arrives as both an ontology document and a code node is
+            # compared like with like rather than "ops:Document" against
+            # "Module" -- which would fire this arm on a formatting difference.
+            onto_declared = node.get("ontology_type", "Document")
+            previous = declared_ops_type.setdefault(node_iri, onto_declared)
+            if previous != onto_declared:
+                raise ValueError(
+                    f"#98 dedupe: {node_iri} is declared ops:{previous} by one "
+                    f"node dict and ops:{onto_declared} by another. "
+                    f"Deduplicating at "
+                    f"emission must not change any node's rdf:type -- that is "
+                    f"#105's territory and it is closed. Fix the disagreement "
+                    f"upstream in the extractor rather than letting emission "
+                    f"pick a winner."
+                )
+            if not owns_declaration:
+                continue
+            iri = node_iri
             label = _escape_literal(node.get("label", node["id"]))
             onto_type = node.get("ontology_type", "Document")
             lines.append(f"{iri} a ops:{onto_type} ;")
@@ -528,7 +648,25 @@ def serialize(
                     node_type = "entity"
                     untyped_non_code += 1
         ops_type = TYPE_MAP[node_type]
-        iri = f"code:{project_clean}_{sanitize_iri(node['id'])}"
+
+        # #98's required arm. The type is computed for EVERY dict, including the
+        # ones whose declaration is about to be suppressed, for two reasons: the
+        # `untyped_non_code` counter keeps counting attributions exactly as it
+        # did before this change, and a collapsed group that disagrees on its
+        # ops class stops the run instead of publishing an arbitrary winner.
+        previous = declared_ops_type.setdefault(node_iri, ops_type)
+        if previous != ops_type:
+            raise ValueError(
+                f"#98 dedupe: {node_iri} is declared ops:{previous} by one node "
+                f"dict and ops:{ops_type} by another. Deduplicating at emission "
+                f"must not change any node's rdf:type -- that is #105's "
+                f"territory and it is closed. Fix the disagreement upstream in "
+                f"the extractor rather than letting emission pick a winner."
+            )
+        if not owns_declaration:
+            continue
+
+        iri = node_iri
         label = _escape_literal(node.get("label", node["id"]))
         line_num = _extract_line(node)
         signature = node.get("signature", "")


### PR DESCRIPTION
Closes #98.

`base ast query --contains RuntimeError` returns one node. There are six referencing lines behind it, and nothing in the output says so. The map holds one node per IRI while the TTL declared it many times, so the tool tells a person there is one thing where there are several.

## The cause

`extract()` accumulates nodes with `all_nodes.extend(...)` once per file (`extractor.py:8253`) and the only id dedupe is `seen_ids`, which `extractor.py:1610` scopes to a single file — its own comment says so. Nothing between there and the return at `extractor.py:8437` collapses ids across files. A symbol referenced from six files therefore reaches the serializer as **six dicts carrying one id**, and each was emitted as its own `code:<id> a ops:<T>` block. In `--full` mode `serialize()` is called exactly once (`onto_ast.py:172`), so this is not repeated calls — it is one node list containing repeats.

Measured at `cbb375b2`: **9 IRIs, 17 excess declarations, occurrences [6,6,2,2,2,2,2,2,2]**.

## The fix

#98's ruling is option C: deduplicate at emission. `_plan_declarations` decides which node dict **owns** each IRI's one declaration; the emission loop skips the rest. Both declaration sites in that loop are gated — a guard covering only the code branch and not the ontology-document branch would have a blind axis.

The extractor is **unchanged**. Option C deliberately declined to stop the per-reference duplication, so the collapse is now counted and printed rather than silent:

```
# 17 repeat declaration(s) across 9 IRIs collapsed to one declaration each (the extractor emits one node per reference; #98)
#   5 kept a later dict carrying a real source line over an earlier one with none
```

### Placement is load-bearing

The dedupe is inside the emission loop, **not** on the `nodes` list:

- `_build_import_resolver` keys on the cleaned node **label** with first-match-wins, and the colliding dicts carry different labels (`./panels/Alpha.svelte` from the import site, `Alpha.svelte` from the file node). Deduping earlier moves import edge resolution.
- `stats` counts **dicts**, and #98 rules that counting attributions is still the right tripwire.

So every map is still built from the full node list. Measured on both arms: `total_entities` 5270, `app_root_entities` 18, `untyped_non_code_entities` 0 — all identical.

### Keep-first would have been wrong

6 of the 9 collisions are a real **file node** meeting an **import-target stub** for that same file, identical but for the source line — and node order does not agree on which arrives first:

```
GraphExplorer.svelte    declared at TTL 7810 sourceLine 0, at 8286 sourceLine 1
CostAttribution.svelte  declared at TTL 8111 sourceLine 1, at 9161 sourceLine 0
```

Keep-first therefore publishes `ops:sourceLine 0` for five panels and `1` for the sixth, a coin flip per id that **no arm counting declarations can detect**. The rule is: a real line beats the `0` placeholder, then first-in-order breaks the tie. 5 rescues, verified **per id** rather than by the count matching a prediction, and no id lost a real source line it had.

### Scope: declaration count, never type

Retyping was #105 and it is merged and closed. The arm is enforced in the product code, not only in a test: every dict collapsing onto one IRI has its ops class computed as before, and a disagreement raises naming **both** classes rather than letting emission pick a winner.

## Acceptance

Every cell measured in one run of `accept98.py`, both sides, over an **isolated pair**: one `extract()` feeding both serializer versions.

| # | leg | before | after | expected | |
|---|---|---|---|---|---|
| 1 | duplicated id population | 9 | **0** | 0 | PASS |
| 2 | excess declaration lines | 17 | **0** | 0 | PASS |
| 3 | distinct declared ids vs declaration lines | 5254 vs 5271 | **5254 vs 5254** | equal; distinct identical both sides | PASS |
| 4 | `base_svelte` declaration count | 6 | **1** | 1 | PASS |
| 5 | the `UnresolvedImport` stub for `../lib/api.ts` | 6 | **1** | 1 | PASS |
| 6 | the seven remaining duplicated ids | 2 each | **1 each** | 1 each | PASS |
| 7 | type census, whole map, by IRI | 13 classes | **identical, 0 ids retyped** | identical | PASS |
| 8a | relation triples at column 0 | 9535 | **9535** | unchanged | PASS |
| 8b | intra-block `ops:definedIn` lines | 5269 | **5252** | down by exactly 17 | PASS |
| 9 | app-root counter | 18 | **18** | unchanged, relationship stated | PASS |

Named arms, enumerated rather than subtracted from a total: **A1** every IRI declared exactly once · **A2** no id changed `rdf:type` · **A3** no id lost a real source line · **A4** line-rescue verified per id · **A5** the operator-visible notice agrees with the TTL census · **A6** import resolution untouched (`241 resolved, 0 failed, 608 third-party` both sides) · **A7** notice lines byte-identical to the real `onto_ast.py` stderr. All PASS.

### Leg 8 is split, and the figure it replaced was mislabelled

The acceptance table originally read "edge lines 5238 → unchanged". `count98.py`'s `EDGE` regex is `^\s+(ops:|code:)\S+\s+code:\S+\s*[;.]\s*$` — it **requires leading whitespace**, so it cannot match the relation triples the serializer writes at column 0. All 5238 of its matches were indented `ops:definedIn` lines **inside declaration blocks**. Removing 17 declaration blocks must remove their `definedIn` lines too, so that leg was impossible on a correct fix by construction.

**8b falling by exactly 17 is a third independent reproduction of the excess at a different layer**, and it proves whole blocks were removed rather than only their type lines.

### Leg 9 in words, because it is a claim about a shipped number

The counter counts **attributions** — 18 orphan dicts across only **7** distinct app-root IRIs, of which 3 are duplicated ids (`base_svelte` 6, the api.ts stub 6, `base_d3` 2 = 14 dicts) and 4 are genuinely single. #98 rules that counting attributions is still the right tripwire, so the counter is deliberately untouched and its meaning has not changed. **The changelog wording therefore does not change.** The two numbers still differ; the difference is now explained rather than accidental.

## Why the measurement needed an isolated pair

base's AST extractor extracts base's own source, so this fix is **inside the corpus under test**. Two full `onto_ast.py` runs compared two different trees: `_plan_declarations` and its docstring added +1 `ops:Function` and +1 `ops:Rationale`, and the new call sites added relation triples. The first acceptance run read distinct ids **5223 before, 5225 after** and leg 8a **9471 to 9476**, failing legs 7, 8a and 8b. **None of those numbers was the dedupe.**

`iso98.py` removes the corpus as a variable: `extract()` runs once and the same node and edge objects go to both serializer versions. It produces **no numbers at all** unless four conditions hold — the two serializer files differ by md5, the new arm has `_plan_declarations`, the orig arm does not, and each serializer reproduces its own output across interleaved calls (`orig, new, new, orig`), which is what proves neither arm leaves mutable state behind for the other. The baseline arm is the pristine file at `HEAD`, md5 `eeceae354ae3fd0eb10d3e7f35610bf7`, equal to the md5 recorded **before** any edit; a must-fail canary on the same git channel returned rc 128.

## Tests

`scripts/ast/test_declaration_dedupe.py` — **11 legs, 11 executed, rc 0.** `check_test_reachability.py` reports `shape=A defined=11 unreachable=0 __main__=True`.

Its first arm is a positive control **in the opposite direction**: `extract()` must still hand back more than one dict for some id. Every other arm asserts "no IRI is declared twice", and all of them pass perfectly over a fixture that never collided — so if the fixture stops reproducing the shape, the file says so instead of reporting a clean map.

Each product mutation fires **exactly one** detector:

| mutation | fired | stayed green |
|---|---|---|
| line-rescue clause deleted (keep-first) | the determinism arm, only | all 8 count arms |
| notice suppressed, dedupe working | the notice arm, only | all count arms |
| dedupe removed, notice printing | the 3 count arms | the notice arm, and the extractor control |
| two dicts one id, disagreeing types | the `ValueError`, naming both classes | — |
| two dicts one id, **agreeing** types | nothing — collapsed to exactly 1 | the guard did not over-fire |

The instrument itself was proven over four inputs: healthy gives **PASS rc 0**; regressed fix gives **FAIL rc 1** with all five controls still green (the blindness control); blinded anchor gives **VOID rc 2** with zero counts printed; empty input gives **VOID rc 2**.

That exercise also caught a defect in the instrument's own first version: a control asserting "reads exactly 1 after" fails when the **fix** is missing, which reports VOID (*the instrument cannot see*) for what is actually FAIL (*the fix is not there*). It now asserts the id is still **present**, and "exactly once" is left to legs 4 and 6.

## Not run locally, and why

Zero `.rs` files change. `target/release/deps` holds 0 files, so a release build is a cold full compile of the rocksdb dependency tree. The two Rust tests most exposed to a notice-stream change were read rather than assumed: `tests/ast_extractor_notices_test.rs:61`'s exact-equality assertion is over a synthetic fixture (`# one`, `# two`, `# three`), not real extractor output, and its real-extraction assertions at `:105-115` use `contains`, which an added line does not break. CI covers the suite and clippy on this head sha.

## One pre-existing red, not from this change

`scripts/ast/test_file_attribution.py` fails on **Windows** at `cbb375b2`, before this branch touched anything. It hardcodes POSIX separators (`TREE = {"src/alpha/mod.rs": ...}`) and asserts that literal appears in the TTL; on Windows the TTL carries the backslash spelling, so the comparison cannot match and it fails with a message naming the exact regression it guards. Extraction returns rc 0 and normalising separators makes the two equal.

**The failure is platform-specific rather than a flake. Whether the emitter or the assertion is at fault is unsettled.**

An earlier version of this section called it "a Windows-only false FAIL in the test, not a product defect". That bundled two claims and treated both as measured, and only the first was:

- **Measured:** it fails on Windows and passes on `ubuntu-latest` — `python-ast-tests` step 6 concluded success on this head sha.
- **Not measured, and CI cannot measure it:** that the failure is *false*, i.e. the assertion is at fault rather than the emitter. A POSIX-asserting test passing on POSIX is what **both** readings predict, so the green proves platform-specificity and nothing more.

The read that would settle it, deliberately unchased as out of this lane's scope: does `base ast query --file` work on Windows against backslash `sourceFile` values? A backslashed query side means the emitter is self-consistent and the assertion is at fault; a normalising query side means the emitter is.

> **Settled by `condor` on 2026-09-09 by measurement: the assertion is at fault. Test-only fix.** The paragraph above is preserved as what was concluded at the time and on what basis; this line exists so the open question does not read as still open. `ast_query.rs:534` `norm_file_expr` normalises the **stored** side, **every comparing site normalises** (the four at `:103`, `:301`, `:423`, `:740`, via `:109`, `:306`, `:429`, `:745`), and a Windows fixture whose map is 19-of-19 backslash resolves `src/alpha/mod.rs` to 2 entities while a must-fail canary returns nothing — so the test asserts a serialization spelling the product never promised. The claim was true and *unmeasured*; publishing it as measured was the overclaim, and narrowing it was correct regardless of which way the measurement later fell.

Proven pre-existing by A/B on exactly the two files this branch changes, with pristine copies pulled from `HEAD` and their md5s matched against the values recorded before any edit: **rc 1 pristine, rc 1 changed, same assertion, same line.** No GitHub issue opened per standing order 2; recorded as `N-ATTRIBUTION-TEST-POSIX-SEPARATORS` in the work order's Unranked findings.

---

**DO NOT MERGE.** `condor` grades, `auk` merges.

Build record: `~/.base-gbl/verification/base-0.14.3-heron/BUILD-98-cbb375b2.md`
