### PR TITLE
fix(store): retry the atomic rename, and stop discarding its Err (#127)

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -448,7 +448,12 @@ fn append_line(log_path: &Path, line: &str) -> io::Result<()> {
 /// The transient lock family a scanner or backup agent produces:
 /// `EPERM`, `EBUSY`, `EACCES`, `EMFILE`, `ENFILE` — plus their Windows
 /// equivalents. Everything else is fatal.
-fn is_transient_lock(e: &io::Error) -> bool {
+///
+/// `pub(crate)` for `store::rename_with_retry` (#127), which faces the same
+/// family on the same files: an antivirus or the search indexer holding a handle
+/// makes the log append fail here and the graph rename fail there. One list, two
+/// callers — a second copy is a second thing to drift.
+pub(crate) fn is_transient_lock(e: &io::Error) -> bool {
     use io::ErrorKind::*;
     if matches!(e.kind(), PermissionDenied | Interrupted | WouldBlock) {
         return true;

--- a/src/crud/project.rs
+++ b/src/crud/project.rs
@@ -69,7 +69,22 @@ pub fn add_with_stage(
     let link_sparql = format!(
         "INSERT DATA {{ GRAPH <{graph}> {{ <{iri}> {p}:hasDomain <{domain_iri}> }} }}"
     );
-    let _ = crud::load_and_mutate(cwd, ns, &link_sparql);
+    // #127. This was `let _ =`, so a failed write here was discarded and `add`
+    // returned `Ok(slug)` regardless -- `base project add` printed success over
+    // a link that is not in the graph. MEASURED by inducing a real rename
+    // failure on this exact write: exit 0, "Project '…' created", and zero
+    // `hasDomain` quads in the store. The same injection one write earlier, at
+    // `:61`, exits non-zero and says why, so the silence was this line's alone.
+    //
+    // The project record at `:61` has already landed by the time we get here, so
+    // the message says what IS in the graph as well as what is not: a bare
+    // failure would read as "nothing happened", which is the opposite of true.
+    crud::load_and_mutate(cwd, ns, &link_sparql).with_context(|| {
+        format!(
+            "project '{slug}' IS registered, but linking it to domain \
+             '{domain_slug}' failed and that link is NOT in the graph"
+        )
+    })?;
 
     Ok(slug)
 }

--- a/src/crud/rule.rs
+++ b/src/crud/rule.rs
@@ -55,7 +55,16 @@ pub fn add_with(
            FILTER NOT EXISTS {{ GRAPH <{graph}> {{ <{domain_iri}> a {p}:Domain }} }}\n\
          }}"
     );
-    let _ = crud::load_and_mutate(cwd, ns, &ensure_domain);
+    // #127. This was `let _ =`. MEASURED by inducing a real rename failure on
+    // this exact write and releasing the conflict before the rule write below:
+    // `base rule add` exits 0 and prints "Rule 0 added to domain '…'", the rule
+    // quads are in the graph, and the domain's `rdf:type Domain` quad is not --
+    // a rule hanging off a domain record that was never written, reported as
+    // success. Failing here instead means the rule is not written either, which
+    // is the honest outcome: the alternative is a rule filed under a domain that
+    // does not exist.
+    crud::load_and_mutate(cwd, ns, &ensure_domain)
+        .with_context(|| format!("ensuring domain '{domain_name}' exists"))?;
 
     // Optional rationale triple (Phase 26) — "Do X — because Y" on injection.
     let rationale_triple = match rationale.filter(|r| !r.is_empty()) {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1000,8 +1000,19 @@ fn write_back_inner<W: Write>(
         }
     }
 
-    // Atomic rename
-    fs::rename(&tmp_path, path).with_context(|| {
+    // Atomic rename, retried across the transient lock family (#127).
+    //
+    // MEASURED on Windows: `fs::rename` over an existing destination returns
+    // `PermissionDenied` / os error 5 for as long as ANY other process holds
+    // that destination open without `FILE_SHARE_DELETE`, and succeeds the moment
+    // the same handle allows DELETE -- so the cause is the share mode, not the
+    // handle. An antivirus or the search indexer holding one for a few
+    // milliseconds is routine, which made an un-retried rename turn an ordinary,
+    // self-clearing conflict into a failed write.
+    //
+    // Same predicate and same shape as the change-log append below: retrying
+    // anything OUTSIDE the lock family turns a clear error into a slow one.
+    rename_with_retry(&tmp_path, path).with_context(|| {
         format!(
             "Failed to rename {} → {}",
             tmp_path.display(),
@@ -1018,6 +1029,41 @@ fn write_back_inner<W: Write>(
     crate::doorbell::ring(path);
 
     Ok(())
+}
+
+/// Attempts for the rename retry, and the first backoff step. Matches the
+/// change-log append (`changelog.rs`), which faces the same lock family on the
+/// same directory: sleeps of 15+30+60+120 ms, so a conflict has ~225 ms to
+/// clear.
+///
+/// BOUNDED on purpose. Every caller of this sits on a path a hook can reach on
+/// every tool call, so an unbounded spin would turn a stuck handle into a hang.
+/// A conflict that outlives the budget is a real failure and must still surface
+/// -- retrying forever would replace a lost write with a wedged command.
+const RENAME_ATTEMPTS: usize = 5;
+const RENAME_BASE_DELAY: std::time::Duration = std::time::Duration::from_millis(15);
+
+/// `fs::rename`, retried only while the error is the transient lock family.
+fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
+    let mut delay = RENAME_BASE_DELAY;
+    let mut last: Option<std::io::Error> = None;
+
+    for attempt in 0..RENAME_ATTEMPTS {
+        match fs::rename(from, to) {
+            Ok(()) => return Ok(()),
+            // Anything outside the lock family is a real failure. Retrying
+            // ENOSPC or a missing temp turns a clear error into a slow one.
+            Err(e) if !crate::changelog::is_transient_lock(&e) => return Err(e),
+            Err(e) => last = Some(e),
+        }
+
+        if attempt + 1 < RENAME_ATTEMPTS {
+            std::thread::sleep(delay);
+            delay *= 2;
+        }
+    }
+
+    Err(last.unwrap_or_else(|| std::io::Error::other("rename failed")))
 }
 
 /// Dump the store into `sink` through a buffer, close it, and prove the file
@@ -1723,5 +1769,59 @@ mod tests {
     fn union_query_surfaces_parse_errors() {
         let store = named_graph_store();
         assert!(query_union(&store, "SELECT ?x WHERE { this is not sparql").is_err());
+    }
+
+    // ─── #127 rename retry ───────────────────────────────────────
+
+    #[test]
+    fn rename_with_retry_renames() {
+        let dir = tempfile::tempdir().unwrap();
+        let from = dir.path().join("a");
+        let to = dir.path().join("b");
+        std::fs::write(&from, b"payload").unwrap();
+        rename_with_retry(&from, &to).unwrap();
+        assert_eq!(std::fs::read(&to).unwrap(), b"payload");
+        assert!(!from.exists(), "source should be gone after a rename");
+    }
+
+    #[test]
+    fn rename_with_retry_replaces_an_existing_destination() {
+        // The case #127 is actually about: the destination already exists, which
+        // on Windows is what makes the rename need DELETE access to it.
+        let dir = tempfile::tempdir().unwrap();
+        let from = dir.path().join("a");
+        let to = dir.path().join("b");
+        std::fs::write(&from, b"new").unwrap();
+        std::fs::write(&to, b"old").unwrap();
+        rename_with_retry(&from, &to).unwrap();
+        assert_eq!(std::fs::read(&to).unwrap(), b"new");
+    }
+
+    /// A non-transient error must come back IMMEDIATELY, not after the budget.
+    ///
+    /// This is the clause that keeps the retry honest: `is_transient_lock` is
+    /// what separates "wait, this clears itself" from "this is a real failure",
+    /// and without the early return a missing temp file would cost every caller
+    /// the full backoff before saying so. Delete the `if !is_transient_lock`
+    /// guard and this test fails on the elapsed bound, so it discriminates the
+    /// clause rather than merely reaching it.
+    #[test]
+    fn rename_with_retry_does_not_retry_a_non_transient_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        let to = dir.path().join("b");
+
+        let started = std::time::Instant::now();
+        let err = rename_with_retry(&missing, &to).unwrap_err();
+        let elapsed = started.elapsed();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound, "got {err:?}");
+        // The full budget is 15+30+60+120 = 225 ms. Anything under half of that
+        // can only mean the loop returned without sleeping.
+        assert!(
+            elapsed < std::time::Duration::from_millis(100),
+            "a NotFound burned the retry budget ({elapsed:?}) — the \
+             is_transient_lock early return is not being taken"
+        );
     }
 }


### PR DESCRIPTION
Closes #127.

## The defect, measured rather than inferred

`fs::rename` over an existing `graph.nq` (`store.rs:1004`) returns `PermissionDenied` / os error 5 for as long as any other process holds that file open without `FILE_SHARE_DELETE`. On Windows an antivirus or the search indexer holding one for a few milliseconds is routine. The rename had **no retry**, and two callers discarded the resulting `Err` with `let _ =`, so an ordinary self-clearing conflict became a **silently lost write behind a success message**.

The prior re-verify established by *reading the tree* that the `Err` reaches every caller and that two sites throw it away. It explicitly did not induce a failure, and said so. A fault-injection harness now does, by holding the destination open with a share mode that denies DELETE:

| command | conflict on | result on `main` |
|---|---|---|
| `base project add` | the link write, `project.rs:72` | **exit 0**, `Project '…' created`, **zero `hasDomain` quads** |
| `base rule add` | the ensure-domain write, `rule.rs:58` | **exit 0**, `Rule 0 added to domain '…'`, rule quads present, the domain's **`rdf:type Domain` quad absent** |

The same injection one write earlier, at a site that *propagates*, exits non-zero and names the rename. So the silence belonged to those two `let _ =` lines and not to the injection.

## The mechanism, isolated before anything else was built

25 lines of dependency-free Rust calling `std::fs::rename` — the exact API at `store.rs:1004` — built with the same toolchain as base:

| arm | condition | result |
|---|---|---|
| A | no handle, dst exists | `RENAME_OK` |
| B | handle, `share=FILE_SHARE_READ` | `raw_os_error=Some(5) PermissionDenied` |
| C | no handle, dst absent | `RENAME_OK` |
| D | handle, `share=READ\|WRITE\|DELETE` | `RENAME_OK` |

A is the positive control, C the can-succeed canary, **D the discriminator**: B and D differ in exactly one integer, so the cause is the share mode and not the existence of an open handle.

## The change

- **`store::rename_with_retry`** retries only the transient lock family: 5 attempts on a 15 ms doubling backoff (~225 ms), matching the change-log append that faces the same family on the same directory. **Bounded on purpose** — these paths are reached by a hook on every tool call, so an unbounded spin would trade a lost write for a wedged command, and a conflict that outlives the budget is a real failure that must still surface.
- **`changelog::is_transient_lock` becomes `pub(crate)` and is reused, not copied.** It already carries `PermissionDenied`, os error 5 and os error 32. A second list is a second thing to drift.
- **`crud/project.rs:72` and `crud/rule.rs:58` propagate.** The project message names what **is** in the graph as well as what is not, because the project record at `:61` has already landed by that point and a bare failure would read as "nothing happened".

## Acceptance: four trees, so each leg is shown to discriminate one thing

Three legs, and neither substitutes for the other — a retry-only fix leaves the silent loss untouched, a propagate-only fix delivers no retry at all. Two intermediate mutants were built to prove that rather than assert it:

| tree | binary md5 | L7 transient (retry) | L2 permanent (`project.rs:72`) | L8 (`rule.rs:58`) |
|---|---|---|---|---|
| `main` 96ce58ca | `d34ddf14` | RED | RED | RED |
| M1 retry only | `2d0ad19c` | **GREEN** | RED | RED |
| M2 propagate only | `3516aff5` | RED | **GREEN** | **GREEN** |
| this branch | `3e690ccb` | GREEN | GREEN | GREEN |

**M1 fires only L2/L8. M2 fires only L7.** Each mutation fires exactly one detector.

Alongside them, on every run: a control leg that must find a write which *did* land (or the reader cannot be trusted to see one), a must-fail canary on a slug never written, a leg applying the identical injection at a propagated site that must stay **loud**, and a whole-command-hold guard recorded explicitly as a regression guard on the propagated path — it passes on both trees and is therefore never evidence the fix works.

## Severity — deliberately not oversold

**One lost write, not a degrading store.** A normal `project add` immediately after a failed rename exits 0 and reads back complete: the per-pid temp name means a fresh process does not collide, and the sweep in `write_back_inner` reaps the stale temp after 60 s. Measured, not predicted.

## Tests

Three unit tests on `rename_with_retry`. The third asserts a **non-transient** error returns immediately rather than burning the budget; deleting the `is_transient_lock` early-return arm makes it fail at 226.9 ms — the exact full budget — while the other two stay green, so it discriminates that clause rather than merely reaching it.

## Known-red on Windows, not introduced here

`cargo test --no-fail-fast` on this branch has one failing target on a Windows checkout: `hook_output_channel_test::the_events_that_deliver_plain_stdout_still_use_it`. **It fails identically on unmodified `main`** (same assertion, `"pre-tool-use" => must not write bare blocks`, at `tests/hook_output_channel_test.rs:191`), measured in a clean control worktree at `96ce58ca` before attributing anything. It is pre-existing and Windows-only. `cargo clippy --all-targets -- -D warnings` is clean, with a permissive-clippy control leg run beside it so a missing tool could not be read as a pass.
