### PR TITLE
fix(ast): a PHP config key resolves to its config file in another file

### DIFF
--- a/scripts/ast/extractor.py
+++ b/scripts/ast/extractor.py
@@ -1518,6 +1518,38 @@ def _report_no_literal_key(helper: str, reason: str, path_str: str, line: int) -
     )
 
 
+def _report_ambiguous_cross_file_target(
+    relation: str, callee: str, candidates: list[str], path_str: str, location: str
+) -> None:
+    """One stderr line when a helper reference names a target that is not unique.
+
+    Scoped to raw_calls entries carrying their own `relation` -- the helper-reference
+    lane -- for the same reason _report_no_literal_key is not widened. An ordinary
+    cross-file call to a common short name (log, execute, find) collides by design and
+    its silence is the DOCUMENTED behaviour of the uniqueness gate, not a defect; a
+    helper reference whose key read perfectly and named exactly one file that happens
+    to share a basename is a silent loss, which is the shape #118 shipped a fix for.
+
+    Measured on a real Laravel tree before scoping this: 897 raw_calls entries, and
+    entries hitting len(candidates) > 1 in the ordinary-call lane numbered ZERO -- so
+    the narrow scope is not about volume today, it is about the collision case the
+    comment on the uniqueness gate itself names for repos larger than that one.
+
+    REPORTS rather than preferring a candidate. A directory-based tie-break (prefer a
+    `config/` match) would put framework-specific logic inside a pass built for every
+    language, which is a defect waiting for its second framework.
+    """
+    # raw_calls stores source_location as "L<n>"; the report says ":<n>" so it reads the
+    # same as _report_no_literal_key above. One report convention, not two.
+    line = location[1:] if location[:1] == "L" else location
+    print(
+        f"base-ast: {relation} target {callee!r} at {path_str}:{line} matches "
+        f"{len(candidates)} nodes ({', '.join(sorted(candidates))}) "
+        f"- ambiguous, no {relation} edge emitted",
+        file=sys.stderr,
+    )
+
+
 _PHP_CONFIG = LanguageConfig(
     ts_module="tree_sitter_php",
     ts_language_fn="language_php",
@@ -2303,6 +2335,28 @@ def _extract_generic(
                                 "source_location": f"L{line}",
                                 "weight": 1.0,
                             })
