### PR TITLE
chore(release): bump to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "base"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 description = "Proactive context-injection engine for Claude Code"


### PR DESCRIPTION
Version bump only. No product code.

`Cargo.toml` and `Cargo.lock` both read `0.14.2`. The last cut release is **v0.14.2 (2026-09-08)** and **no v0.14.3 tag exists**, so the 21 fixes closed under the 0.14.3 milestone have never shipped. They ship as **0.15.0**.

**Why the bump has to land before an install:** four distinct binaries measured today all printed `base 0.14.2` — two mains and both mutants — so the version string discriminated nothing and only md5 did. Installing without this bump gives no way to tell the new build from the old one.

Exactly one substitution per file, verified before commit.