+                    elif not tgt_nid:
+                        # The key read fine but names no node in THIS file. Hand it to
+                        # the cross-file pass in extract() the way an unresolved call is
+                        # handed over -- but carrying its OWN relation, because the
+                        # promotion hard-codes "calls" and a config key is a reference,
+                        # not a call. Routing this in without the relation would assert
+                        # that a controller CALLS config/app.php: fabricated
+                        # relationship data, and worse than the silence it replaces
+                        # because a wrong edge is believed.
+                        #
+                        # The target is the ".php" form. Measured on a real Laravel
+                        # tree: the bare segment is not a key in the global label index
+                        # at all (0 hits) and only "<segment>.php" resolves -- and it is
+                        # the form this branch already computes on the line above.
+                        raw_calls.append({
+                            "caller_nid": caller_nid,
+                            "callee": f"{segment}.php",
+                            "relation": f"uses_{callee_name}",
+                            "is_member_call": is_member_call,
+                            "source_file": str_path,
+                            "source_location": f"L{node.start_point[0] + 1}",
+                        })
 
             # Service container bindings: $this->app->bind(Foo::class, Bar::class)
             if (node.type == "member_call_expression"
@@ -8447,10 +8501,26 @@ def extract(
         if rc.get("is_member_call"):
             continue
         candidates = global_label_to_nids.get(callee.lower(), [])
+        # An entry may carry its own relation (a helper reference such as
+        # config('app.name') is a REFERENCE to a file, not a call to it). The key is
+        # OPTIONAL and read with a default: raw_calls is persisted to the per-file
+        # cache, so a cache written before this field existed is read back after it
+        # and must default rather than raise.
+        relation = rc.get("relation", "calls")
         # Skip ambiguous names that resolve to multiple nodes — these are
         # common short names (log, execute, find) with no import evidence
         # to pick the right target; emitting all edges inflates god_nodes.
         if len(candidates) != 1:
+            # A helper reference that collides is a SILENT LOSS: its key read
+            # perfectly and named one file, which happens to share a basename with
+            # another. Report it rather than preferring a candidate. Ordinary calls
+            # keep the documented silence — colliding on a common short name is the
+            # behaviour this gate exists for, not a defect.
+            if relation != "calls" and len(candidates) > 1:
+                _report_ambiguous_cross_file_target(
+                    relation, callee, candidates,
+                    rc.get("source_file", ""), rc.get("source_location", ""),
+                )
             continue
         tgt = candidates[0]
         caller = rc["caller_nid"]
@@ -8473,17 +8543,22 @@ def extract(
             else:
                 confidence = "INFERRED"
                 confidence_score = 0.8
-            all_edges.append({
+            edge = {
                 "source": caller,
                 "target": tgt,
-                "relation": "calls",
-                "context": "call",
+                "relation": relation,
                 "confidence": confidence,
                 "confidence_score": confidence_score,
                 "source_file": rc.get("source_file", ""),
                 "source_location": rc.get("source_location"),
                 "weight": 1.0,
-            })
+            }
+            # "context": "call" describes a call site. A helper reference is not one,
+            # and the in-file uses_* emission at the config branch does not set it
+            # either — so the two lanes agree on the shape they produce.
+            if relation == "calls":
+                edge["context"] = "call"
+            all_edges.append(edge)
 
     # Relativize source_file fields so paths are portable across machines (#555)
     for item in all_nodes + all_edges:

--- a/scripts/ast/relation_vocabulary.py
+++ b/scripts/ast/relation_vocabulary.py
@@ -31,6 +31,23 @@ assumptions (law 31 — a guard is only proven against the codebase):
      this single site. Resolving it means reading the guard, so that widening
      `helper_fn_names` widens the vocabulary and fails this test until the
      table is updated, rather than silently dropping a new relation.
+  7. the SAME f-string, written INLINE in the slot rather than bound to a name
+     first. Shape 6 only ever looked for an `ast.Assign`, so an author who put
+     `"relation": f"uses_{callee_name}"` straight into a `raw_calls` dict — the
+     obvious spelling, and identical in meaning — landed in `unresolved`. The
+     reduction is the same closed-set walk; only where the JoinedStr sits
+     differs, so shapes 6 and 7 share one resolver.
+  8. a RELAY: a name bound to `<mapping>.get("relation", <const>)`, which hands
+     on a relation some OTHER site in this file already wrote. It resolves to
+     the default, and its non-default range needs no separate resolution
+     because shape 2 already visits every site in this file that writes a
+     `"relation"` key — a relay cannot introduce a relation no writer spelled,
+     and if a writer's own slot is unresolvable then THAT site fails the census.
+     The closure is only valid while every write goes through a dict literal, so
+     the resolver first proves there is no `<expr>["relation"] = ...` subscript
+     write anywhere in the file; one such write and the relay goes back to
+     `unresolved` rather than being trusted. That is what keeps this from being
+     a narrowing: the shape is falsifiable by a single line of new code.
 
 Anything the resolver cannot reduce to constants is returned in `unresolved`, and
 the caller is expected to FAIL on a non-empty list rather than report a smaller
@@ -357,6 +374,10 @@ def extractor_relations(source_path: Path | str) -> Vocabulary:
         if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name in EDGE_FNS
     )
     counts["forwarders"] = len(forwarders)
+    # Shape 8's precondition, computed ONCE and reported so a reader can see it was
+    # checked rather than assumed. A non-empty list revokes every relay.
+    subscript_writes = _subscript_writes_key(tree, "relation")
+    counts["subscript_writes_relation_key"] = len(subscript_writes)
 
     def record(shape: str, node: ast.AST, slot: ast.AST | None) -> None:
         if inside_helper(getattr(node, "lineno", 0)):
@@ -378,6 +399,22 @@ def extractor_relations(source_path: Path | str) -> Vocabulary:
             if expanded:
                 vocab.relations.update(expanded)
                 counts["via_closed_set"] = counts.get("via_closed_set", 0) + 1
+                return
+        # shape 7: the same f-string written INLINE in the slot
+        if isinstance(slot, ast.JoinedStr) and scope is not None:
+            inline = _expand_joinedstr(slot, node, scope, closed_sets)
+            if inline:
+                vocab.relations.update(inline)
+                counts["via_inline_fstring"] = counts.get("via_inline_fstring", 0) + 1
+                return
+        # shape 8: a relay of a relation another site in this file wrote. Valid only
+        # while no subscript write can smuggle in a value no dict literal spells.
+        if (isinstance(slot, ast.Name) and scope is not None
+                and not subscript_writes):
+            relayed = _relay_bindings(scope, slot.id, "relation")
+            if relayed:
+                vocab.relations.update(relayed)
+                counts["via_relay"] = counts.get("via_relay", 0) + 1
                 return
         if isinstance(slot, ast.Attribute):
             per_class = _dataclass_field_constants(tree, slot.attr)
@@ -406,17 +443,56 @@ def extractor_relations(source_path: Path | str) -> Vocabulary:
     return vocab
 
 
+def _expand_joinedstr(
+    joined: ast.JoinedStr,
+    at: ast.AST,
+    scope: "_Scope",
+    closed_sets: dict[str, set[str]],
+) -> set[str]:
+    """The shared half of shapes 6 and 7: reduce ONE f-string to constants using the
+    guards that dominate the position `at`.
+
+    Split out of `_expand_fstring_binding` when shape 7 arrived. The reduction never
+    depended on the JoinedStr being the right-hand side of an assignment — only on
+    which guards enclose it — so a bound f-string and an inline one are the same
+    problem read at two different nodes.
+
+    Returns the full cross-product, or an EMPTY SET when any part of the chain is
+    open. An empty return means "unresolved", never "no relations".
+    """
+    pieces: list[set[str]] = []
+    for part in joined.values:
+        literal = _const_str(part)
+        if literal is not None:
+            pieces.append({literal})
+            continue
+        if not (isinstance(part, ast.FormattedValue)
+                and isinstance(part.value, ast.Name)):
+            return set()
+        guards = _dominating_guards(scope.node, at)
+        fields = guards.get(part.value.id) or set()
+        if len(fields) != 1:
+            # No dominating guard, or more than one — the name is not provably
+            # closed at this site, so the whole slot is unresolved rather than
+            # partially guessed.
+            return set()
+        members = closed_sets.get(next(iter(fields)))
+        if not members:
+            return set()
+        pieces.append(set(members))
+    combos = {""}
+    for piece in pieces:
+        combos = {prefix + suffix for prefix in combos for suffix in piece}
+    return combos
+
+
 def _expand_fstring_binding(
     name: str,
     scope: "_Scope",
     closed_sets: dict[str, set[str]],
 ) -> set[str]:
     """Shape 6: a name bound to an f-string over other names the same scope has
-    constrained to a closed frozenset.
-
-    Returns the full cross-product, or an empty set when any part of the chain
-    is open — an empty return means "unresolved", never "no relations".
-    """
+    constrained to a closed frozenset."""
     out: set[str] = set()
     for node in ast.walk(scope.node):
         if not (isinstance(node, ast.Assign) and len(node.targets) == 1):
@@ -426,28 +502,60 @@ def _expand_fstring_binding(
             continue
         if not isinstance(node.value, ast.JoinedStr):
             continue
-        pieces: list[set[str]] = []
-        for part in node.value.values:
-            literal = _const_str(part)
-            if literal is not None:
-                pieces.append({literal})
-                continue
-            if not (isinstance(part, ast.FormattedValue)
-                    and isinstance(part.value, ast.Name)):
-                return set()
-            guards = _dominating_guards(scope.node, node)
-            fields = guards.get(part.value.id) or set()
-            if len(fields) != 1:
-                # No dominating guard, or more than one — the name is not
-                # provably closed at this site, so the whole binding is
-                # unresolved rather than partially guessed.
-                return set()
-            members = closed_sets.get(next(iter(fields)))
-            if not members:
-                return set()
-            pieces.append(set(members))
-        combos = {""}
-        for piece in pieces:
-            combos = {prefix + suffix for prefix in combos for suffix in piece}
+        combos = _expand_joinedstr(node.value, node, scope, closed_sets)
+        if not combos:
+            return set()
         out.update(combos)
+    return out
+
+
+def _subscript_writes_key(tree: ast.AST, key: str) -> list[int]:
+    """Every `<expr>["<key>"] = ...` assignment line in the file.
+
+    Shape 8's closure holds only while every write of a relation key goes through a
+    dict LITERAL, which shape 2 already visits. A subscript write is the one shape
+    that could smuggle in a relation no literal spells, so its presence must revoke
+    the relay rather than be assumed absent (law 48: absence needs a reader that can
+    see, and this one is the reader).
+    """
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        targets: list[ast.AST] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+            targets = [node.target]
+        for t in targets:
+            if isinstance(t, ast.Subscript) and _const_str(t.slice) == key:
+                hits.append(getattr(node, "lineno", 0))
+    return hits
+
+
+def _relay_default(node: ast.AST, key: str) -> str | None:
+    """Shape 8: `<mapping>.get("<key>", "<const>")` -> the constant default."""
+    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get" and len(node.args) == 2):
+        return None
+    if _const_str(node.args[0]) != key:
+        return None
+    return _const_str(node.args[1])
+
+
+def _relay_bindings(scope: "_Scope", name: str, key: str) -> set[str]:
+    """Every constant default a `.get("<key>", ...)` binding of `name` can yield.
+
+    An empty return means unresolved: either the name is not a relay here, or one of
+    its bindings is a relay whose default this reader cannot see.
+    """
+    out: set[str] = set()
+    for node in ast.walk(scope.node):
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1):
+            continue
+        target = node.targets[0]
+        if not (isinstance(target, ast.Name) and target.id == name):
+            continue
+        default = _relay_default(node.value, key)
+        if default is None:
+            return set()
+        out.add(default)
     return out

--- a/scripts/ast/test_php_config_cross_file.py
+++ b/scripts/ast/test_php_config_cross_file.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""`config('app.name')` must resolve to `config/app.php` in ANOTHER file, as `uses_config`.
+
+THE DEFECT THESE LEGS PIN (N-HELPER-NEVER-RESOLVES). The config branch resolved its key
+against `label_to_nid`, which holds only the CURRENT FILE's nodes. `config/app.php` is a
+different file, so the lookup missed and the reference was dropped with no edge and no
+report. Measured on a real 68-file Laravel tree at `main 96df6829`: **26 keys read, ZERO
+edges emitted**, and zero of those 26 resolved in-file -- so the whole feature was silent
+on a real app.
+
+THE BLOCKER `test_relation_is_uses_config` EXISTS FOR. Handing the miss to the cross-file
+promotion in `extract()` is the obvious fix and is wrong on its own: that promotion
+HARD-CODED `"relation": "calls"`. Routed in unchanged it asserts that a controller CALLS
+`config/app.php` -- fabricated relationship data, and WORSE than the silence it replaced,
+because a wrong edge is believed. `test_cross_file_resolves` passes for such an
+implementation. Only the relation leg fails it.
+
+`test_stale_cache_defaults` IS NOT OPTIONAL. `raw_calls` is PERSISTED to the per-file
+cache (`cache.py:217` writes the whole result dict; a cached entry's top-level keys are
+`edges, nodes, raw_calls`). A cache written before the `relation` field existed is read
+back after it, so the promotion reads `rc.get("relation", "calls")` and must NEVER require
+the key. An implementation using `rc["relation"]` raises on a stale cache; one with a wrong
+default silently mis-relates. **Both look like "works" to every other leg here.**
+
+`test_collision_reports` asserts the REPORT, not just the zero. A colliding file-shaped
+target reads zero either way, so a count-only leg is identical before and after the fix and
+proves nothing. Measured on the real tree: 68 files, 66 distinct basenames, `auth.php`
+twice, and one of the two is among the 11 `config/` files -- so a Laravel app with
+`config/auth.php` and any other `auth.php` loses that key. Reporting rather than preferring
+a `config/` directory match is deliberate: framework-specific logic inside a pass built for
+every language is a defect waiting for its second framework.
+
+NO PYTEST. `ci.yml` runs each of these files as plain `python <file>`, and pytest is not
+installed in that job, so bare `def test_` functions would be defined, called by nothing,
+and the job would go green having executed zero legs. The `__main__` driver below is what
+makes them run, and `check_test_reachability.py` is what keeps that true.
+"""
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cache as cache_mod
+from extractor import extract, extract_php
+
+# A Laravel config file: a bare `return [...]`, no class. Its ONLY node is the file node,
+# whose label is `<name>.php` -- which is exactly the key the fix looks up. Measured: the
+# BARE segment (`app`) is not a key in the global label index at all, and only `app.php`
+# resolves, which is the form the config branch already computes.
+CONFIG_FILE = "<?php\nreturn ['b' => 1, 'x' => 2];\n"
+
+
+def _write(root, files):
+    written = []
+    for rel, text in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf8")
+        written.append(p)
+    return sorted(written)
+
+
+def _run(root, paths):
+    """stderr captured in-process, which parallel=False makes possible."""
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        result = extract(paths, cache_root=root, parallel=False)
+    return result, buf.getvalue()
+
+
+def _labels(result):
+    return {n["id"]: n.get("label") for n in result.get("nodes", [])}
+
+
+def _uses(result):
+    return [e for e in result.get("edges", [])
+            if str(e.get("relation", "")).startswith("uses_")]
+
+
+@contextlib.contextmanager
+def _box(name):
+    """A unique, cache-free directory per leg. `.php` is not in
+    `_JS_CACHE_BYPASS_SUFFIXES`, so a shared root would let one leg serve another's
+    answer."""
+    with tempfile.TemporaryDirectory(prefix="cfgxf_%s_" % name) as d:
+        root = Path(d) / uuid.uuid4().hex[:8]
+        root.mkdir(parents=True)
+        assert not (root / ".base-ast-cache").exists(), "cache pre-existing in %s" % root
+        yield root
+
+
+def test_ordinary_cross_file_call_still_resolves():
+    """POSITIVE CONTROL, and it must be read FIRST.
+
+    If the cross-file promotion cannot emit an ordinary `calls` edge at all, then every
+    "0 edges" leg below reads 0 for a reason that has nothing to do with what it claims
+    to test, and the file goes green having proved nothing. #118 lost thirteen arms to
+    exactly this shape.
+    """
+    with _box("ordinary") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nfunction caller() {\n    g();\n}\n",
+            "other.php": "<?php\nfunction g() { return 1; }\n",
+        })
+        result, _err = _run(root, paths)
+        labels = _labels(result)
+        calls = [e for e in result.get("edges", [])
+                 if e.get("relation") == "calls"
+                 and labels.get(e.get("target")) in ("g", "g()")]
+        assert len(calls) == 1, (
+            "POSITIVE CONTROL FAILED: the cross-file promotion emitted %d ordinary "
+            "calls edges, so every zero-edge leg in this file is vacuous" % len(calls))
+        assert calls[0].get("context") == "call", (
+            "an ordinary call edge lost its context field: %r" % calls[0].get("context"))
+
+
+def test_cross_file_resolves():
+    """THE FINDING: a config key naming another file must produce exactly one edge."""
+    with _box("crossfile") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nfunction caller() {\n    config('a.b');\n}\n",
+            "a.php": CONFIG_FILE,
+        })
+        result, _err = _run(root, paths)
+        labels = _labels(result)
+        uses = _uses(result)
+        targets = sorted(labels.get(e["target"], "?") for e in uses)
+        assert len(uses) == 1, "expected 1 uses_ edge, got %d" % len(uses)
+        assert targets == ["a.php"], "expected the a.php file node, got %r" % targets
+
+
+def test_relation_is_uses_config():
+    """THE BLOCKER. A config key is a REFERENCE, not a call.
+
+    An implementation that routes the miss into `raw_calls` without carrying its own
+    relation passes `test_cross_file_resolves` and asserts here that a controller CALLS
+    `config/app.php`.
+    """
+    with _box("relation") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nfunction caller() {\n    config('a.b');\n}\n",
+            "a.php": CONFIG_FILE,
+        })
+        result, _err = _run(root, paths)
+        rels = sorted({e["relation"] for e in _uses(result)})
+        assert rels == ["uses_config"], (
+            "expected ['uses_config'], got %r -- a 'calls' edge here asserts that a "
+            "caller CALLS a config file, which is fabricated relationship data" % rels)
+        # The in-file uses_* emission carries no "context", so the two lanes must agree
+        # on the shape they produce.
+        for e in _uses(result):
+            assert "context" not in e, (
+                "a uses_ edge carried context=%r; the in-file lane sets none"
+                % e.get("context"))
+
+
+def test_in_file_resolution_unchanged():
+    """What #118 shipped. A fix that moves resolution to the global pass breaks this."""
+    with _box("infile") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nclass a { public function m() { return 1; } }\n"
+                          "function caller() {\n    config('a.b');\n}\n",
+        })
+        result, _err = _run(root, paths)
+        uses = _uses(result)
+        rels = sorted({e["relation"] for e in uses})
+        assert len(uses) == 1, "in-file resolution emitted %d edges" % len(uses)
+        assert rels == ["uses_config"], "in-file relation changed to %r" % rels
+
+
+def test_missing_target_stays_silent():
+    """NEGATIVE CONTROL. A missing TARGET is not an unknown VALUE.
+
+    The key `zzz.b` reads perfectly and names nothing, so silence is correct. A report
+    here would mean the fix reports on every non-emitting call, which is the opposite
+    defect and the one `_report_no_literal_key` was deliberately not widened to cover.
+    """
+    with _box("silent") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nfunction caller() {\n    config('zzz.b');\n}\n",
+            "a.php": CONFIG_FILE,
+        })
+        result, err = _run(root, paths)
+        assert len(_uses(result)) == 0, "emitted an edge for an unresolvable key"
+        assert "ambiguous" not in err, (
+            "reported a key that simply has no target: %r" % err[:300])
+
+
+def test_collision_reports():
+    """Zero edges AND one report naming the file, the target and the candidate count."""
+    with _box("collision") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nfunction caller() {\n    config('auth.x');\n}\n",
+            "config/auth.php": CONFIG_FILE,
+            "modules/auth.php": CONFIG_FILE,
+        })
+        result, err = _run(root, paths)
+        assert len(_uses(result)) == 0, "emitted an edge for an ambiguous target"
+        # A targeted contract, never "stderr is non-empty" -- the extractor prints other
+        # warnings and an empty-vs-nonempty test would read those as a pass.
+        hits = [ln for ln in err.splitlines()
+                if "caller.php" in ln
+                and ":3 " in ln
+                and "'auth.php'" in ln
+                and "matches 2 nodes" in ln
+                and "ambiguous, no uses_config edge emitted" in ln]
+        assert len(hits) == 1, (
+            "expected exactly one conforming report line, got %d from stderr %r"
+            % (len(hits), err[:400]))
+
+
+def test_stale_cache_defaults():
+    """A cache written BEFORE the `relation` field existed must still read.
+
+    Built by extracting the fixture, DELETING `relation` from every raw_calls entry, and
+    planting the result as the cache. The cache must be proven CONSUMED or this leg is
+    vacuous: an ignored cache would be re-extracted and read `uses_config`, which is a
+    different failure wearing the same face. A sentinel node does that positively.
+    """
+    with _box("stalecache") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nfunction caller() {\n    config('a.b');\n}\n",
+            "a.php": CONFIG_FILE,
+        })
+        caller = [p for p in paths if p.name == "caller.php"][0]
+        per_file = extract_php(caller)
+        raw = per_file.get("raw_calls", [])
+        assert any("relation" in rc for rc in raw), (
+            "the fixture produced no raw_calls entry carrying a relation, so stripping "
+            "the key strips nothing and this leg would prove nothing")
+        old_shape = [{k: rc[k] for k in ("caller_nid", "callee", "is_member_call",
+                                         "source_file", "source_location") if k in rc}
+                     for rc in raw]
+
+        sentinel = "cache_sentinel_%s" % uuid.uuid4().hex[:8]
+        entry = {
+            "nodes": per_file.get("nodes", []) + [{
+                "id": sentinel, "label": sentinel, "source_file": str(caller),
+                "file_type": "code",
+            }],
+            "edges": per_file.get("edges", []),
+            "raw_calls": old_shape,
+        }
+        cdir = cache_mod.cache_dir(root, "ast")
+        h = cache_mod.file_hash(caller, root)
+        (cdir / ("%s.json" % h)).write_text(json.dumps(entry), encoding="utf8")
+
+        result, _err = _run(root, paths)   # must not raise
+        labels = _labels(result)
+        assert sentinel in labels, (
+            "the planted cache was NOT consumed, so this leg never exercised the stale "
+            "shape it exists for")
+        cross = [e for e in result.get("edges", [])
+                 if labels.get(e.get("target")) == "a.php"]
+        rels = sorted({e["relation"] for e in cross})
+        assert rels == ["calls"], (
+            "a relation-less cached entry must default to 'calls', got %r" % rels)
+
+
+def test_interpolated_key_never_reaches_cross_file():
+    """A non-literal must not be handed to the resolver, which would invent a target
+    one layer further out than #118's rejection.
+
+    Observed at the PER-FILE layer, the only layer that can see `raw_calls` at all --
+    `extract()` does not return it.
+    """
+    with _box("interp") as root:
+        paths = _write(root, {
+            "caller.php": '<?php\nfunction caller() {\n    config("a.$key");\n}\n',
+            "a.php": CONFIG_FILE,
+        })
+        caller = [p for p in paths if p.name == "caller.php"][0]
+        leaked = [rc for rc in extract_php(caller).get("raw_calls", [])
+                  if str(rc.get("relation", "")).startswith("uses_")
+                  or str(rc.get("callee", "")).endswith(".php")]
+        assert leaked == [], "an interpolated key reached raw_calls: %r" % leaked
+        result, err = _run(root, paths)
+        assert len(_uses(result)) == 0, "an interpolated key produced an edge"
+        assert "interpolates" in err, (
+            "the #118 interpolation report stopped firing: %r" % err[:300])
+
+
+def test_member_call_still_skipped():
+    """The `is_member_call` guard, in case it is dropped while touching the loop."""
+    with _box("member") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nfunction caller() {\n    $o->g();\n}\n",
+            "other.php": "<?php\nfunction g() { return 1; }\n",
+        })
+        result, _err = _run(root, paths)
+        labels = _labels(result)
+        calls = [e for e in result.get("edges", [])
+                 if e.get("relation") == "calls"
+                 and labels.get(e.get("target")) in ("g", "g()")]
+        assert len(calls) == 0, (
+            "a member call was promoted across files: %d edges" % len(calls))
+
+
+if __name__ == "__main__":
+    # The positive control runs FIRST and by name. If the promotion cannot fire, every
+    # zero-edge leg below is vacuous and this file must say so rather than go green.
+    ordered = [test_ordinary_cross_file_call_still_resolves]
+    ordered += [v for k, v in sorted(globals().items())
+                if k.startswith("test_") and callable(v) and v not in ordered]
+    rc = 0
+    executed = 0
+    for t in ordered:
+        executed += 1
+        try:
+            t()
+            print("ok   %s" % t.__name__)
+        except Exception as exc:                      # noqa: BLE001
+            rc = 1
+            first = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+            print("FAIL %s: %s" % (t.__name__, first))
+            if t is ordered[0]:
+                print("VOID: the positive control failed, so no count below is evidence")
+                sys.exit(2)
+    print("ran %d of %d legs; rc=%d" % (executed, len(ordered), rc))
+    if executed == 0:
+        print("VOID: zero legs executed, so this file proved nothing")
+        sys.exit(2)
+    sys.exit(rc)

--- a/scripts/ast/test_php_config_cross_file.py
+++ b/scripts/ast/test_php_config_cross_file.py
@@ -214,6 +214,38 @@ def test_collision_reports():
             % (len(hits), err[:400]))
 
 
+def test_ordinary_collision_stays_silent():
+    """The scope of the collision report, asserted rather than assumed.
+
+    An ordinary cross-file call to a name that resolves to several nodes is the case the
+    uniqueness gate exists for -- the comment there names `log`, `execute` and `find` --
+    and its silence is documented behaviour, not a defect. Widening the report to every
+    entry would print a line per such call on any large repo. This leg is what stops the
+    report from being scoped by accident: without it, dropping the `relation != "calls"`
+    condition changes real behaviour and no leg notices.
+    """
+    with _box("ordcollide") as root:
+        paths = _write(root, {
+            "caller.php": "<?php\nfunction caller() {\n    log_it();\n}\n",
+            "one.php": "<?php\nfunction log_it() { return 1; }\n",
+            "two.php": "<?php\nclass log_it { public function m() { return 2; } }\n",
+        })
+        result, err = _run(root, paths)
+        labels = _labels(result)
+        cands = [nid for nid, lab in labels.items()
+                 if str(lab).strip("()").lower() == "log_it"]
+        assert len(cands) > 1, (
+            "FIXTURE CONTROL FAILED: log_it resolves to %d nodes, so this leg is not "
+            "testing a collision at all" % len(cands))
+        calls = [e for e in result.get("edges", [])
+                 if e.get("relation") == "calls"
+                 and str(labels.get(e.get("target"), "")).strip("()").lower() == "log_it"]
+        assert len(calls) == 0, "an ambiguous ordinary call was promoted: %d" % len(calls)
+        assert "ambiguous" not in err, (
+            "the collision report widened to ordinary calls, which would print a line "
+            "per colliding common name on any large repo: %r" % err[:300])
+
+
 def test_stale_cache_defaults():
     """A cache written BEFORE the `relation` field existed must still read.
 


### PR DESCRIPTION
Closes rank 05, `N-HELPER-NEVER-RESOLVES` (`BASE-WORK-ORDER.md:1033`). Branched off `main 96df6829`. **DO NOT MERGE** — `condor` grades, `auk` merges (law 6).

## The finding

The config branch resolved its key against `label_to_nid`, which holds only the **current file's** nodes. `config/app.php` is a different file, so `config('app.name')` in a controller could never resolve, and the reference was dropped with **no edge and no report**.

Measured on `Documents/caddy-baseline` (68 `.php`) at `96df6829`: **26 keys read, 0 edges emitted, and 0 of the 26 resolved in-file.** The feature was silent on a real Laravel app.

## The blocker this PR is shaped around

Handing the miss to the cross-file promotion in `extract()` is the obvious fix and is wrong on its own: that promotion **hard-coded** `"relation": "calls"`. Routed in unchanged it asserts that a controller **calls** `config/app.php` — fabricated relationship data of the same class #115 and #118 shipped fixes for, and **worse than the silence it replaces, because a wrong edge is believed.**

So `raw_calls` entries gained an **optional** `relation`, read as `rc.get("relation", "calls")`. The key is never required: `raw_calls` is **persisted to the per-file cache**, so a cache written before this change is read after it. The five other producers are untouched and keep emitting `calls` by default.

A colliding file-shaped target is **reported**, not dropped — measured on the same tree: 66 distinct basenames across 68 files, `auth.php` twice, and one of the two is among the 11 `config/` files, so a Laravel app with `config/auth.php` and any other `auth.php` lost that key with no error. Preferring a `config/` directory match was **rejected**: framework-specific logic inside a pass built for every language is a defect waiting for its second framework.

## Acceptance

Instrument `accept05.py`, sha256 `7d42135174a0ab4c1b5ff5e378dca47d11c0c9ba2fea802a10efafc59a638774` — **the same build produced both records below.** Two-arm provenance gate, told apart positively: red requires the `96df6829` blob hash **and** the new symbol absent; green requires a different hash **and** the symbol present. Each aborts rather than producing numbers.

| # | arm | RED (`96df6829`) | GREEN (`5d9b0a32`) | what it discriminates |
|---|---|---|---|---|
| 1 | `cross_file_resolves` | **FAIL** 0 edges | PASS 1 edge → `a.php` | the lane never reaching the resolver |
| 2 | `relation_is_uses_config` | **FAIL** no relation | PASS `uses_config` | ⛔ **the blocker.** Arm 1 passes for a fix that omits the relation |
| 3 | `in_file_still_resolves` | PASS 1 edge | PASS 1 edge | a change that moves resolution to the global pass, breaking #118 |
| 4 | `no_endpoint_anywhere` | PASS 0, silent | PASS 0, silent | a fix that reports every non-emitting call |
| 5 | `collision_reports` | **FAIL** 0 reports | PASS 0 edges + 1 report | a colliding target dropped silently |
| 6 | `stale_cache_defaults` | **FAIL** | PASS defaults to `calls`, no raise | a required key (raises) vs a wrong default (mis-relates) |
| 7 | `ordinary_calls_unchanged` | PASS 1 `calls` | PASS 1 `calls` | the default path; **also C1** |
| 8 | `interpolating_never_reaches_raw_calls` | PASS | PASS 0 edges, no leak, 1 report | a non-literal reaching cross-file resolution |
| 9 | `member_call_still_skipped` | PASS 0 | PASS 0 | the `is_member_call` guard |
| 10 | `real_tree_delta` | **FAIL** 0 edges | PASS 14 edges | the finding on the real corpus |

**RED: 5 of 5 must-fail arms failed, all four controls green.** GREEN: **10 of 10 arms, all four controls green, rc 0.**

Controls in every run, void by name with a nonzero rc: **C1** the promotion can fire at all, asserted **first** (#118 lost thirteen arms to a fixture whose target was never resolvable); **C2** a key that reads perfectly and matches nothing stays silent; **C3** five canary red states including a report matcher that rejects the wrong line number and the wrong target; **C4** every fixture parsed directly against the grammar, 0 `ERROR` and 0 `MISSING`.

### Real-tree delta, accounted key by key (`delta05.py`, rc 0)

```
keys read                : 26   = 26 handed to cross-file + 0 resolved in-file
  emitted cross-file     : 14   (model.php 13, app.php 1)
  emitted in-file (#118) :  0
  = uses_config edges    : 14   (run: 14)
  reported ambiguous     :  0   (run: 0)
  correctly silent       : 12   (duplicate caller/target pairs deduped by existing_pairs)
  UNACCOUNTED            :  0
```

Every key read is in exactly one bucket and the buckets predict the run's edge and report counts exactly. **0 ambiguous reports is the predicted value**, not a miss: MEASURE-05 recorded that this corpus never calls `config('auth.*')`, so the collision path has no input here. Arm 5 is what proves that path fires.

## Committed legs

`scripts/ast/test_php_config_cross_file.py` — 10 legs, driven from `__main__` because `ci.yml` runs each file as plain `python <file>` with no pytest. Reachability gate: `shape=A defined=10 unreachable=0`, run total `files=10 defined_tests=73 unreachable=0`.

The positive control runs **first and by name**: if the promotion cannot emit an ordinary cross-file `calls` edge, the file prints `VOID` and exits 2 rather than going green on vacuous zeros. **Against unfixed `96df6829`, four legs fail while that control passes throughout.**

## Mutation matrix (`mutate05.py`, rc 0)

Nine plausible half-fixes. **0 survivors, 0 unapplied, tree clean and `extractor.py` sha256 restored after every revert.**

| mutation | detected by |
|---|---|
| `M1_relation_not_carried` | `collision_reports`, `cross_file_resolves`, `relation_is_uses_config`, `stale_cache_defaults` |
| `M2_relation_required` | 9 of 10 legs — **blunt**, see below |
| `M3_wrong_default` | `ordinary_collision_stays_silent`, `ordinary_cross_file_call_still_resolves`, `stale_cache_defaults` |
| `M4_collision_silent` | `collision_reports` |
| `M5_never_appends` | `collision_reports`, `cross_file_resolves`, `relation_is_uses_config`, `stale_cache_defaults` |
| `M6_bare_segment_target` | `collision_reports`, `cross_file_resolves`, `relation_is_uses_config`, `stale_cache_defaults` |
| `M7_member_guard_removed` | `member_call_still_skipped` |
| `M8_report_widened_to_all` | `ordinary_collision_stays_silent` |
| `M9_context_kept_on_uses` | `relation_is_uses_config` |

**Two findings from the matrix itself, reported rather than smoothed over.**

**(a) `M2` and `M3` exit 2 through the positive control, so the later legs never ran.** That is the control doing its job (law 48: a failed control voids the run and must not print counts) and it **masks** every subsequent verdict. "Killed by the control" and "killed by the leg that discriminates it" are different claims, and reporting the first as the second credits a leg that was never reached. So each leg is re-run in **isolation**, one subprocess per leg, to answer what the masked run cannot.

**(b) After isolation, `M2` kills 9 of 10 legs** — it raises a `KeyError` inside `extract()`, so every leg that extracts anything dies. Crediting those legs as proven is the **inverted** form of the error law 49 names: it reports a leg as discriminating a property when all it did was witness a global crash. A mutation killing more than half the suite is therefore graded **blunt** and credits no leg with anything specific.

Result: **7 of 10 legs proven by a targeted mutation. 0 killed by nothing. 3 killed only by the blunt `M2`** — `in_file_resolution_unchanged`, `interpolated_key_never_reaches_cross_file`, `missing_target_stays_silent` — and all three carry a structural reason for being unreachable (they guard #118's lane and the `candidates == 0` path, neither of which any mutation here edits). **Real matrix gap: NONE.**

`test_ordinary_collision_stays_silent` was added **while writing the matrix, not after it ran**: without it, dropping the report's `relation != "calls"` condition changes real behaviour on any large repo and no leg notices.

## Two spec defects found by standing order 6, corrected in place

Both were wrong **constants**, not unclear purposes. `auk` accepted both.

1. **The provenance hash was from the wrong tree.** SPEC-05 pinned `8384f0d8…5496b9` and called it "the `96df6829` blob". It is `.cache/marten-127/main-4ce0e18e/scripts/ast/extractor.py` — an **8552-line** file, in a tree whose HEAD is `96ce58ca`, which does not contain commit `96df6829` at all. It was copied forward from `accept118.py`, where it is correctly pinned to `MAIN_SHA = 4ce0e18e`. The real `96df6829` blob is sha256 `3326c286…48e049` (git blob `3fb965c7`, 8634 lines, 370480 bytes, LF — both LF and CRLF forms hashed, neither matches). **Pinned as written the red arm can never match, so the gate could only abort, which looks like protection and is not.**
2. **`if len(candidates) != 1:` is at `:8453`, not `:8452`.** Every other anchor verified exact by construct text, including both producer lists.

## Pre-existing, not from this PR

`scripts/ast/test_file_attribution.py` fails **identically on the pristine `96df6829` worktree** on this Windows box (`src/alpha/mod.rs has no entities attributed to it`). Same failure with and without this change, so it is not a regression here; CI on Linux is the reading that matters. Flagged, not touched.

## Evidence

`~/.base-gbl/verification/base-0.14.3-heron/`: `SPEC-05-acceptance.md` (with the corrections section), `MEASURE-05.md`, `accept05.py`, `ACCEPT-05-red.{txt,json}`, `ACCEPT-05-green.{txt,json}`, `delta05.py`, `mutate05.py`, `MUTATE-05.{txt,json}`.
