### PR TITLE
#158 — a tool that cannot read its own config, or reach its own release API, now says so

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ isolation-guard = []
 [dev-dependencies]
 base = { path = ".", features = ["isolation-guard"] }
 tempfile = "3"
+# `tests/update_release_request_test.rs` inspects the `ureq::Request` the updater
+# builds, so it has to be able to name that type. An integration test links
+# `base` as an external crate and does not inherit its dependencies.
+# Same crate and version the binary already links; nothing new enters the tree.
+ureq = { version = "2", features = ["json"] }
 # The dashboard's node/edge handlers are part of the read surface ruling 4
 # governs, so `tests/transient_kinds_test.rs` drives them directly. Same crate
 # and version the binary already links; nothing new enters the tree.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1429,6 +1429,49 @@ fn die(prefix: &str, e: impl std::fmt::Display) -> ! {
     std::process::exit(1);
 }
 
+/// Read the global `base.toml` for a `config` subcommand, or exit non-zero.
+///
+/// ABSENT comes back as `None` rather than as an error, because the three
+/// subcommands answer that state differently and only they can decide: `get`
+/// falls through to the compiled-in default, `list` and `set` refuse. Unreadable
+/// and unparseable are faults on every path and exit from here.
+///
+/// #158 leg B. Every one of these used to `eprintln!` and then `return` out of a
+/// `run()` that yields `()` -- which is a NORMAL exit. A config that would not
+/// parse reported SUCCESS to the shell, so `&&` chains, scripts and CI steps
+/// carried on as though the settings had been read.
+fn read_global_config(path: &std::path::Path) -> Option<toml::Value> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        // The one quiet case. What it MEANS is the caller's decision, not this
+        // function's -- collapsing absent into unreadable here is the same
+        // defect this issue exists to remove, one layer up.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => die(&format!("Cannot read {}", path.display()), e),
+    };
+    match content.parse::<toml::Value>() {
+        Ok(v) => Some(v),
+        Err(e) => die(&format!("Failed to parse {}", path.display()), e),
+    }
+}
+
+/// The one answer to "there is no global `base.toml`".
+///
+/// `base install` is what creates that file (`install::create_global_tier`), so
+/// its absence means install never ran -- not that this command should write a
+/// bare one. The file install writes carries documented section comments that a
+/// `config set` could not reproduce, and a silently degraded config the operator
+/// later reads as theirs is the same class of harm as the silent default.
+///
+/// The wording mirrors `scaffold::register_workspace` rather than inventing a
+/// second spelling for one state.
+fn no_global_config() -> ! {
+    die(
+        "Error",
+        anyhow::anyhow!("no ~/.base-gbl/base.toml (run base install first)"),
+    )
+}
+
 /// Which tier a write targets: `-g/--global` swaps cwd for `~/.base-gbl`, so
 /// the global tier is something you opt into rather than something you land in
 /// (issue #8). Without the flag, tier-bound writes resolve from cwd and fail
@@ -3661,18 +3704,21 @@ pub fn run() {
 
         // ─── Config ────────────────────────────────────────
         Some(Commands::Config { action }) => {
-            let home = base::home::home_root().expect("Cannot determine home directory");
+            // `die`, not `expect`. Every sibling arm in this file reports a
+            // failure through `die` and exits 1; this one PANICKED at rc 101 for
+            // the same condition, so one fault produced two different exit codes
+            // depending on which command the operator happened to run. (#158 N5)
+            let Some(home) = base::home::home_root() else {
+                die("Error", anyhow::anyhow!("cannot determine home directory"));
+            };
             let path = home.join(".base-gbl").join("base.toml");
 
             match action {
                 ConfigAction::List => {
-                    let Ok(content) = std::fs::read_to_string(&path) else {
-                        eprintln!("Cannot read base.toml at {}", path.display());
-                        return;
-                    };
-                    let Ok(val) = content.parse::<toml::Value>() else {
-                        eprintln!("Failed to parse base.toml");
-                        return;
+                    // `list` reads the FILE, so an absent one has nothing to
+                    // list and is refused with the remedy named.
+                    let Some(val) = read_global_config(&path) else {
+                        no_global_config();
                     };
                     if let Some(table) = val.as_table() {
                         for (section, v) in table {
@@ -3685,19 +3731,22 @@ pub fn run() {
                     }
                 }
                 ConfigAction::Get { key } => {
-                    let Ok(content) = std::fs::read_to_string(&path) else {
-                        eprintln!("Cannot read base.toml");
-                        return;
-                    };
-                    let Ok(val) = content.parse::<toml::Value>() else {
-                        eprintln!("Failed to parse base.toml");
-                        return;
-                    };
+                    // The usage check runs first, and before the file is read: a
+                    // malformed key is wrong whatever the file happens to say.
                     let parts: Vec<&str> = key.splitn(2, '.').collect();
                     if parts.len() != 2 {
-                        eprintln!("Key must be section.field (e.g. memory.mode)");
-                        return;
+                        die(
+                            "Error",
+                            anyhow::anyhow!("key must be section.field (e.g. memory.mode)"),
+                        );
                     }
+                    // ABSENT is not a failure for `get`, and the asymmetry with
+                    // `set` is deliberate. Nearly every setting has a default
+                    // that is what the machine actually does, so a machine with
+                    // no base.toml can still be asked what it will do: reading a
+                    // default is honest. Silently discarding a WRITE is not.
+                    let val = read_global_config(&path)
+                        .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()));
                     // A key absent from base.toml is not an absent key: nearly
                     // every one of them has a default that is what the machine
                     // actually does. `base config get update.auto` used to say
@@ -3713,19 +3762,16 @@ pub fn run() {
                     }
                 }
                 ConfigAction::Set { key, value } => {
-                    let Ok(content) = std::fs::read_to_string(&path) else {
-                        eprintln!("Cannot read base.toml");
-                        return;
-                    };
-                    let Ok(mut doc) = content.parse::<toml::Value>() else {
-                        eprintln!("Failed to parse base.toml");
-                        return;
-                    };
                     let parts: Vec<&str> = key.splitn(2, '.').collect();
                     if parts.len() != 2 {
-                        eprintln!("Key must be section.field (e.g. memory.mode)");
-                        return;
+                        die(
+                            "Error",
+                            anyhow::anyhow!("key must be section.field (e.g. memory.mode)"),
+                        );
                     }
+                    let Some(mut doc) = read_global_config(&path) else {
+                        no_global_config();
+                    };
                     let section = parts[0];
                     let field = parts[1];
 
@@ -3739,25 +3785,31 @@ pub fn run() {
                         toml::Value::String(value.clone())
                     };
 
-                    let table = doc.as_table_mut().unwrap();
+                    let Some(table) = doc.as_table_mut() else {
+                        die(
+                            "Error",
+                            anyhow::anyhow!("{} is not a TOML table", path.display()),
+                        );
+                    };
                     let sec = table.entry(section).or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
-                    if let Some(sec_table) = sec.as_table_mut() {
-                        sec_table.insert(field.to_string(), new_val.clone());
-                    } else {
-                        eprintln!("Section '{section}' is not a table");
-                        return;
-                    }
+                    let Some(sec_table) = sec.as_table_mut() else {
+                        die("Error", anyhow::anyhow!("section '{section}' is not a table"));
+                    };
+                    sec_table.insert(field.to_string(), new_val.clone());
 
-                    match toml::to_string_pretty(&doc) {
-                        Ok(out) => {
-                            if let Err(e) = std::fs::write(&path, out) {
-                                eprintln!("Failed to write base.toml: {e}");
-                            } else {
-                                println!("Updated {key} = {new_val}");
-                            }
-                        }
-                        Err(e) => eprintln!("Failed to serialize: {e}"),
+                    let out = match toml::to_string_pretty(&doc) {
+                        Ok(out) => out,
+                        Err(e) => die("Failed to serialize base.toml", e),
+                    };
+                    // THE leg B line. This used to `eprintln!` and fall through
+                    // with NO `return` at all, so `base config set` against a
+                    // read-only file printed an error and exited 0 -- reporting
+                    // success over a write it did not make. The write IS the
+                    // command: if it did not land, the command failed.
+                    if let Err(e) = std::fs::write(&path, out) {
+                        die(&format!("Failed to write {}", path.display()), e);
                     }
+                    println!("Updated {key} = {new_val}");
                 }
             }
         },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3164,8 +3164,13 @@ pub fn run() {
                 .as_ref()
                 .map(std::path::PathBuf::from)
                 .unwrap_or(cwd.clone());
+            // `die`, not a bare eprintln. This arm sits inside `run()`, which
+            // returns `()`, so printing the error and falling through exits 0 —
+            // the same defect leg B removed from the `config` arm, and the
+            // reason `scaffold` reported success over a refused registry sync
+            // even once `scaffold::run` started returning Err.
             if let Err(e) = base::scaffold::run(&target) {
-                eprintln!("Scaffold failed: {e}");
+                die("Scaffold failed", e);
             }
         }
 
@@ -3211,7 +3216,21 @@ pub fn run() {
         // ─── Workspace registry ───────────────────────────────
         Some(Commands::Workspace { action }) => match action {
             WorkspaceAction::Sync => match base::scaffold::sync_claude_md_registry() {
-                Ok(n) => println!("✓ synced {n} workspace(s) into ~/.claude/CLAUDE.md"),
+                // A count is not a loss. "synced 0 workspace(s)" reads as "there
+                // were none to sync" whether there were none or whether three
+                // were just removed, and the operator cannot tell those apart
+                // from the message that is supposed to describe what happened.
+                Ok(s) if s.cleared() > 0 => println!(
+                    "✓ ~/.claude/CLAUDE.md now lists {} workspace(s) — REMOVED {} that \
+                     ~/.base-gbl/base.toml no longer registers (it listed {} before)",
+                    s.written,
+                    s.cleared(),
+                    s.previous
+                ),
+                Ok(s) => println!(
+                    "✓ synced {} workspace(s) into ~/.claude/CLAUDE.md",
+                    s.written
+                ),
                 Err(e) => die("Failed", e),
             },
         },

--- a/src/config.rs
+++ b/src/config.rs
@@ -811,15 +811,44 @@ impl std::fmt::Display for ConfigFault {
 /// operator diagnostics, not model context". A config warning must never be
 /// able to change one byte of hook stdout, and a test asserts exactly that.
 fn report_config_faults_once(faults: &[ConfigFault]) {
+    report_config_faults(faults, &FAULTS_REPORTED);
+}
+
+/// The one report this process gets.
+///
+/// A `static` rather than a field because there is no object to hang it on:
+/// `load` is an associated function reached from nine unrelated call sites, none
+/// of which share any state.
+static FAULTS_REPORTED: std::sync::Once = std::sync::Once::new();
+
+/// The body of [`report_config_faults_once`], with the latch passed in. Returns
+/// whether THIS call was the one that spoke.
+///
+/// The latch is a parameter for exactly one reason: a `std::sync::Once` cannot be
+/// re-armed, and `cargo test` runs a file's tests inside one process, so a
+/// process-global latch would let whichever test reported first decide the result
+/// of every other one. That is a flaky instrument, not a test.
+///
+/// Production never passes anything but `FAULTS_REPORTED`, so shipped behaviour is
+/// unchanged. And because an injected latch can only ever prove the latch -- never
+/// that production wires the real one -- the once-per-process claim is ALSO proved
+/// end to end against the shipped binary, in
+/// `tests/config_fault_once_per_process_test.rs`.
+fn report_config_faults(faults: &[ConfigFault], latch: &std::sync::Once) -> bool {
+    // Before the latch, deliberately. A healthy load must not spend the one report
+    // the process gets, or a file that broke later in the same process would say
+    // nothing -- which is this defect again, one level up.
     if faults.is_empty() {
-        return;
+        return false;
     }
-    static REPORTED: std::sync::Once = std::sync::Once::new();
-    REPORTED.call_once(|| {
+    let mut spoke = false;
+    latch.call_once(|| {
+        spoke = true;
         for fault in faults {
             eprintln!("base: {fault}");
         }
     });
+    spoke
 }
 
 impl BaseConfig {
@@ -1110,5 +1139,294 @@ mod tests {
             std::fs::create_dir_all(&orphan).unwrap();
             assert_eq!(find_workspace_base(&orphan), None);
         });
+    }
+
+    // ─── #158 leg A — a config that cannot be read is reported, never swallowed ───
+    //
+    // These observe `load_reporting`, which is pure and returns the faults. That is
+    // NOT a channel any operator reads, so every claim below is re-proved against
+    // the shipped binary's stderr and exit code in
+    // `tests/config_fault_surface_test.rs`. Green here and silent there would mean
+    // nothing was fixed.
+
+    /// The global `base.toml` inside an isolated fake home, with its parent made.
+    /// Returns the path so a test can corrupt exactly that file and nothing else.
+    fn fake_global_toml(home: &Path) -> PathBuf {
+        let dir = home.join(".base-gbl");
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("base.toml")
+    }
+
+    /// The headline of #158: a file that exists and does not parse has to SPEAK,
+    /// and what it says has to be actionable — which file, and what is wrong.
+    #[test]
+    fn an_unparseable_global_config_reports_its_path_and_the_parse_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::home::with_thread_home(tmp.path(), || {
+            let path = fake_global_toml(tmp.path());
+            std::fs::write(&path, "[update]\nauto = \n").unwrap();
+
+            let (config, faults) = BaseConfig::load_reporting(tmp.path());
+
+            assert_eq!(faults.len(), 1, "one broken file is one fault: {faults:?}");
+            match &faults[0] {
+                ConfigFault::Unparseable { path: p, err } => {
+                    assert_eq!(p, &path, "the fault names the file the operator must fix");
+                    assert!(!err.is_empty(), "and carries the parser's own words");
+                }
+                other => panic!("an unparseable file is Unparseable, not {other:?}"),
+            }
+            // The settings really are gone. That is the truth the operator needs
+            // told, not hidden — what changed is that it is no longer SILENT.
+            assert_eq!(config.update.auto, BaseConfig::default().update.auto);
+        });
+    }
+
+    /// Exists and cannot be read is a third state, and it used to be
+    /// indistinguishable from absent. A directory where the file belongs fails
+    /// `read_to_string` with something that is NOT `NotFound`, on every platform,
+    /// without depending on the uid the suite happens to run as — `chmod 000` is a
+    /// no-op for root and would make this test silently stop measuring.
+    #[test]
+    fn an_unreadable_global_config_is_a_fault_and_is_not_confused_with_an_absent_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::home::with_thread_home(tmp.path(), || {
+            let path = fake_global_toml(tmp.path());
+            std::fs::create_dir_all(&path).unwrap();
+
+            let (_config, faults) = BaseConfig::load_reporting(tmp.path());
+
+            assert_eq!(faults.len(), 1, "{faults:?}");
+            match &faults[0] {
+                ConfigFault::Unreadable { path: p, err } => {
+                    assert_eq!(p, &path);
+                    assert!(!err.is_empty(), "the OS error is what tells them why");
+                }
+                other => panic!("a file that exists and cannot be read is Unreadable, not {other:?}"),
+            }
+        });
+    }
+
+    /// N2, and the widest of the four collapse points. `try_into()` is
+    /// all-or-nothing: one wrongly typed field — `auto = "yes"` where a bool
+    /// belongs — used to discard every OTHER setting in the file along with it,
+    /// silently. A one-character typo cost the operator their whole configuration.
+    #[test]
+    fn a_single_wrongly_typed_field_no_longer_discards_every_other_setting_in_silence() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::home::with_thread_home(tmp.path(), || {
+            let path = fake_global_toml(tmp.path());
+            // Valid TOML that is not valid settings: it parses, then fails to convert.
+            std::fs::write(
+                &path,
+                "[update]\nauto = \"yes\"\n\n[namespace]\nprefix = \"chosen-by-the-operator\"\n",
+            )
+            .unwrap();
+
+            let (config, faults) = BaseConfig::load_reporting(tmp.path());
+
+            assert_eq!(faults.len(), 1, "{faults:?}");
+            match &faults[0] {
+                ConfigFault::Mismatched { paths, err } => {
+                    assert!(
+                        paths.contains(&path),
+                        "the file that produced the table is named: {paths:?}"
+                    );
+                    assert!(!err.is_empty());
+                }
+                other => panic!("valid TOML of the wrong shape is Mismatched, not {other:?}"),
+            }
+            // The unrelated setting IS still lost — this leg does not change that,
+            // because the conversion is all-or-nothing. It is now announced.
+            assert_eq!(
+                config.namespace.prefix,
+                BaseConfig::default().namespace.prefix,
+                "precondition for the report mattering: the good setting really did go"
+            );
+        });
+    }
+
+    /// The control that makes every test above mean something. Absent is NOT a
+    /// fault: a first run has no `base.toml` anywhere and must stay completely
+    /// quiet, or the warning becomes noise everyone learns to scroll past.
+    #[test]
+    fn an_absent_config_is_not_a_fault_in_either_tier() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::home::with_thread_home(tmp.path(), || {
+            std::fs::create_dir_all(tmp.path().join(".base-gbl")).unwrap();
+            let ws = tmp.path().join("ws");
+            std::fs::create_dir_all(ws.join(".base")).unwrap();
+            assert!(
+                !tmp.path().join(".base-gbl").join("base.toml").exists(),
+                "precondition: no global file"
+            );
+            assert!(
+                !ws.join(".base").join("base.toml").exists(),
+                "precondition: no workspace file"
+            );
+
+            let (config, faults) = BaseConfig::load_reporting(&ws);
+
+            assert!(faults.is_empty(), "a first run is not a fault: {faults:?}");
+            assert_eq!(config.update.auto, BaseConfig::default().update.auto);
+        });
+    }
+
+    /// The other control: a good file is silent AND its settings are the ones in
+    /// force. A "fix" that reported on every load would pass the broken arms and
+    /// fail here.
+    #[test]
+    fn a_healthy_config_reports_nothing_and_its_settings_are_honoured() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::home::with_thread_home(tmp.path(), || {
+            std::fs::write(fake_global_toml(tmp.path()), "[update]\nauto = false\n").unwrap();
+
+            let (config, faults) = BaseConfig::load_reporting(tmp.path());
+
+            assert!(faults.is_empty(), "a good file has nothing to report: {faults:?}");
+            assert!(
+                !config.update.auto,
+                "and the setting the operator chose is the one in force"
+            );
+        });
+    }
+
+    /// Two tiers, one broken. The fault has to name the file that is actually
+    /// broken or the operator edits the wrong one — and the tier that still reads
+    /// must keep applying, so a broken overlay does not cost them settings that
+    /// are perfectly readable.
+    #[test]
+    fn a_broken_workspace_config_names_the_workspace_file_and_spares_the_global_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::home::with_thread_home(tmp.path(), || {
+            std::fs::write(fake_global_toml(tmp.path()), "[update]\nauto = false\n").unwrap();
+            let ws = tmp.path().join("ws");
+            std::fs::create_dir_all(ws.join(".base")).unwrap();
+            let ws_toml = ws.join(".base").join("base.toml");
+            std::fs::write(&ws_toml, "this is not toml {{{\n").unwrap();
+
+            let (config, faults) = BaseConfig::load_reporting(&ws);
+
+            assert_eq!(faults.len(), 1, "only the broken tier faults: {faults:?}");
+            match &faults[0] {
+                ConfigFault::Unparseable { path, .. } => assert_eq!(
+                    path, &ws_toml,
+                    "the workspace file is the broken one; naming the global file would send them to the wrong place"
+                ),
+                other => panic!("{other:?}"),
+            }
+            assert!(
+                !config.update.auto,
+                "the readable global tier still applies — a broken overlay is not a reset"
+            );
+        });
+    }
+
+    /// DoD 15 / N3 — the shipped claim this defect makes false.
+    ///
+    /// `config.rs` documents the pin as `base config set update.auto false`, and
+    /// `hook/session_start.rs` calls `auto_update` on EVERY session start, gated on
+    /// that flag, whose default is `true`. So an unparseable file silently un-pins
+    /// the machine and it resumes updating itself.
+    ///
+    /// This test states the residual honestly instead of hiding it: the pin IS
+    /// lost, because a file that will not parse cannot say `false`. What leg A
+    /// closes is the SILENCE. `load` reports before returning, and `hook/mod.rs`
+    /// loads before it dispatches to `session_start::handle`, so the operator is
+    /// told before `auto_update` is ever reached.
+    #[test]
+    fn a_pinned_machine_that_loses_its_config_is_never_silent_about_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::home::with_thread_home(tmp.path(), || {
+            let path = fake_global_toml(tmp.path());
+
+            // The pin works, and is quiet.
+            std::fs::write(&path, "[update]\nauto = false\n").unwrap();
+            let (pinned, quiet) = BaseConfig::load_reporting(tmp.path());
+            assert!(!pinned.update.auto, "precondition: the machine is pinned");
+            assert!(quiet.is_empty(), "precondition: a good file says nothing");
+
+            // The file stops parsing, which is exactly what #158 reports.
+            std::fs::write(&path, "[update]\nauto = false\n[[[ broken\n").unwrap();
+            let (after, faults) = BaseConfig::load_reporting(tmp.path());
+
+            assert!(
+                after.update.auto,
+                "the pin is genuinely lost — reporting that honestly is the point"
+            );
+            assert!(!faults.is_empty(), "and it is NO LONGER SILENT, which is the fix");
+            assert!(
+                faults
+                    .iter()
+                    .any(|f| f.to_string().contains(&path.display().to_string())),
+                "the report names the file that lost the pin: {faults:?}"
+            );
+        });
+    }
+
+    /// A message has to carry the consequence, not only the cause. "cannot parse X"
+    /// tells an operator a file is broken; it does not tell them that the settings
+    /// they chose are not the settings running.
+    #[test]
+    fn every_fault_names_its_consequence_as_well_as_its_cause() {
+        let faults = [
+            ConfigFault::Unreadable {
+                path: PathBuf::from("/probe/a.toml"),
+                err: "permission denied".into(),
+            },
+            ConfigFault::Unparseable {
+                path: PathBuf::from("/probe/b.toml"),
+                err: "expected value".into(),
+            },
+            ConfigFault::Mismatched {
+                paths: vec![PathBuf::from("/probe/c.toml")],
+                err: "invalid type".into(),
+            },
+            ConfigFault::HomeUnresolvable,
+        ];
+        for f in &faults {
+            let msg = f.to_string();
+            assert!(
+                msg.contains("DEFAULT settings, not yours"),
+                "a fault says what it COST, not only what went wrong: {msg}"
+            );
+        }
+        assert!(faults[0].to_string().contains("/probe/a.toml"));
+        assert!(faults[1].to_string().contains("/probe/b.toml"));
+        assert!(faults[2].to_string().contains("/probe/c.toml"));
+        assert!(
+            faults[0].to_string().contains("permission denied"),
+            "the underlying error survives into the message"
+        );
+    }
+
+    /// The guard is "once per process", not "once per call": one `base scaffold`
+    /// calls `load` three times and the operator does not need telling three times.
+    ///
+    /// The empty case must return BEFORE the latch. If a healthy load spent it, a
+    /// file that broke later in the same process would say nothing — which is the
+    /// defect again, one level up. The latch is a parameter here for exactly this
+    /// test: a process-global `Once` cannot be re-armed, so any other test that
+    /// happened to report first would decide this one's result.
+    #[test]
+    fn the_report_latch_fires_once_and_an_empty_report_does_not_spend_it() {
+        let latch = std::sync::Once::new();
+        let fault = [ConfigFault::HomeUnresolvable];
+
+        assert!(
+            !report_config_faults(&[], &latch),
+            "nothing to say means nothing said"
+        );
+        assert!(
+            !latch.is_completed(),
+            "and a healthy load must not spend the one report the process gets"
+        );
+
+        assert!(report_config_faults(&fault, &latch), "the first real fault speaks");
+        assert!(latch.is_completed());
+        assert!(
+            !report_config_faults(&fault, &latch),
+            "and the second, third and fourth do not"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -768,27 +768,36 @@ pub enum ConfigFault {
     HomeUnresolvable,
 }
 
+impl ConfigFault {
+    /// What went wrong, WITHOUT the consequence clause.
+    ///
+    /// [`Display`] appends "base is running on DEFAULT settings, not yours",
+    /// which is exactly right where a fault makes `BaseConfig` fall back to its
+    /// defaults -- and wrong anywhere else. `scaffold`'s registry read hits the
+    /// same file for a different reason and owes the operator a different
+    /// consequence, so it borrows the cause and states its own. (#158 leg C)
+    pub fn cause(&self) -> String {
+        match self {
+            Self::Unreadable { path, err } => format!("cannot read {} ({err})", path.display()),
+            Self::Unparseable { path, err } => format!("cannot parse {} ({err})", path.display()),
+            Self::Mismatched { paths, err } => {
+                let names: Vec<String> = paths.iter().map(|p| p.display().to_string()).collect();
+                format!("{} is valid TOML but not valid settings ({err})", names.join(" + "))
+            }
+            Self::HomeUnresolvable => {
+                "cannot determine a home directory, so no base.toml could be read".to_string()
+            }
+        }
+    }
+}
+
 impl std::fmt::Display for ConfigFault {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Every arm ends with the consequence, because a path and a parse error
         // alone do not tell the operator the thing that actually matters: the
         // settings they chose are NOT the settings base is running on.
         const TAIL: &str = "base is running on DEFAULT settings, not yours";
-        match self {
-            Self::Unreadable { path, err } => {
-                write!(f, "cannot read {} ({err}) -- {TAIL}", path.display())
-            }
-            Self::Unparseable { path, err } => {
-                write!(f, "cannot parse {} ({err}) -- {TAIL}", path.display())
-            }
-            Self::Mismatched { paths, err } => {
-                let names: Vec<String> = paths.iter().map(|p| p.display().to_string()).collect();
-                write!(f, "{} is valid TOML but not valid settings ({err}) -- {TAIL}", names.join(" + "))
-            }
-            Self::HomeUnresolvable => {
-                write!(f, "cannot determine a home directory, so no base.toml could be read -- {TAIL}")
-            }
-        }
+        write!(f, "{} -- {TAIL}", self.cause())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -747,36 +747,176 @@ impl Default for SyncConfig {
     }
 }
 
+/// A `base.toml` that EXISTS but could not become settings.
+///
+/// There is deliberately NO `Absent` variant. A missing `base.toml` is a normal
+/// first run, not a fault, and collapsing those two states is the defect this
+/// type exists to remove (#158): absent, empty and unreadable are three
+/// different things and only the last two are worth speaking about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigFault {
+    /// The file is there and could not be read: permissions, a directory in its
+    /// place, an I/O error. Anything except "not found".
+    Unreadable { path: PathBuf, err: String },
+    /// The file was read and is not valid TOML.
+    Unparseable { path: PathBuf, err: String },
+    /// Valid TOML, wrong shape for `BaseConfig`. One wrongly typed field --
+    /// `auto = "yes"` where a bool belongs -- used to discard every OTHER
+    /// setting in the file as well, silently.
+    Mismatched { paths: Vec<PathBuf>, err: String },
+    /// No home directory could be resolved, so neither tier could be located.
+    HomeUnresolvable,
+}
+
+impl std::fmt::Display for ConfigFault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Every arm ends with the consequence, because a path and a parse error
+        // alone do not tell the operator the thing that actually matters: the
+        // settings they chose are NOT the settings base is running on.
+        const TAIL: &str = "base is running on DEFAULT settings, not yours";
+        match self {
+            Self::Unreadable { path, err } => {
+                write!(f, "cannot read {} ({err}) -- {TAIL}", path.display())
+            }
+            Self::Unparseable { path, err } => {
+                write!(f, "cannot parse {} ({err}) -- {TAIL}", path.display())
+            }
+            Self::Mismatched { paths, err } => {
+                let names: Vec<String> = paths.iter().map(|p| p.display().to_string()).collect();
+                write!(f, "{} is valid TOML but not valid settings ({err}) -- {TAIL}", names.join(" + "))
+            }
+            Self::HomeUnresolvable => {
+                write!(f, "cannot determine a home directory, so no base.toml could be read -- {TAIL}")
+            }
+        }
+    }
+}
+
+/// Report config faults on stderr, at most once per process.
+///
+/// ONCE PER PROCESS, not once per call, because one `base scaffold` calls
+/// `BaseConfig::load` three times (`scaffold.rs:114`, `install.rs:977` and
+/// `install.rs:1520`) and the operator does not need telling three times. The
+/// empty case returns before touching the latch, so a healthy first load does
+/// not spend it and a fault arriving later still speaks.
+///
+/// STDERR, deliberately, and the reason is specific rather than stylistic.
+/// `hook/mod.rs:136` is one of the nine production call sites, so this runs
+/// inside a hook. A hook STDOUT is a parsed contract: on pre-tool-use,
+/// post-tool-use and stop it must be exactly one JSON envelope, and on
+/// session-start and user-prompt-submit it is the injected text itself. Stderr
+/// is the operator-diagnostic channel on every one of those paths -- `dispatch`
+/// at `hook/mod.rs:67` fails open to "stderr only, exit 0, empty stdout", and
+/// `post_tool_use.rs` records that "stderr stays stderr -- those lines are
+/// operator diagnostics, not model context". A config warning must never be
+/// able to change one byte of hook stdout, and a test asserts exactly that.
+fn report_config_faults_once(faults: &[ConfigFault]) {
+    if faults.is_empty() {
+        return;
+    }
+    static REPORTED: std::sync::Once = std::sync::Once::new();
+    REPORTED.call_once(|| {
+        for fault in faults {
+            eprintln!("base: {fault}");
+        }
+    });
+}
+
 impl BaseConfig {
     /// Load config: global `~/.base-gbl/base.toml` as base, workspace `.base/base.toml` overlaid on top.
     /// Workspace sections override global at the key level; missing sections inherit from global.
+    ///
+    /// A config that cannot be read or parsed is REPORTED (once per process)
+    /// rather than silently replaced by defaults. The signature is unchanged on
+    /// purpose: six of the nine production call sites have no useful error path
+    /// and would each end in `unwrap_or_default()`, which would copy the silent
+    /// default to six places instead of removing it from one. A caller that
+    /// needs to ACT on a fault uses [`BaseConfig::load_reporting`].
     pub fn load(cwd: &Path) -> Self {
-        Self::try_load(cwd).unwrap_or_default()
+        let (config, faults) = Self::load_reporting(cwd);
+        report_config_faults_once(&faults);
+        config
     }
 
-    fn try_load(cwd: &Path) -> Option<Self> {
-        let home = crate::home::home_root()?;
+    /// Load, and say what could not be read.
+    ///
+    /// The returned list is empty on a healthy load AND on a first run with no
+    /// `base.toml` anywhere -- absent is not a fault, which is why
+    /// [`ConfigFault`] has no variant for it. Every other outcome that used to
+    /// collapse into `default()` now names itself here.
+    pub fn load_reporting(cwd: &Path) -> (Self, Vec<ConfigFault>) {
+        let mut faults = Vec::new();
+
+        let Some(home) = crate::home::home_root() else {
+            faults.push(ConfigFault::HomeUnresolvable);
+            return (Self::default(), faults);
+        };
         let global_path = home.join(".base-gbl").join("base.toml");
         let ws_path = cwd.join(".base").join("base.toml");
 
-        let global = Self::load_toml_table(&global_path);
-        let workspace = Self::load_toml_table(&ws_path);
+        let global = Self::read_table(&global_path, &mut faults);
+        let workspace = Self::read_table(&ws_path, &mut faults);
+
+        // Only the files that actually produced a table are named as sources of
+        // a shape error. Asking the filesystem again with `exists()` would cost
+        // a syscall and could disagree with what was just read.
+        let mut sources = Vec::new();
+        if global.is_some() {
+            sources.push(global_path);
+        }
+        if workspace.is_some() {
+            sources.push(ws_path);
+        }
 
         let merged = match (global, workspace) {
             (Some(g), Some(w)) => merge_toml_tables(g, w),
             (Some(g), None) => g,
             (None, Some(w)) => w,
-            (None, None) => return None,
+            (None, None) => return (Self::default(), faults),
         };
 
-        toml::Value::Table(merged).try_into().ok()
+        match toml::Value::Table(merged).try_into() {
+            Ok(config) => (config, faults),
+            Err(e) => {
+                faults.push(ConfigFault::Mismatched {
+                    paths: sources,
+                    err: e.to_string(),
+                });
+                (Self::default(), faults)
+            }
+        }
     }
 
-    fn load_toml_table(path: &Path) -> Option<toml::Table> {
-        let content = std::fs::read_to_string(path).ok()?;
-        content.parse::<toml::Table>().ok()
+    /// One tier table. Returns `None` for "nothing to merge from here", and
+    /// pushes a fault for every reason EXCEPT the file being absent.
+    ///
+    /// This single match arm is the honest-envelope law in code: the read used
+    /// to end `.ok()?`, which made a missing file and an unreadable one
+    /// indistinguishable to everything downstream.
+    fn read_table(path: &Path, faults: &mut Vec<ConfigFault>) -> Option<toml::Table> {
+        let content = match std::fs::read_to_string(path) {
+            Ok(content) => content,
+            // The one quiet case: no file is a normal first run.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                faults.push(ConfigFault::Unreadable {
+                    path: path.to_path_buf(),
+                    err: e.to_string(),
+                });
+                return None;
+            }
+        };
+        match content.parse::<toml::Table>() {
+            Ok(table) => Some(table),
+            Err(e) => {
+                faults.push(ConfigFault::Unparseable {
+                    path: path.to_path_buf(),
+                    err: e.to_string(),
+                });
+                None
+            }
+        }
     }
-
 }
 
 /// Deep-merge two TOML tables. Overlay values win; nested tables merge recursively.

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -106,7 +106,11 @@ pub fn run(target: &Path) -> Result<()> {
     print!("   ↳ sync CLAUDE.md registry ... ");
     match sync_claude_md_registry() {
         Ok(n) => println!("✓ ({n} workspaces)"),
-        Err(e) => println!("⊘ ({e})"),
+        // STDERR, not stdout. `scaffold` keeps going after this -- the write was
+        // refused, so the registry is already safe -- but a refusal that scrolls
+        // past in the middle of a nine-step progress list is a refusal nobody
+        // reads, and this one means a file on disk is broken.
+        Err(e) => eprintln!("⊘ ({e})"),
     }
 
     // Step 5: Initialize graph
@@ -160,19 +164,59 @@ const WS_START: &str =
     "<!-- BASE:WORKSPACES:START — auto-generated from ~/.base-gbl/base.toml; do not edit between markers -->";
 const WS_END: &str = "<!-- BASE:WORKSPACES:END -->";
 
+/// What the global registry says, or why it could not be read.
+///
+/// THREE states, not two, and the third is the entire point of this type.
+/// `registered_workspace_paths` returned `Vec<String>` and answered ALL of them
+/// with an empty vec: no home, no file, an unreadable file and an unparseable one
+/// all came back as "there are no registered workspaces". That empty vec reached
+/// `build_workspace_block`, which wrote `- (none registered)` over the operator's
+/// real registry in `~/.claude/CLAUDE.md`. (#158 leg C -- the data-loss leg.)
+///
+/// The codebase already drew this distinction one function away:
+/// `workspace_is_registered` has an `Err(_)` arm that falls back to a raw line
+/// scan precisely BECAUSE an unparseable registry still carries real
+/// registrations. This read is the one that failed to draw it.
+enum RegistryRead {
+    /// The registry was read. It may legitimately be empty.
+    Paths(Vec<String>),
+    /// There is no `base.toml` at all. Nothing is registered, and saying so is
+    /// the truth rather than a guess.
+    Absent,
+    /// There IS a registry and it could not be turned into paths. Nothing about
+    /// the real registrations is known, so nothing may be written about them.
+    Fault(crate::config::ConfigFault),
+}
+
 /// Read `[[workspace]]` paths from the global registry (`~/.base-gbl/base.toml`).
-fn registered_workspace_paths() -> Vec<String> {
+fn read_registered_workspaces() -> RegistryRead {
     #[derive(serde::Deserialize)]
     struct WsOnly { #[serde(default)] workspace: Vec<WsPath> }
     #[derive(serde::Deserialize)]
     struct WsPath { path: String }
 
-    let Some(home) = crate::home::home_root() else { return Vec::new() };
+    let Some(home) = crate::home::home_root() else {
+        return RegistryRead::Fault(crate::config::ConfigFault::HomeUnresolvable);
+    };
     let toml_path = home.join(".base-gbl").join("base.toml");
-    let Ok(content) = std::fs::read_to_string(&toml_path) else { return Vec::new() };
-    toml::from_str::<WsOnly>(&content)
-        .map(|w| w.workspace.into_iter().map(|e| e.path).collect())
-        .unwrap_or_default()
+    let content = match std::fs::read_to_string(&toml_path) {
+        Ok(c) => c,
+        // The one state that honestly means "nothing is registered".
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return RegistryRead::Absent,
+        Err(e) => {
+            return RegistryRead::Fault(crate::config::ConfigFault::Unreadable {
+                path: toml_path,
+                err: e.to_string(),
+            });
+        }
+    };
+    match toml::from_str::<WsOnly>(&content) {
+        Ok(w) => RegistryRead::Paths(w.workspace.into_iter().map(|e| e.path).collect()),
+        Err(e) => RegistryRead::Fault(crate::config::ConfigFault::Unparseable {
+            path: toml_path,
+            err: e.to_string(),
+        }),
+    }
 }
 
 fn tildify(path: &str, home: &Path) -> String {
@@ -234,7 +278,29 @@ pub fn sync_claude_md_registry() -> Result<usize> {
     if !claude_md.exists() {
         return Ok(0);
     }
-    let paths = registered_workspace_paths();
+    // Read the registry BEFORE touching CLAUDE.md, and refuse on a fault.
+    //
+    // The block this function writes is generated ENTIRELY from the registry, so
+    // a registry that cannot be read leaves nothing honest to write -- and the
+    // only safe action on a file that already holds the operator's real
+    // registrations is to write nothing at all. An empty list is a CLAIM that
+    // nothing is registered; it must never be the way base says "I could not
+    // tell".
+    let paths = match read_registered_workspaces() {
+        RegistryRead::Paths(p) => p,
+        // No base.toml means nothing is registered. The block states that
+        // correctly, and this is the ordinary first-run path.
+        RegistryRead::Absent => Vec::new(),
+        RegistryRead::Fault(fault) => {
+            anyhow::bail!(
+                "refusing to rewrite {}: {}. The registered-workspaces block is \
+                 generated from that file, so rewriting it now would replace your \
+                 registrations with '(none registered)'.",
+                claude_md.display(),
+                fault.cause()
+            );
+        }
+    };
     let content = std::fs::read_to_string(&claude_md)?;
     let block = build_workspace_block(&paths, &home);
     let updated = splice_workspace_block(&content, &block);

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -104,13 +104,31 @@ pub fn run(target: &Path) -> Result<()> {
     // Step 4b: Mirror the registry into ~/.claude/CLAUDE.md so Claude is auto-aware
     // of every registered workspace without anyone having to remember to edit it.
     print!("   ↳ sync CLAUDE.md registry ... ");
+    // Held, not returned, so the steps after this one still run: the write was
+    // REFUSED, so the registry is already safe, and steps 5 onward are
+    // independent of it. The operator gets every piece of work that was still
+    // safe to do AND a non-zero exit, rather than one or the other.
+    let mut registry_refusal: Option<anyhow::Error> = None;
     match sync_claude_md_registry() {
-        Ok(n) => println!("✓ ({n} workspaces)"),
-        // STDERR, not stdout. `scaffold` keeps going after this -- the write was
-        // refused, so the registry is already safe -- but a refusal that scrolls
-        // past in the middle of a nine-step progress list is a refusal nobody
-        // reads, and this one means a file on disk is broken.
-        Err(e) => eprintln!("⊘ ({e})"),
+        Ok(s) if s.cleared() > 0 => println!(
+            "✓ ({} workspaces — REMOVED {} no longer in base.toml)",
+            s.written,
+            s.cleared()
+        ),
+        Ok(s) => println!("✓ ({} workspaces)", s.written),
+        Err(e) => {
+            // TERMINATE THE STDOUT LINE HERE. The step opened with a `print!`
+            // and no newline, and the refusal itself goes to stderr, so without
+            // this the progress list reads "sync CLAUDE.md registry ... " and
+            // step 5 continues ON THE SAME LINE. A reader of stdout alone sees
+            // this step start and never finish.
+            println!("REFUSED — see stderr");
+            // STDERR for the reason, because a refusal that scrolls past inside
+            // a nine-step progress list is a refusal nobody reads, and this one
+            // means a file on disk is broken.
+            eprintln!("⊘ ({e})");
+            registry_refusal = Some(e);
+        }
     }
 
     // Step 5: Initialize graph
@@ -144,7 +162,15 @@ pub fn run(target: &Path) -> Result<()> {
     }
 
     println!("\n═══════════════════════════════════════");
-    println!("✓ Workspace scaffolded");
+    // The banner is a claim about the whole command, so it cannot say ✓ while a
+    // step refused. `base scaffold` is the command the #158 reporter actually
+    // ran; reporting success here is the same defect as `config set` printing
+    // "Updated" over a write it did not make.
+    if registry_refusal.is_some() {
+        println!("⊘ Workspace scaffolded — ONE STEP REFUSED, see stderr");
+    } else {
+        println!("✓ Workspace scaffolded");
+    }
     println!("═══════════════════════════════════════\n");
     println!("  Path: {}", target.display());
     println!("  Config: .base/base.toml");
@@ -157,7 +183,12 @@ pub fn run(target: &Path) -> Result<()> {
     print!("{}", crate::first_run::text());
     crate::first_run::mark_shown();
 
-    Ok(())
+    // The exit code follows the message (#158 leg B's invariant, at a different
+    // command). A refused step is a failed command, however much else succeeded.
+    match registry_refusal {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 const WS_START: &str =
@@ -269,14 +300,56 @@ fn splice_workspace_block(content: &str, block: &str) -> String {
     out
 }
 
+/// What one sync did, in the terms an operator cares about.
+///
+/// `written` alone is not enough to describe the outcome, and reporting only the
+/// count is what made the old message false: "synced 0 workspace(s)" reads as
+/// "there were none to sync" whether there were none or whether three were just
+/// removed. A count is not a loss. (#158 leg C)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegistrySync {
+    /// How many registrations the block names now.
+    pub written: usize,
+    /// How many it named before this run.
+    pub previous: usize,
+}
+
+impl RegistrySync {
+    /// How many registrations this run removed from the block.
+    pub fn cleared(&self) -> usize {
+        self.previous.saturating_sub(self.written)
+    }
+}
+
+/// Count the registration lines inside the managed block.
+///
+/// Entries are written as ``- `path` `` by `build_workspace_block`, so the
+/// backtick is what distinguishes a real entry from the literal
+/// `- (none registered)` placeholder, which must count as zero.
+fn count_block_entries(content: &str) -> usize {
+    let (Some(si), Some(ei)) = (
+        content.find("BASE:WORKSPACES:START"),
+        content.find("BASE:WORKSPACES:END"),
+    ) else {
+        return 0;
+    };
+    if ei <= si {
+        return 0;
+    }
+    content[si..ei]
+        .lines()
+        .filter(|l| l.trim_start().starts_with("- `"))
+        .count()
+}
+
 /// Regenerate the managed registered-workspaces block in `~/.claude/CLAUDE.md` from
 /// the global registry. Idempotent; only ever rewrites between the markers. No-op if
-/// CLAUDE.md is absent. Returns the number of workspaces written.
-pub fn sync_claude_md_registry() -> Result<usize> {
+/// CLAUDE.md is absent. Returns what the sync did, not merely how many it wrote.
+pub fn sync_claude_md_registry() -> Result<RegistrySync> {
     let home = crate::home::home_root().context("Cannot determine home directory")?;
     let claude_md = home.join(".claude").join("CLAUDE.md");
     if !claude_md.exists() {
-        return Ok(0);
+        return Ok(RegistrySync { written: 0, previous: 0 });
     }
     // Read the registry BEFORE touching CLAUDE.md, and refuse on a fault.
     //
@@ -302,6 +375,7 @@ pub fn sync_claude_md_registry() -> Result<usize> {
         }
     };
     let content = std::fs::read_to_string(&claude_md)?;
+    let previous = count_block_entries(&content);
     let block = build_workspace_block(&paths, &home);
     let updated = splice_workspace_block(&content, &block);
     if updated != content {
@@ -309,7 +383,7 @@ pub fn sync_claude_md_registry() -> Result<usize> {
         std::fs::write(&tmp, &updated)?;
         std::fs::rename(&tmp, &claude_md)?;
     }
-    Ok(paths.len())
+    Ok(RegistrySync { written: paths.len(), previous })
 }
 
 /// Add a workspace path to ~/.base-gbl/base.toml [[workspace]] if not already present.

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -99,7 +99,16 @@ pub fn run(target: &Path) -> Result<()> {
         .unwrap_or_else(|_| target.to_path_buf())
         .to_string_lossy()
         .to_string();
-    register_workspace(&target_str)?;
+    // C-10, and it is C-9's defect at a different step. This line opened with a
+    // `print!` and no newline; on the UNREADABLE path `register_workspace` fails
+    // here and the `?` carries the error out, so stdout was left reading
+    // "4. Register workspace ... " with the next thing glued to the end of it —
+    // and that is the #158 reporter's own path, the one C-9's measurement could
+    // not reach because step 4b is never reached when this aborts.
+    if let Err(e) = register_workspace(&target_str) {
+        println!("FAILED — see stderr");
+        return Err(e);
+    }
 
     // Step 4b: Mirror the registry into ~/.claude/CLAUDE.md so Claude is auto-aware
     // of every registered workspace without anyone having to remember to edit it.

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -9,8 +9,22 @@
 //! release pipeline never publishes to, so `base update` could not deliver the
 //! releases actually being cut. GitHub releases are the single source of truth now.
 //!
-//! No license. No account. No identifiers leave the machine. The only request is an
-//! anonymous GET of a public repo's latest release, plus the asset download.
+//! No license. No account. No identifiers leave the machine. The release check is a
+//! GET of a public repo's latest release, plus the asset download.
+//!
+//! That check is anonymous unless the operator's own environment already holds a
+//! GitHub token. `GITHUB_TOKEN` or `GH_TOKEN`, if either is set, is sent as an
+//! `Authorization` header, because an anonymous check is rate limited per IP
+//! address and a shared or busy address runs out of budget -- at which point the
+//! tool can no longer tell anyone that a new version exists.
+//!
+//! Nothing is read that the operator did not already put in their own
+//! environment, and the token can only ever reach `api.github.com`: the address
+//! below is a hardcoded constant, with no setting and no environment variable
+//! that can point this request anywhere else. That is deliberate. There is no
+//! signature check and no checksum check in the download path, so the constant
+//! is the only thing vouching for what gets installed, and making it overridable
+//! would turn a redirected update into arbitrary code execution.
 
 use std::path::{Path, PathBuf};
 
@@ -63,15 +77,79 @@ fn is_current(current: &str, latest: &str) -> bool {
     semver_tuple(current) >= semver_tuple(latest)
 }
 
+/// The two variables a GitHub token conventionally lives in, in the order `gh`
+/// itself resolves them.
+const TOKEN_VARS: [&str; 2] = ["GITHUB_TOKEN", "GH_TOKEN"];
+
+/// A token already sitting in the operator's environment, or `None` for an
+/// anonymous check.
+///
+/// These two variables and nothing else. `plugin::dist` resolves a token from
+/// further sources, ending in a `gh auth token` subprocess, and that is right
+/// for a one-off plugin download and wrong here: `hook/session_start.rs` runs
+/// the update check on EVERY session start, so a subprocess on this path is one
+/// spawn per session — and on a machine with no `gh` installed, one FAILED spawn
+/// per session, forever, to learn nothing. This path reads two environment
+/// variables and touches nothing else.
+fn token_from_env() -> Option<String> {
+    TOKEN_VARS
+        .iter()
+        .find_map(|v| std::env::var(v).ok().filter(|s| !s.is_empty()))
+}
+
+/// Say what actually went wrong with the release check.
+///
+/// Every failure used to be wrapped in "could not reach the GitHub releases
+/// API", status codes included. That sentence is true only of a transport
+/// failure. On a rate limit it sent the operator off to check a network that was
+/// working perfectly, and hid the one thing that fixes it: a token.
+fn describe_release_api_error(err: ureq::Error) -> anyhow::Error {
+    match err {
+        ureq::Error::Status(403, ref r) if r.header("x-ratelimit-remaining") == Some("0") => {
+            anyhow::anyhow!(
+                "GitHub rate limit reached for this machine's IP address, so the \
+                 release check was refused. Set GITHUB_TOKEN or GH_TOKEN to check \
+                 as yourself, which raises the limit."
+            )
+        }
+        ureq::Error::Status(403, _) => {
+            anyhow::anyhow!("GitHub refused the release check (403 forbidden)")
+        }
+        ureq::Error::Status(code, _) => {
+            anyhow::anyhow!("the GitHub releases API answered with status {code}")
+        }
+        ureq::Error::Transport(t) => {
+            anyhow::anyhow!("could not reach the GitHub releases API: {t}")
+        }
+    }
+}
+
 /// The latest release: its tag (leading `v` stripped) and the download URL for
 /// this platform's asset.
-fn fetch_latest_release() -> Result<(String, String)> {
-    let resp = ureq::get(LATEST_RELEASE_API)
+///
+/// `send` is the transport, supplied by the caller. Production passes a closure
+/// that calls the request. A test passes one that reads the request and answers
+/// it from memory, so no socket is opened anywhere.
+///
+/// The request is built HERE and in no other place in this file, and that is the
+/// point rather than an accident of style. With a single construction site there
+/// is nowhere else for this module to build a release request, so no later edit
+/// can quietly route around the header wiring below, and the request a test
+/// inspects is the same object production sends.
+pub fn fetch_latest_release<F>(send: F) -> Result<(String, String)>
+where
+    F: Fn(ureq::Request) -> std::result::Result<ureq::Response, ureq::Error>,
+{
+    let req = ureq::get(LATEST_RELEASE_API)
         .timeout(std::time::Duration::from_secs(API_TIMEOUT_SECS))
         .set("user-agent", USER_AGENT)
-        .set("accept", "application/vnd.github+json")
-        .call()
-        .context("could not reach the GitHub releases API")?;
+        .set("accept", "application/vnd.github+json");
+    let req = match token_from_env() {
+        Some(t) => req.set("authorization", &format!("Bearer {t}")),
+        None => req,
+    };
+
+    let resp = send(req).map_err(describe_release_api_error)?;
 
     let json: serde_json::Value = resp.into_json().context("malformed release JSON")?;
 
@@ -510,7 +588,7 @@ fn auto_install_dest() -> Result<PathBuf> {
 /// The background path: no output, no ceremony, just get current.
 fn run_quiet(force: bool) -> Result<Option<String>> {
     let current = env!("CARGO_PKG_VERSION");
-    let (latest, url) = fetch_latest_release()?;
+    let (latest, url) = fetch_latest_release(|req| req.call())?;
     if !force && is_current(current, &latest) {
         return Ok(None);
     }
@@ -539,7 +617,7 @@ fn run_verbose(check_only: bool, force: bool) -> Result<Option<String>> {
     let current = env!("CARGO_PKG_VERSION");
     println!("base {current} — checking GitHub releases …");
 
-    let (latest, url) = fetch_latest_release()?;
+    let (latest, url) = fetch_latest_release(|req| req.call())?;
 
     if !force && is_current(current, &latest) {
         println!("✓ already up to date (base {current}).");

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -103,8 +103,8 @@ fn token_from_env() -> Option<String> {
 /// API", status codes included. That sentence is true only of a transport
 /// failure. On a rate limit it sent the operator off to check a network that was
 /// working perfectly, and hid the one thing that fixes it: a token.
-fn describe_release_api_error(err: ureq::Error) -> anyhow::Error {
-    match err {
+fn describe_release_api_error(err: Box<ureq::Error>) -> anyhow::Error {
+    match *err {
         ureq::Error::Status(403, ref r) if r.header("x-ratelimit-remaining") == Some("0") => {
             anyhow::anyhow!(
                 "GitHub rate limit reached for this machine's IP address, so the \
@@ -138,7 +138,7 @@ fn describe_release_api_error(err: ureq::Error) -> anyhow::Error {
 /// inspects is the same object production sends.
 pub fn fetch_latest_release<F>(send: F) -> Result<(String, String)>
 where
-    F: Fn(ureq::Request) -> std::result::Result<ureq::Response, ureq::Error>,
+    F: Fn(ureq::Request) -> std::result::Result<ureq::Response, Box<ureq::Error>>,
 {
     let req = ureq::get(LATEST_RELEASE_API)
         .timeout(std::time::Duration::from_secs(API_TIMEOUT_SECS))
@@ -588,7 +588,7 @@ fn auto_install_dest() -> Result<PathBuf> {
 /// The background path: no output, no ceremony, just get current.
 fn run_quiet(force: bool) -> Result<Option<String>> {
     let current = env!("CARGO_PKG_VERSION");
-    let (latest, url) = fetch_latest_release(|req| req.call())?;
+    let (latest, url) = fetch_latest_release(|req| req.call().map_err(Box::new))?;
     if !force && is_current(current, &latest) {
         return Ok(None);
     }
@@ -617,7 +617,7 @@ fn run_verbose(check_only: bool, force: bool) -> Result<Option<String>> {
     let current = env!("CARGO_PKG_VERSION");
     println!("base {current} — checking GitHub releases …");
 
-    let (latest, url) = fetch_latest_release(|req| req.call())?;
+    let (latest, url) = fetch_latest_release(|req| req.call().map_err(Box::new))?;
 
     if !force && is_current(current, &latest) {
         println!("✓ already up to date (base {current}).");

--- a/tests/claude_md_registry_survives_test.rs
+++ b/tests/claude_md_registry_survives_test.rs
@@ -38,6 +38,10 @@ use std::process::Command;
 
 const BIN: &str = env!("CARGO_BIN_EXE_base");
 
+/// A newline, as a constant, because a char literal for it does not survive
+/// being written through a shell heredoc and a Python string on the way here.
+const NEWLINE: char = 10u8 as char;
+
 /// Three workspaces an operator would lose. Real-looking, and one of them is the
 /// Windows shape whose raw paste is what breaks the file in the first place.
 const REGISTERED: [&str; 3] = [
@@ -544,4 +548,60 @@ stderr:
 {err}");
     assert!(out.contains("✓ Workspace scaffolded"), "{out}");
     assert!(!out.contains("REFUSED"), "{out}");
+}
+
+/// C-10. The same defect as C-9, at step 4, on the path C-9 could NOT reach.
+///
+/// When `base.toml` is UNREADABLE, `register_workspace` fails at step 4 and the
+/// `?` carries the error out — so step 4b never runs and C-9's terminator is
+/// never exercised. That is the #158 reporter's own path, and it was left
+/// reading "4. Register workspace ... " with the next output glued to the end.
+///
+/// Shipping C-9 while leaving this would mean the acceptance criterion still
+/// fails on the case the row is actually about.
+#[test]
+fn the_aborting_step_four_also_terminates_its_own_stdout_line() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::with_unreadable_registry();
+    let target = f.root().join("newws");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let (code, out, err) = f.run(&["scaffold", target.to_str().unwrap()]);
+
+    assert_ne!(code, 0, "an unreadable registry is a failed scaffold: {err}");
+    let line = out
+        .lines()
+        .find(|l| l.contains("Register workspace"))
+        .unwrap_or_else(|| panic!("step 4 never appeared on stdout:
+{out}"));
+    assert!(
+        line.contains("FAILED"),
+        "step 4 must close its own line when it aborts: {line:?}"
+    );
+    // The real assertion: the line ENDS. `lines()` already split on the newline,
+    // so reaching here with a found line proves a terminator followed it — but
+    // pin the glue case explicitly, because that is the symptom.
+    assert!(
+        !line.contains("5."),
+        "the next step must not be glued to this line: {line:?}"
+    );
+    assert!(
+        out.ends_with(NEWLINE),
+        "stdout must not end mid-line either: {out:?}"
+    );
+}
+
+/// The control: an ordinary scaffold does not print step 4 as failed.
+#[test]
+fn step_four_reports_failure_only_when_it_fails() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some(&healthy_registry()));
+    let target = f.root().join("newws");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let (code, out, _err) = f.run(&["scaffold", target.to_str().unwrap()]);
+
+    assert_eq!(code, 0);
+    let line = out.lines().find(|l| l.contains("Register workspace")).unwrap();
+    assert!(!line.contains("FAILED"), "{line:?}");
 }

--- a/tests/claude_md_registry_survives_test.rs
+++ b/tests/claude_md_registry_survives_test.rs
@@ -395,3 +395,153 @@ fn readable_and_empty_is_not_the_same_state_as_unreadable() {
         "the broken one wrote nothing at all"
     );
 }
+
+// ─── A count is not a loss ─────────────────────────────────────────────────
+
+/// `✓ synced 0 workspace(s)` is FALSE when three registrations were just
+/// removed. It reports a COUNT where the operator needs a LOSS, and the two
+/// cases it cannot distinguish — "there were none" and "there were three and now
+/// there are none" — are exactly the ones that matter.
+///
+/// This is the message half of the residual. Whether sync SHOULD clear a
+/// populated block when `base.toml` is absent is a separate design question,
+/// ruled out of this lane and logged as `N-SYNC-CLEARS-ON-ABSENT-REGISTRY`.
+/// Honest reporting does not depend on settling that.
+#[test]
+fn a_sync_that_removes_registrations_reports_the_loss_not_a_count() {
+    assert_binary_contains_the_code_under_test();
+    // Absent registry, populated block: the case that produced the false line.
+    let f = Fake::new(None);
+    assert_registrations_present(&f, "precondition");
+
+    let (code, out, err) = f.run(&["workspace", "sync"]);
+
+    assert_eq!(code, 0, "absent is not a fault: {err}");
+    assert!(
+        out.contains("REMOVED") && out.contains('3'),
+        "it has to say what it took away, and how many: {out}"
+    );
+    assert!(
+        !out.contains("synced 0 workspace(s)"),
+        "and must NOT report a bare count, which reads as 'there were none': {out}"
+    );
+}
+
+/// The control. A sync that removes nothing keeps the plain message — otherwise
+/// every ordinary sync would shout about a loss that did not happen.
+#[test]
+fn a_sync_that_removes_nothing_keeps_the_plain_message() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some(&healthy_registry()));
+
+    let (code, out, err) = f.run(&["workspace", "sync"]);
+
+    assert_eq!(code, 0, "{err}");
+    assert!(out.contains("synced 3 workspace(s)"), "{out}");
+    assert!(
+        !out.contains("REMOVED"),
+        "nothing was removed, so nothing may claim it was: {out}"
+    );
+}
+
+/// The placeholder must not be counted as a registration, or a block reading
+/// `- (none registered)` would report a phantom loss of one on the next sync.
+#[test]
+fn the_none_registered_placeholder_counts_as_zero_not_one() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(None);
+    // First sync clears the three and writes the placeholder.
+    let (_, out1, _) = f.run(&["workspace", "sync"]);
+    assert!(out1.contains("REMOVED"), "precondition: the first sync cleared them: {out1}");
+
+    // Second sync: the block now holds only the placeholder, so nothing is lost.
+    let (code, out2, err) = f.run(&["workspace", "sync"]);
+    assert_eq!(code, 0, "{err}");
+    assert!(
+        !out2.contains("REMOVED"),
+        "the placeholder is not a registration, so this sync removed nothing: {out2}"
+    );
+}
+
+// ─── base scaffold: the command the #158 reporter actually ran ─────────────
+
+/// THE measurement for this half of the leg, and it is the reporter's own
+/// command. `base scaffold` reported SUCCESS over a refused registry sync: the
+/// step printed nothing terminal on stdout, the banner said "✓ Workspace
+/// scaffolded", and the process exited 0.
+///
+/// It needed TWO fixes and either alone leaves rc at 0. `scaffold::run` now
+/// returns Err, AND the `cli.rs` Scaffold arm now calls `die` instead of
+/// printing the error and falling through — that arm sits inside `run()`, which
+/// returns `()`, so a bare `eprintln!` there is a normal exit. Same shape as the
+/// twelve rc-0 branches leg B removed.
+#[test]
+fn scaffold_exits_non_zero_when_the_registry_sync_is_refused() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some(&broken_registry()));
+    let before = f.claude_md_bytes();
+
+    let target = f.root().join("newws");
+    std::fs::create_dir_all(&target).unwrap();
+    let (code, out, err) = f.run(&["scaffold", target.to_str().unwrap()]);
+
+    assert_ne!(
+        code, 0,
+        "a refused step is a failed command.
+stdout:
+{out}
+stderr:
+{err}"
+    );
+    assert!(
+        !out.contains("✓ Workspace scaffolded"),
+        "the banner is a claim about the WHOLE command and one step refused: {out}"
+    );
+    assert_eq!(before, f.claude_md_bytes(), "and the registry is still untouched");
+}
+
+/// The dangling line. Step 4b opens with a `print!` and no newline; the refusal
+/// goes to stderr, so without a terminator on stdout the progress list reads
+/// "sync CLAUDE.md registry ... " and step 5 continues ON THE SAME LINE. A
+/// reader of stdout alone sees the step start and never finish.
+#[test]
+fn the_refused_step_still_terminates_its_own_stdout_line() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some(&broken_registry()));
+    let target = f.root().join("newws");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let (_code, out, _err) = f.run(&["scaffold", target.to_str().unwrap()]);
+
+    let line = out
+        .lines()
+        .find(|l| l.contains("sync CLAUDE.md registry"))
+        .unwrap_or_else(|| panic!("step 4b did not appear on stdout at all:
+{out}"));
+    assert!(
+        line.contains("REFUSED"),
+        "the step has to close its own line before the next one starts: {line:?}"
+    );
+    assert!(
+        !line.contains("5."),
+        "step 5 must not be sharing this line: {line:?}"
+    );
+}
+
+/// The control: an ordinary scaffold still succeeds and still exits 0. Without
+/// it, a change that made scaffold always fail would pass both tests above.
+#[test]
+fn an_ordinary_scaffold_still_succeeds_and_exits_zero() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some(&healthy_registry()));
+    let target = f.root().join("newws");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let (code, out, err) = f.run(&["scaffold", target.to_str().unwrap()]);
+
+    assert_eq!(code, 0, "a good registry scaffolds fine.
+stderr:
+{err}");
+    assert!(out.contains("✓ Workspace scaffolded"), "{out}");
+    assert!(!out.contains("REFUSED"), "{out}");
+}

--- a/tests/claude_md_registry_survives_test.rs
+++ b/tests/claude_md_registry_survives_test.rs
@@ -1,0 +1,397 @@
+//! #158 leg C: a registry base cannot read must never become a registry base
+//! reports as empty.
+//!
+//! THE DEFECT. `registered_workspace_paths()` returned `Vec<String>` and answered
+//! four different states with the same empty vec: no home directory, no
+//! `base.toml`, a `base.toml` that could not be read, and one that could not be
+//! parsed. That empty vec went to `build_workspace_block`, which writes
+//! `- (none registered)`, and `sync_claude_md_registry` then wrote that over the
+//! managed block in `~/.claude/CLAUDE.md`. One unparseable character in
+//! `base.toml` — a legacy Windows path pasted raw is the reported cause — and the
+//! operator's entire registered-workspace list was replaced with the words "none
+//! registered", by a command whose whole job is to keep that list current.
+//!
+//! An empty list is a CLAIM that nothing is registered. It must never be the way
+//! base says "I could not tell".
+//!
+//! HOW THIS LEG CLOSES, and it closes no other way: every test here starts from a
+//! `CLAUDE.md` that already holds real registrations and a `base.toml` that is
+//! deliberately broken, and asserts the file is **byte-identical** afterwards. A
+//! test that starts from a good config and asserts the good path proves nothing
+//! about this leg.
+//!
+//! BYTE-IDENTICAL, not "still mentions three workspaces". A count survives a
+//! rewrite that happened to produce the same count, and the block is not the only
+//! thing in that file — the prose around it is the operator's own and has to come
+//! through untouched too. Comparing the whole file byte for byte is the only
+//! assertion that covers both.
+//!
+//! ISOLATION. `BASE_HOME` is a tempdir and the cwd sits inside it. The
+//! `~/.claude/CLAUDE.md` every one of these tests writes to is
+//! `<tempdir>/.claude/CLAUDE.md`; `install::ensure_claude_md_current` and
+//! `scaffold::sync_claude_md_registry` both resolve their home through
+//! `home::home_root`, which consults `BASE_HOME` before the OS. Nothing here can
+//! reach the operator's real file, which is the lane's first hard boundary.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_base");
+
+/// Three workspaces an operator would lose. Real-looking, and one of them is the
+/// Windows shape whose raw paste is what breaks the file in the first place.
+const REGISTERED: [&str; 3] = [
+    "/home/operator/lifestyle",
+    "/home/operator/ops-sys/toolbox",
+    "C:/Users/operator/Documents/grazer",
+];
+
+/// The `base.toml` that breaks, and why it breaks.
+///
+/// `\\?\` is a real Windows extended-length prefix and `\?` is not a TOML escape,
+/// so a registry that recorded one verbatim stops parsing. This is the reported
+/// cause of #158, not an invented corruption — and note that the file still
+/// plainly contains the other two paths, which is exactly why erasing them is
+/// data loss rather than an honest empty answer.
+fn broken_registry() -> String {
+    format!(
+        "[[workspace]]\npath = \"\\\\?\\E:\\legacy\"\n\n\
+         [[workspace]]\npath = \"{}\"\n\n\
+         [[workspace]]\npath = \"{}\"\n",
+        REGISTERED[0], REGISTERED[1]
+    )
+}
+
+fn healthy_registry() -> String {
+    REGISTERED
+        .iter()
+        .map(|p| format!("[[workspace]]\npath = \"{p}\"\n"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A `CLAUDE.md` that already carries the managed block with all three
+/// workspaces in it, plus prose either side that must survive untouched.
+fn claude_md_with_registrations() -> String {
+    let mut s = String::from(
+        "# Operator instructions\n\nThis paragraph is the operator's own and is not managed.\n\n",
+    );
+    s.push_str("<!-- BASE:WORKSPACES:START — auto-generated from ~/.base-gbl/base.toml; do not edit between markers -->\n");
+    s.push_str("## Registered Workspaces (auto — synced from base.toml)\n\n");
+    for p in REGISTERED {
+        s.push_str(&format!("- `{p}`\n"));
+    }
+    s.push_str("<!-- BASE:WORKSPACES:END -->\n");
+    s.push_str("\n## Something after the block\n\nAlso the operator's own.\n");
+    s
+}
+
+struct Fake {
+    dir: tempfile::TempDir,
+}
+
+impl Fake {
+    /// A fake home with `.claude/CLAUDE.md` holding three registrations and a
+    /// `base.toml` in whatever state the test needs.
+    fn new(registry: Option<&str>) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join(".base-gbl").join(".base")).unwrap();
+        std::fs::create_dir_all(root.join(".claude")).unwrap();
+        std::fs::write(root.join(".claude").join("CLAUDE.md"), claude_md_with_registrations())
+            .unwrap();
+        if let Some(r) = registry {
+            std::fs::write(root.join(".base-gbl").join("base.toml"), r).unwrap();
+        }
+        Self { dir }
+    }
+
+    /// The same, but `base.toml` is a directory: present and unreadable.
+    fn with_unreadable_registry() -> Self {
+        let f = Self::new(None);
+        std::fs::create_dir_all(f.root().join(".base-gbl").join("base.toml")).unwrap();
+        f
+    }
+
+    fn root(&self) -> &Path {
+        self.dir.path()
+    }
+
+    fn claude_md(&self) -> PathBuf {
+        self.root().join(".claude").join("CLAUDE.md")
+    }
+
+    /// The whole file, as bytes.
+    ///
+    /// Raw bytes rather than a hash on purpose: it is the same assertion, needs
+    /// no crate, and when it fails it shows the difference instead of two hex
+    /// strings that say only "these are not equal".
+    fn claude_md_bytes(&self) -> Vec<u8> {
+        std::fs::read(self.claude_md()).unwrap()
+    }
+
+    fn run(&self, args: &[&str]) -> (i32, String, String) {
+        let out = Command::new(BIN)
+            .args(args)
+            .current_dir(self.root())
+            .env("BASE_HOME", self.root())
+            .env("BASE_NO_AUTO_UPDATE", "1")
+            .output()
+            .expect("the base binary runs");
+        (
+            out.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+}
+
+/// The precondition every test in this file depends on: the file really does
+/// start out holding the registrations, so "it survived" means something.
+fn assert_registrations_present(f: &Fake, when: &str) {
+    let text = std::fs::read_to_string(f.claude_md()).unwrap();
+    for p in REGISTERED {
+        assert!(
+            text.contains(p),
+            "{when}: expected {p} in CLAUDE.md, got:\n{text}"
+        );
+    }
+    assert!(
+        !text.contains("(none registered)"),
+        "{when}: CLAUDE.md must not say (none registered):\n{text}"
+    );
+}
+
+// ─── The binary has to be the one we just built ────────────────────────────
+
+/// Refuse to measure a `base` binary that does not contain the code under test.
+///
+/// MEASURED 2026-09-11, and the reason this is BEHAVIOURAL rather than an mtime
+/// comparison: `target/debug/base` — the exact path `CARGO_BIN_EXE_base` names —
+/// held a build with pre-leg-B behaviour while its mtime (11:28:54) was NEWER
+/// than every source file in `src/` (newest 11:26:55). An mtime check would have
+/// called it fresh and been wrong. `cargo test --no-run` did not correct it
+/// either; only `cargo build --bin base --all-features` did.
+///
+/// Cargo builds the bin with one feature set for `cargo build` and another for
+/// `cargo test` (the self-dev-dependency turns on `isolation-guard`), and both
+/// uplift to that same path. Running one after the other can leave it holding
+/// the other build.
+///
+/// Every test in this file then failed for a reason that had nothing to do with
+/// the product, which is the same class as a mutation that does not mutate: a
+/// test that runs against a stale binary is indistinguishable from a guard that
+/// cannot fire. This turns that into a named refusal instead of a confusing red.
+///
+/// The marker is leg A's fault report, which is committed, pushed, and
+/// independent of everything this file asserts: any `base` command run against
+/// an unreadable config says so on stderr. A binary without it cannot possibly
+/// have leg C.
+fn assert_binary_contains_the_code_under_test() {
+    let f = Fake::new(Some(&broken_registry()));
+    let (_code, _out, err) = f.run(&["hooks", "manifest"]);
+    assert!(
+        err.contains("base is running on DEFAULT settings, not yours"),
+        "STALE BINARY. {BIN} does not carry leg A's config-fault report, so it          cannot carry leg C either and nothing this file measures would mean          anything.
+
+Rebuild it with:
+    cargo build --bin base --all-features
+
+         stderr was: {err}"
+    );
+}
+
+/// Run first by name (tests are alphabetical within a file only by chance, so
+/// this is also called from each test that depends on it).
+#[test]
+fn the_binary_under_test_is_not_stale() {
+    assert_binary_contains_the_code_under_test();
+}
+
+// ─── The fixture has to be broken, or this whole file measures nothing ─────
+
+/// Every test below starts from a registry that must FAIL to parse. If the
+/// fixture ever parses, each of them silently becomes a test of the healthy
+/// path — green, and proving nothing about the leg.
+///
+/// So the fixture asserts its own brokenness before anything relies on it. This
+/// is the same rule as "a mutation that does not mutate is indistinguishable
+/// from a guard that cannot fire", applied to a test fixture.
+#[test]
+fn the_broken_fixture_really_does_fail_to_parse() {
+    let raw = broken_registry();
+    let parsed = raw.parse::<toml::Value>();
+    assert!(
+        parsed.is_err(),
+        "the fixture PARSED, so every other test in this file is measuring the          healthy path.
+fixture bytes:
+{raw}
+parsed as: {parsed:?}"
+    );
+    // And it still plainly contains real registrations, which is exactly why
+    // erasing them is data loss rather than an honest empty answer.
+    assert!(raw.contains(REGISTERED[0]), "{raw}");
+    assert!(raw.contains(REGISTERED[1]), "{raw}");
+}
+
+// ─── THE LEG ───────────────────────────────────────────────────────────────
+
+/// `base workspace sync` against an UNPARSEABLE registry must refuse and touch
+/// nothing. This is the leg, stated as a test.
+#[test]
+fn workspace_sync_refuses_rather_than_erasing_when_the_registry_will_not_parse() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some(&broken_registry()));
+    assert_registrations_present(&f, "precondition");
+    let before = f.claude_md_bytes();
+
+    let (code, out, err) = f.run(&["workspace", "sync"]);
+
+    assert_ne!(code, 0, "a sync that could not read the registry has failed: {out}");
+    assert_eq!(
+        before,
+        f.claude_md_bytes(),
+        "CLAUDE.md must be BYTE-IDENTICAL. stderr: {err}"
+    );
+    assert_registrations_present(&f, "after a refused sync");
+    assert!(
+        err.contains("refusing to rewrite"),
+        "and it has to say that it refused, and why: {err}"
+    );
+}
+
+/// The same, for a registry that is present and cannot be READ. Unreadable and
+/// unparseable are different states and each gets its own arm — leg A's law is
+/// the same law here.
+#[test]
+fn workspace_sync_refuses_rather_than_erasing_when_the_registry_cannot_be_read() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::with_unreadable_registry();
+    assert_registrations_present(&f, "precondition");
+    let before = f.claude_md_bytes();
+
+    let (code, _out, err) = f.run(&["workspace", "sync"]);
+
+    assert_ne!(code, 0, "an unreadable registry is a failure: {err}");
+    assert_eq!(before, f.claude_md_bytes(), "CLAUDE.md byte-identical. stderr: {err}");
+    assert_registrations_present(&f, "after a refused sync");
+}
+
+/// The OTHER reach point, and it needs its own test because it behaves
+/// differently on purpose.
+///
+/// `base scaffold` calls `sync_claude_md_registry` as one step of nine and keeps
+/// going afterwards — the write was refused, so the registry is already safe and
+/// there is no reason to abandon the rest of the scaffold. What it must NOT do is
+/// lose the refusal: it used to `println!` it into the middle of a progress list.
+#[test]
+fn scaffold_also_refuses_and_reports_the_refusal_on_stderr() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some(&broken_registry()));
+    assert_registrations_present(&f, "precondition");
+    let before = f.claude_md_bytes();
+
+    let target = f.root().join("newws");
+    std::fs::create_dir_all(&target).unwrap();
+    let (_code, out, err) = f.run(&["scaffold", target.to_str().unwrap()]);
+
+    assert_eq!(
+        before,
+        f.claude_md_bytes(),
+        "scaffold must not erase the registry either. stderr: {err}"
+    );
+    assert_registrations_present(&f, "after a refused scaffold sync");
+    assert!(
+        err.contains("refusing to rewrite"),
+        "the refusal belongs on stderr, where it will not scroll past inside a \
+         nine-step progress list. stdout was:\n{out}\nstderr was:\n{err}"
+    );
+}
+
+// ─── The controls, without which none of the above proves anything ─────────
+
+/// A readable registry still syncs, and all three registrations reach the block.
+/// Without this arm, a "fix" that refused unconditionally would pass every test
+/// above and break the feature completely.
+#[test]
+fn a_readable_registry_still_syncs_every_workspace() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some(&healthy_registry()));
+    let (code, out, err) = f.run(&["workspace", "sync"]);
+
+    assert_eq!(code, 0, "a good registry syncs: {err}");
+    assert!(out.contains("3 workspace"), "and reports what it wrote: {out}");
+    assert_registrations_present(&f, "after a successful sync");
+}
+
+/// A registry that is READABLE and genuinely empty writes `(none registered)`,
+/// and that is correct rather than data loss: the source of truth says nothing is
+/// registered, so the generated block says nothing is registered.
+///
+/// This is the arm that makes the leg a real distinction instead of a blanket
+/// refusal. "Readable and empty" and "unreadable" now produce opposite
+/// behaviours, which is the entire point.
+#[test]
+fn a_readable_but_empty_registry_correctly_writes_none_registered() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(Some("[update]\nauto = false\n"));
+    let before = f.claude_md_bytes();
+
+    let (code, _out, err) = f.run(&["workspace", "sync"]);
+
+    assert_eq!(code, 0, "an empty registry is not a fault: {err}");
+    assert_ne!(before, f.claude_md_bytes(), "the block is regenerated");
+    let text = std::fs::read_to_string(f.claude_md()).unwrap();
+    assert!(
+        text.contains("(none registered)"),
+        "a readable registry with no [[workspace]] entries says so: {text}"
+    );
+    // And the operator's own prose either side is still there, because only the
+    // managed block may ever be rewritten.
+    assert!(text.contains("This paragraph is the operator's own"), "{text}");
+    assert!(text.contains("Also the operator's own."), "{text}");
+}
+
+/// An ABSENT `base.toml` also writes `(none registered)`, and that is honest for
+/// the same reason: there is no registry, so nothing is registered.
+///
+/// Absent is deliberately NOT grouped with unreadable here, which is the same
+/// distinction leg A's `ConfigFault` encodes by having no `Absent` variant.
+#[test]
+fn an_absent_registry_is_not_a_fault_and_writes_none_registered() {
+    assert_binary_contains_the_code_under_test();
+    let f = Fake::new(None);
+    let (code, _out, err) = f.run(&["workspace", "sync"]);
+
+    assert_eq!(code, 0, "a first run is not a fault: {err}");
+    let text = std::fs::read_to_string(f.claude_md()).unwrap();
+    assert!(text.contains("(none registered)"), "{text}");
+}
+
+/// The distinction, stated as one assertion rather than left implicit across six
+/// tests: the SAME command, on a file that is readable-and-empty versus one that
+/// is unreadable, must do opposite things.
+#[test]
+fn readable_and_empty_is_not_the_same_state_as_unreadable() {
+    assert_binary_contains_the_code_under_test();
+    let empty = Fake::new(Some("[update]\nauto = false\n"));
+    let (empty_code, _, _) = empty.run(&["workspace", "sync"]);
+
+    let broken = Fake::new(Some(&broken_registry()));
+    let broken_before = broken.claude_md_bytes();
+    let (broken_code, _, _) = broken.run(&["workspace", "sync"]);
+
+    assert_eq!(empty_code, 0, "readable and empty: writes, succeeds");
+    assert_ne!(broken_code, 0, "unreadable: refuses, fails");
+    assert!(
+        std::fs::read_to_string(empty.claude_md())
+            .unwrap()
+            .contains("(none registered)"),
+        "the empty one wrote the honest answer"
+    );
+    assert_eq!(
+        broken_before,
+        broken.claude_md_bytes(),
+        "the broken one wrote nothing at all"
+    );
+}

--- a/tests/config_exit_code_test.rs
+++ b/tests/config_exit_code_test.rs
@@ -125,6 +125,46 @@ fn run(root: &Path, args: &[&str]) -> (i32, String, String) {
     )
 }
 
+// ─── The binary has to be the one we just built ────────────────────────────
+
+/// Refuse to measure a `base` binary that does not contain the code under test.
+///
+/// MEASURED 2026-09-11: `target/debug/base` — the exact path `CARGO_BIN_EXE_base`
+/// names — held a build with pre-leg-B behaviour while its mtime (11:28:54) was
+/// NEWER than every source file in `src/` (newest 11:26:55). An mtime check would
+/// have called it fresh and been wrong, which is why this one is BEHAVIOURAL.
+///
+/// Cargo builds the bin with one feature set for `cargo build` and another for
+/// `cargo test` (the self-dev-dependency turns on `isolation-guard`), and both
+/// uplift to that same path, so running one after the other can leave it holding
+/// the other build. `cargo test --no-run` did not correct it and `cargo test`
+/// put the stale one back; only `cargo clean -p base` dislodged it.
+///
+/// A test that runs against a stale binary is indistinguishable from a guard
+/// that cannot fire, so this refuses by name rather than producing a red that
+/// blames the product.
+///
+/// The marker is leg A's config-fault report, which is committed, pushed, and
+/// independent of every exit code this file asserts.
+fn assert_binary_contains_the_code_under_test() {
+    let h = home_with(Config::Unparseable);
+    let (_code, _out, err) = run(h.path(), &["hooks", "manifest"]);
+    assert!(
+        err.contains("DEFAULT settings, not yours"),
+        "STALE BINARY. {BIN} does not carry leg A's config-fault report, so its          exit codes are not this branch's exit codes and nothing here would mean          anything.
+
+Rebuild with:
+    cargo clean -p base && cargo test
+
+         stderr was: {err}"
+    );
+}
+
+#[test]
+fn the_binary_under_test_is_not_stale() {
+    assert_binary_contains_the_code_under_test();
+}
+
 // ─── The invariant, swept ──────────────────────────────────────────────────
 
 /// Every failing branch of `base config`, the state that reaches it, and a
@@ -161,6 +201,7 @@ const FAILING: &[(&str, Config, &[&str], &str)] = &[
 /// the message names the cause it actually hit.
 #[test]
 fn exit_code_follows_the_message_on_every_failing_branch() {
+    assert_binary_contains_the_code_under_test();
     let mut wrong = Vec::new();
     for (name, state, args, expected) in FAILING {
         let h = home_with(*state);
@@ -204,6 +245,7 @@ fn exit_code_follows_the_message_on_every_failing_branch() {
 /// always exited non-zero would pass every row and be useless.
 #[test]
 fn the_succeeding_branches_still_exit_zero() {
+    assert_binary_contains_the_code_under_test();
     // list
     let h = home_with(Config::Healthy);
     let (code, out, err) = run(h.path(), &["config", "list"]);
@@ -236,6 +278,7 @@ fn the_succeeding_branches_still_exit_zero() {
 /// operator, in as many words, that it had updated a setting it had not written.
 #[test]
 fn config_set_never_claims_success_over_a_write_it_did_not_make() {
+    assert_binary_contains_the_code_under_test();
     let h = home_with(Config::ReadOnly);
     let path = global_toml(h.path());
     let before = std::fs::read(&path).unwrap();
@@ -262,6 +305,7 @@ fn config_set_never_claims_success_over_a_write_it_did_not_make() {
 /// mirrors `scaffold::register_workspace` rather than being a second spelling.
 #[test]
 fn set_against_an_absent_config_refuses_and_names_base_install() {
+    assert_binary_contains_the_code_under_test();
     let h = home_with(Config::Absent);
     let (code, _out, err) = run(h.path(), &["config", "set", "update.auto", "true"]);
 
@@ -281,6 +325,7 @@ fn set_against_an_absent_config_refuses_and_names_base_install() {
 /// 0 anyway. The message was right; the exit code contradicted it.
 #[test]
 fn list_against_an_absent_config_refuses_and_names_base_install() {
+    assert_binary_contains_the_code_under_test();
     let h = home_with(Config::Absent);
     let (code, _out, err) = run(h.path(), &["config", "list"]);
 
@@ -296,6 +341,7 @@ fn list_against_an_absent_config_refuses_and_names_base_install() {
 /// will do. Reading a default is honest. Silently discarding a WRITE is not.
 #[test]
 fn get_against_an_absent_config_answers_from_the_default_and_exits_zero() {
+    assert_binary_contains_the_code_under_test();
     let h = home_with(Config::Absent);
     let (code, out, err) = run(h.path(), &["config", "get", "update.auto"]);
 

--- a/tests/config_exit_code_test.rs
+++ b/tests/config_exit_code_test.rs
@@ -1,0 +1,345 @@
+//! #158 leg B: a `base config` command that fails has to EXIT non-zero.
+//!
+//! REAL BINARY FROM THE FIRST LINE, and that is not a stylistic preference. Leg B
+//! is entirely about what the PROCESS EXITS WITH, and a unit test cannot observe a
+//! process exit code at all — it observes a return value. "rc 0 over a parse
+//! failure" is precisely the gap between those two things.
+//!
+//! Leg A measured that gap rather than assuming it: under the mutation that made
+//! leg A's fault report a no-op, all nine of its unit tests stayed GREEN while
+//! both of its real-binary files went RED. A unit layer does not guard the
+//! shipping channel, so this leg does not have one.
+//!
+//! THE INVARIANT, which settles every branch uniformly instead of making twelve
+//! separate judgement calls: **the exit code follows the message.** A branch that
+//! prints an error exits non-zero; a branch that succeeds exits 0. `exit_code_
+//! follows_the_message_on_every_failing_branch` is that invariant as a sweep, and
+//! the named tests below it pin the ones with extra consequences.
+//!
+//! WHY THESE ALL USED TO EXIT 0. Every branch was `eprintln!(...)` followed by a
+//! bare `return`, inside `cli::run()`, which returns `()`. A bare return from a
+//! function that yields `()` is a NORMAL exit. So `base config set x.y v && echo
+//! ok` printed the error AND then printed ok, and every CI step, shell chain and
+//! script treated a broken config as a success.
+//!
+//! ONE DOCUMENTED EXCLUSION, ruled rather than missed. `base config get
+//! <section>.<field>` for a key that exists nowhere and has no compiled-in
+//! default still prints "Key not found" and exits 0. A missing key is not a parse
+//! failure, so it sits outside this lane under the backlog's standing order 1 and
+//! is logged to the work order's unranked findings instead. It is deliberately
+//! NOT asserted either way here: pinning rc 0 would turn a deferral into a rule
+//! and make the eventual fix look like a regression.
+//!
+//! ISOLATION. `BASE_HOME` points at a tempdir and the cwd sits inside it, so
+//! every `~`-rooted path resolves into the sandbox. Nothing here can reach the
+//! operator's real `~/.base-gbl/base.toml`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_base");
+
+/// What state the global `base.toml` is in when the command runs.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Config {
+    /// No file at all — a first run.
+    Absent,
+    /// Present, readable, valid.
+    Healthy,
+    /// Present, readable, not TOML.
+    Unparseable,
+    /// Present and cannot be read: a directory sits where the file belongs.
+    /// Chosen over `chmod 000` because that is a no-op for root, which would make
+    /// the test silently stop measuring rather than fail.
+    Unreadable,
+    /// Valid TOML whose `[update]` is a string, so `set update.auto` finds a
+    /// section that is not a table.
+    SectionIsScalar,
+    /// Present, readable, valid, and not writable.
+    ReadOnly,
+}
+
+fn home_with(state: Config) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let gbl = tmp.path().join(".base-gbl");
+    std::fs::create_dir_all(gbl.join(".base")).unwrap();
+    let path = gbl.join("base.toml");
+    match state {
+        Config::Absent => {}
+        Config::Healthy => std::fs::write(&path, "[update]\nauto = false\n").unwrap(),
+        Config::Unparseable => std::fs::write(&path, "[update]\nauto = \n").unwrap(),
+        Config::Unreadable => std::fs::create_dir_all(&path).unwrap(),
+        Config::SectionIsScalar => std::fs::write(&path, "update = \"not a table\"\n").unwrap(),
+        Config::ReadOnly => {
+            std::fs::write(&path, "[update]\nauto = false\n").unwrap();
+            set_read_only(&path);
+        }
+    }
+    tmp
+}
+
+#[cfg(unix)]
+fn set_read_only(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o444)).unwrap();
+    // A read-only file is only a failure mechanism for a user the kernel actually
+    // stops. Root writes straight through it, and this test would then pass while
+    // measuring nothing — the same silent-skip shape leg B exists to remove. So
+    // prove the mechanism works in THIS process before relying on it.
+    if std::fs::write(path, "probe").is_ok() {
+        panic!(
+            "this test cannot measure anything: writing to a 0444 file succeeded, \
+             so the suite is running with permission to ignore the mode bits (root \
+             or CAP_DAC_OVERRIDE). Run it as an ordinary user."
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn set_read_only(path: &Path) {
+    let mut p = std::fs::metadata(path).unwrap().permissions();
+    p.set_readonly(true);
+    std::fs::set_permissions(path, p).unwrap();
+    if std::fs::write(path, "probe").is_ok() {
+        panic!("this test cannot measure anything: a read-only file was still writable");
+    }
+}
+
+fn global_toml(root: &Path) -> PathBuf {
+    root.join(".base-gbl").join("base.toml")
+}
+
+/// Exit code, stdout, stderr — with an explicit environment.
+fn run(root: &Path, args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(BIN)
+        .args(args)
+        .current_dir(root)
+        .env("BASE_HOME", root)
+        .env("BASE_NO_AUTO_UPDATE", "1")
+        .output()
+        .expect("the base binary runs");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+// ─── The invariant, swept ──────────────────────────────────────────────────
+
+/// Every failing branch of `base config`, the state that reaches it, and a
+/// fragment of the message it owes the operator.
+///
+/// This is the enumeration, not a sample. Each row is one of the branches that
+/// used to print an error and exit 0.
+///
+/// THE EXPECTED FRAGMENT IS NOT DECORATION, and it was added because designing
+/// this leg's mutations exposed the gap. Make the parse failure return "no file"
+/// instead of dying, and `list` still exits non-zero — it just exits non-zero
+/// with the WRONG cause, sending the operator to run `base install` over a
+/// `base.toml` that is sitting right there with a typo in it. An exit code alone
+/// cannot tell those two apart, so the row pins the cause as well.
+const FAILING: &[(&str, Config, &[&str], &str)] = &[
+    // `list` reads the file, so all three bad states are failures for it.
+    ("list / unparseable", Config::Unparseable, &["config", "list"], "Failed to parse"),
+    ("list / unreadable", Config::Unreadable, &["config", "list"], "Cannot read"),
+    ("list / absent", Config::Absent, &["config", "list"], "base install"),
+    // `get` fails on a file it cannot use, and on a malformed key.
+    ("get / unparseable", Config::Unparseable, &["config", "get", "update.auto"], "Failed to parse"),
+    ("get / unreadable", Config::Unreadable, &["config", "get", "update.auto"], "Cannot read"),
+    ("get / malformed key", Config::Healthy, &["config", "get", "nodot"], "section.field"),
+    // `set` fails on all of those, plus the states only a write can reach.
+    ("set / unparseable", Config::Unparseable, &["config", "set", "update.auto", "true"], "Failed to parse"),
+    ("set / unreadable", Config::Unreadable, &["config", "set", "update.auto", "true"], "Cannot read"),
+    ("set / absent", Config::Absent, &["config", "set", "update.auto", "true"], "base install"),
+    ("set / malformed key", Config::Healthy, &["config", "set", "nodot", "true"], "section.field"),
+    ("set / section is not a table", Config::SectionIsScalar, &["config", "set", "update.auto", "true"], "not a table"),
+    ("set / read-only file", Config::ReadOnly, &["config", "set", "update.auto", "true"], "Failed to write"),
+];
+
+/// THE leg B test. Every branch that writes an error string exits non-zero, and
+/// the message names the cause it actually hit.
+#[test]
+fn exit_code_follows_the_message_on_every_failing_branch() {
+    let mut wrong = Vec::new();
+    for (name, state, args, expected) in FAILING {
+        let h = home_with(*state);
+        let (code, out, err) = run(h.path(), args);
+        if code == 0 {
+            wrong.push(format!(
+                "  {name}: rc 0\n    stderr: {}\n    stdout: {}",
+                err.trim(),
+                out.trim()
+            ));
+            continue;
+        }
+        // A non-zero code with nothing said is not the fix either: the operator
+        // has to be able to tell what went wrong.
+        if err.trim().is_empty() {
+            wrong.push(format!("  {name}: rc {code} but said NOTHING on stderr"));
+            continue;
+        }
+        // And it must not be a panic. A panic clears non-zero by accident, which
+        // is not the same as answering correctly.
+        if code == 101 || err.contains("panicked at") {
+            wrong.push(format!("  {name}: PANICKED (rc {code}) instead of reporting: {}", err.trim()));
+            continue;
+        }
+        // Right code, right channel, WRONG CAUSE is still a wrong answer.
+        if !err.contains(expected) {
+            wrong.push(format!(
+                "  {name}: rc {code} but the message names the wrong cause\n    wanted to see: {expected}\n    stderr: {}",
+                err.trim()
+            ));
+        }
+    }
+    assert!(
+        wrong.is_empty(),
+        "these branches do not report their failure correctly:\n{}",
+        wrong.join("\n")
+    );
+}
+
+/// The control, and without it the sweep above proves nothing: a `config` that
+/// always exited non-zero would pass every row and be useless.
+#[test]
+fn the_succeeding_branches_still_exit_zero() {
+    // list
+    let h = home_with(Config::Healthy);
+    let (code, out, err) = run(h.path(), &["config", "list"]);
+    assert_eq!(code, 0, "a readable config lists fine: {err}");
+    assert!(out.contains("update.auto"), "and really did list it: {out}");
+
+    // get, against a key the file sets
+    let h = home_with(Config::Healthy);
+    let (code, out, err) = run(h.path(), &["config", "get", "update.auto"]);
+    assert_eq!(code, 0, "{err}");
+    assert!(out.contains("false"), "the file's value is the one reported: {out}");
+
+    // set
+    let h = home_with(Config::Healthy);
+    let (code, out, err) = run(h.path(), &["config", "set", "update.auto", "true"]);
+    assert_eq!(code, 0, "{err}");
+    assert!(out.contains("Updated"), "{out}");
+    let after = std::fs::read_to_string(global_toml(h.path())).unwrap();
+    assert!(after.contains("auto = true"), "and the write actually landed: {after}");
+}
+
+// ─── The branches with consequences beyond the exit code ───────────────────
+
+/// The headline of leg B: `config set` must not report success over a write it
+/// did not make.
+///
+/// This branch was the worst of the twelve because it had no `return` AT ALL —
+/// it printed the error and fell through to `println!("Updated {key} = {new_val}")`.
+/// So `base config set update.auto false` against a read-only file told the
+/// operator, in as many words, that it had updated a setting it had not written.
+#[test]
+fn config_set_never_claims_success_over_a_write_it_did_not_make() {
+    let h = home_with(Config::ReadOnly);
+    let path = global_toml(h.path());
+    let before = std::fs::read(&path).unwrap();
+
+    let (code, out, err) = run(h.path(), &["config", "set", "update.auto", "true"]);
+
+    assert_ne!(code, 0, "a write that did not happen is not a success: {out} {err}");
+    assert!(
+        !out.contains("Updated"),
+        "it must not SAY it updated anything — this is the sentence that lied: {out}"
+    );
+    assert!(!err.trim().is_empty(), "and it has to say what went wrong: {err}");
+
+    let after = std::fs::read(&path).unwrap();
+    assert_eq!(before, after, "the file is byte-identical, as it must be");
+}
+
+/// `set` against an absent config refuses and NAMES THE REMEDY.
+///
+/// `base install` is what creates this file (`install::create_global_tier`), so
+/// absent means install never ran. Creating a bare one here would hand the
+/// operator a silently degraded config they would later read as theirs — the same
+/// class of harm as the silent default this whole lane removes. The wording
+/// mirrors `scaffold::register_workspace` rather than being a second spelling.
+#[test]
+fn set_against_an_absent_config_refuses_and_names_base_install() {
+    let h = home_with(Config::Absent);
+    let (code, _out, err) = run(h.path(), &["config", "set", "update.auto", "true"]);
+
+    assert_ne!(code, 0, "a discarded write is not a success");
+    assert!(
+        err.contains("base install"),
+        "a bare refusal leaves the operator stuck; name the fix: {err}"
+    );
+    assert!(
+        !global_toml(h.path()).exists(),
+        "and it must NOT have created the file it refused to write"
+    );
+}
+
+/// `list` against an absent config refuses too, and for a reason the old code had
+/// already half-decided: it printed "Cannot read base.toml at ..." and then exited
+/// 0 anyway. The message was right; the exit code contradicted it.
+#[test]
+fn list_against_an_absent_config_refuses_and_names_base_install() {
+    let h = home_with(Config::Absent);
+    let (code, _out, err) = run(h.path(), &["config", "list"]);
+
+    assert_ne!(code, 0, "there is no file to list");
+    assert!(err.contains("base install"), "name the fix: {err}");
+}
+
+/// The asymmetry between `get` and `set` on an ABSENT file is deliberate, and
+/// this test is what makes it a decision rather than an inconsistency.
+///
+/// Nearly every setting has a compiled-in default that is what the machine
+/// actually does, so a machine with no `base.toml` can still be asked what it
+/// will do. Reading a default is honest. Silently discarding a WRITE is not.
+#[test]
+fn get_against_an_absent_config_answers_from_the_default_and_exits_zero() {
+    let h = home_with(Config::Absent);
+    let (code, out, err) = run(h.path(), &["config", "get", "update.auto"]);
+
+    assert_eq!(code, 0, "absent is a read-state for get, not an error: {err}");
+    assert!(
+        out.contains("true") && out.contains("default"),
+        "it answers with the default, and says that is what it is: {out}"
+    );
+}
+
+/// N5. The `Config` arm used to `.expect()` on the home directory — a PANIC at
+/// rc 101 — for the same condition its 113 sibling call sites report through
+/// `die` at rc 1. One fault, two exit codes, depending on which command you ran.
+///
+/// WHAT THIS TEST CAN AND CANNOT PROVE, said plainly rather than overclaimed:
+/// the panic cannot be reached from a test binary at all. `home::home_root` is
+/// compiled with the `isolation-guard` feature under `cargo test`, and that build
+/// ends `let home = Some(test_root())` — it never returns `None`, by design, so no
+/// test process can drive that branch. So this pins it STRUCTURALLY: no `.expect(`
+/// survives in the arm, and the sweep above separately asserts that no failing
+/// branch answers with rc 101.
+#[test]
+fn the_config_arm_no_longer_panics_where_its_siblings_die() {
+    let cli = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs")).unwrap();
+    let start = cli
+        .find("Some(Commands::Config { action }) => {")
+        .expect("the Config arm");
+    let end = cli[start..]
+        .find("Some(Commands::Context {")
+        .expect("the arm after it")
+        + start;
+    let arm = &cli[start..end];
+
+    assert!(
+        !arm.contains(".expect("),
+        "the Config arm must report failures, not panic on them"
+    );
+    assert_eq!(
+        arm.matches("return;").count(),
+        0,
+        "a bare `return` from `run() -> ()` is a NORMAL exit — that is the whole defect"
+    );
+    assert!(
+        arm.contains("die("),
+        "and it uses the mechanism the rest of the file already uses"
+    );
+}

--- a/tests/config_fault_once_per_process_test.rs
+++ b/tests/config_fault_once_per_process_test.rs
@@ -1,0 +1,149 @@
+//! #158 leg A, the "once per process" half, proved end to end on the real binary.
+//!
+//! WHY THIS FILE EXISTS SEPARATELY, and it is the whole point of it.
+//!
+//! `src/config.rs` proves the latch by passing one in. That proves the LATCH and
+//! nothing else: it cannot show that production actually wires the process-global
+//! `Once`, because the test supplies its own. Moving the untested thing is not
+//! testing it.
+//!
+//! A `std::sync::Once` cannot be re-armed, and `cargo test` runs every test in one
+//! file inside ONE process, so whichever test reported first would decide the
+//! result for all the others. Each `tests/*.rs` is its own process and its own
+//! fresh `Once`, so this file gets the real latch, untouched, exactly once — which
+//! is why the claim lives here on its own rather than beside the other binary
+//! tests in `tests/config_fault_surface_test.rs`.
+//!
+//! THE VEHICLE. `base scaffold` loads the config TWICE in one process: once in
+//! `cli::run`, which every subcommand inherits, and again in `scaffold::run`. An
+//! unguarded report would therefore print twice, and the operator would be told
+//! the same thing about the same file twice in one command. The second assertion
+//! in this file pins that two-load shape, so the test cannot quietly degrade into
+//! proving nothing if a load site is ever removed.
+
+use std::path::Path;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_base");
+
+/// The consequence clause every fault carries, and the thing to count.
+const CONSEQUENCE: &str = "base is running on DEFAULT settings, not yours";
+
+/// Isolated fake home. `BASE_HOME` redirects `home::home_root`, which every
+/// `~`-rooted path in the crate resolves through, so the real
+/// `~/.base-gbl/base.toml` and `~/.claude/CLAUDE.md` are unreachable from here.
+fn isolated_home() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".base-gbl").join(".base")).unwrap();
+    tmp
+}
+
+fn run_scaffold(root: &Path, target: &Path) -> (i32, String, String) {
+    let out = Command::new(BIN)
+        .args(["scaffold", target.to_str().unwrap()])
+        .current_dir(root)
+        // Explicit environment: the isolation, and no network from a test.
+        .env("BASE_HOME", root)
+        .env("BASE_NO_AUTO_UPDATE", "1")
+        .output()
+        .expect("the base binary runs");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// One command, two config loads, ONE report.
+///
+/// Red without the latch: the same sentence about the same file, printed twice in
+/// one command. That is the shape that makes an operator stop reading warnings,
+/// which would waste the entire leg.
+#[test]
+fn one_command_that_loads_the_config_twice_reports_the_fault_once() {
+    let home = isolated_home();
+    let root = home.path();
+    std::fs::write(
+        root.join(".base-gbl").join("base.toml"),
+        "[update]\nauto = \n",
+    )
+    .unwrap();
+
+    let target = root.join("ws");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let (_code, _out, err) = run_scaffold(root, &target);
+
+    let times = err.matches(CONSEQUENCE).count();
+    assert!(
+        times > 0,
+        "precondition: the fault has to be reported at all, or this counts nothing.\nstderr: {err}"
+    );
+    assert_eq!(
+        times, 1,
+        "one process, one report — a command that loads the config twice must not \
+         say the same thing twice.\nstderr: {err}"
+    );
+}
+
+/// The control that keeps the test above honest.
+///
+/// `one_command_..._once` counts to one. If a future change removed the second
+/// load site, that count would still be one and the test would pass while proving
+/// nothing at all — it would no longer be measuring a latch, just a single call.
+/// So pin the two-load shape it depends on.
+#[test]
+fn the_command_under_test_really_does_load_the_config_more_than_once() {
+    let cli = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs")).unwrap();
+    let scaffold =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/scaffold.rs")).unwrap();
+
+    // Load 1: every subcommand inherits this one from `cli::run`.
+    let run_at = cli.find("pub fn run() {").expect("cli::run is the entry point");
+    let after_run = &cli[run_at..];
+    assert!(
+        after_run.contains("let config = BaseConfig::load(&cwd);"),
+        "cli::run loads the config for every subcommand — if this moved, \
+         the once-per-process test is measuring something else"
+    );
+
+    // Load 2: scaffold's own, inside the same process.
+    assert!(
+        scaffold.contains("BaseConfig::load(target)"),
+        "scaffold::run loads the config a second time in the same process"
+    );
+
+    // And `base scaffold` really is the command that reaches it.
+    assert!(
+        cli.contains("base::scaffold::run(&target)"),
+        "the Scaffold arm dispatches to scaffold::run"
+    );
+}
+
+/// The absent control, in this process too. A first run scaffolding a workspace
+/// is the single most common way anyone meets this code path, and it must be
+/// completely silent about config.
+#[test]
+fn scaffolding_with_no_config_at_all_reports_nothing() {
+    let home = isolated_home();
+    let root = home.path();
+    assert!(
+        !root.join(".base-gbl").join("base.toml").exists(),
+        "precondition: no config file anywhere"
+    );
+
+    let target = root.join("ws");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let (_code, out, err) = run_scaffold(root, &target);
+
+    assert_eq!(
+        err.matches(CONSEQUENCE).count(),
+        0,
+        "a first run is not a fault: {err}"
+    );
+    assert!(
+        !out.trim().is_empty(),
+        "precondition: scaffold really ran, so the silence means something"
+    );
+}

--- a/tests/config_fault_once_per_process_test.rs
+++ b/tests/config_fault_once_per_process_test.rs
@@ -20,6 +20,18 @@
 //! the same thing about the same file twice in one command. The second assertion
 //! in this file pins that two-load shape, so the test cannot quietly degrade into
 //! proving nothing if a load site is ever removed.
+//!
+//! ONE HARNESS TRAP THIS FILE CANNOT GUARD AGAINST ITSELF, named so the next
+//! reader does not lose an hour to it. `CARGO_BIN_EXE_base` can name a STALE
+//! binary: cargo builds the bin with one feature set for `cargo build` and
+//! another for `cargo test` (the self-dev-dependency turns on
+//! `isolation-guard`) and both uplift to the same `target/debug/base`, so
+//! running one after the other can leave that path holding the other build.
+//! Measured 2026-09-11 with an mtime NEWER than every source file, so an mtime
+//! check passes it. `cargo test --no-run` does not correct it; `cargo clean -p
+//! base` does. The tests below assert behaviour only the current code produces,
+//! so a stale binary shows up as a red here rather than a false green — but the
+//! red will blame the product, and the fix is `cargo clean -p base && cargo test`.
 
 use std::path::Path;
 use std::process::Command;

--- a/tests/config_fault_surface_test.rs
+++ b/tests/config_fault_surface_test.rs
@@ -1,0 +1,359 @@
+//! #158 leg A at the surface an operator actually sees: the shipped binary, its
+//! stderr, and its exit code.
+//!
+//! The unit tests in `src/config.rs` observe `BaseConfig::load_reporting`, which
+//! returns its faults as a value. No operator reads a return value. A fix that is
+//! green there and silent here has not fixed anything, so every claim leg A makes
+//! is re-proved below against the binary `cargo test` actually builds.
+//!
+//! ISOLATION. `BASE_HOME` points at a tempdir and the cwd sits inside it, so both
+//! config tiers and every `~`-rooted path resolve into the sandbox:
+//! `home::home_root` consults `BASE_HOME` before the OS, and
+//! `install::ensure_claude_md_current` — the one session-start step that writes a
+//! `CLAUDE.md` — resolves its home through that same function. Nothing here can
+//! reach the operator's real `~/.base-gbl/base.toml` or `~/.claude/CLAUDE.md`,
+//! which is the lane's first hard boundary.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+const BIN: &str = env!("CARGO_BIN_EXE_base");
+
+/// The fault text the product emits, as a consumer would grep for it.
+const CONSEQUENCE: &str = "DEFAULT settings, not yours";
+
+/// A fake home carrying a global tier and an operator profile.
+///
+/// The operator profile is not decoration. It makes `session-start` emit a block
+/// on stdout whose content does not depend on `base.toml` in any way, which is
+/// what gives the byte-identity test something real to compare. Two empty stdouts
+/// compare equal and prove nothing — that silent pass is the same shape as the
+/// bug, so `stdout_is_byte_identical_...` asserts the block is present as well.
+fn home() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join(".base-gbl").join(".base")).unwrap();
+    std::fs::create_dir_all(root.join(".base")).unwrap();
+    std::fs::write(
+        root.join(".base-gbl").join("operator.toml"),
+        "name = \"probe-158\"\nactive = true\nnorth_star = \"a config that never lies\"\n",
+    )
+    .unwrap();
+    tmp
+}
+
+fn global_toml(root: &Path) -> std::path::PathBuf {
+    root.join(".base-gbl").join("base.toml")
+}
+
+/// One invocation of the real binary, with an EXPLICIT environment.
+///
+/// `BASE_HOME` is the isolation. `BASE_NO_AUTO_UPDATE` keeps a test off the
+/// network; it is checked INSIDE `auto_update`, after the `update.auto` gate, so
+/// it cannot mask anything these tests measure.
+fn base(root: &Path) -> Command {
+    let mut c = Command::new(BIN);
+    c.current_dir(root)
+        .env("BASE_HOME", root)
+        .env("BASE_NO_AUTO_UPDATE", "1");
+    c
+}
+
+/// Exit code, stdout, stderr.
+fn run(root: &Path, args: &[&str]) -> (i32, String, String) {
+    let out = base(root).args(args).output().expect("the base binary runs");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// One hook event, driven the way Claude Code drives it: JSON on stdin.
+fn run_hook(root: &Path, event: &str, payload: &str) -> (i32, String, String) {
+    let mut child = base(root)
+        .args(["hook", event])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("the base binary runs");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(payload.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn session_start_payload(root: &Path) -> String {
+    serde_json::json!({
+        "session_id": "probe-158",
+        "cwd": root.display().to_string(),
+        "hook_event_name": "SessionStart",
+    })
+    .to_string()
+}
+
+// ─── The broken arm: the binary speaks ──────────────────────────────────────
+
+/// An ordinary command, not a hook. `cli::run` loads the config for every
+/// subcommand before it dispatches, so a broken file has to announce itself on
+/// the very first thing an operator types.
+///
+/// `hooks manifest` is the cheap one: it reaches that load, writes nothing to the
+/// graph, and its own output is a JSON object on stdout, so a fault on stderr
+/// cannot be confused with it.
+#[test]
+fn an_unparseable_config_reaches_stderr_of_an_ordinary_command() {
+    let h = home();
+    let root = h.path();
+    std::fs::write(global_toml(root), "[update]\nauto = \n").unwrap();
+
+    let (_code, _out, err) = run(root, &["hooks", "manifest"]);
+
+    assert!(
+        err.contains("cannot parse"),
+        "a file that will not parse has to say so: {err}"
+    );
+    assert!(
+        err.contains(&global_toml(root).display().to_string()),
+        "and name the file, or the operator cannot act on it: {err}"
+    );
+    assert!(
+        err.contains(CONSEQUENCE),
+        "and say what it cost them: {err}"
+    );
+}
+
+/// The same file, read by the hook that runs on every session start. This is the
+/// path #158's data loss travels, so it gets its own proof rather than inheriting
+/// the one above.
+#[test]
+fn an_unparseable_config_reaches_stderr_of_the_session_start_hook() {
+    let h = home();
+    let root = h.path();
+    std::fs::write(global_toml(root), "[update]\nauto = \n").unwrap();
+
+    let (code, _out, err) = run_hook(root, "session-start", &session_start_payload(root));
+
+    assert_eq!(code, 0, "hooks fail open and must keep doing so: {err}");
+    assert!(
+        err.contains("cannot parse") && err.contains(CONSEQUENCE),
+        "the session-start hook reports the fault on stderr: {err}"
+    );
+}
+
+// ─── The absent control: the binary stays quiet ─────────────────────────────
+
+/// The control. With no `base.toml` at all — a first run — the binary must say
+/// nothing about config on any channel. Without this arm, a "fix" that warned
+/// unconditionally would pass every test above.
+#[test]
+fn an_absent_config_says_nothing_on_the_real_binary() {
+    let h = home();
+    let root = h.path();
+    assert!(
+        !global_toml(root).exists(),
+        "precondition: this run has no config file at all"
+    );
+
+    let (_code, out, err) = run(root, &["hooks", "manifest"]);
+
+    assert!(
+        !err.contains(CONSEQUENCE),
+        "a first run is not a fault and must not be reported as one: {err}"
+    );
+    assert!(
+        !err.contains("cannot parse") && !err.contains("cannot read"),
+        "nothing to complain about: {err}"
+    );
+    assert!(
+        !out.trim().is_empty(),
+        "precondition: the command really ran and produced its manifest"
+    );
+}
+
+/// The other control: a good file is silent too, and the setting it carries is
+/// the one in force. Proved through the binary, on the channel that ships.
+#[test]
+fn a_healthy_config_says_nothing_on_the_real_binary() {
+    let h = home();
+    let root = h.path();
+    std::fs::write(global_toml(root), "[update]\nauto = false\n").unwrap();
+
+    let (_code, _out, err) = run(root, &["hooks", "manifest"]);
+
+    assert!(
+        !err.contains(CONSEQUENCE) && !err.contains("cannot parse"),
+        "a readable config has nothing to report: {err}"
+    );
+}
+
+// ─── DoD 18: the fault must not move one byte of a hook's stdout ────────────
+
+/// A hook's stdout is a parsed contract. `dispatch` documents the rule — "any
+/// error → stderr only, exit 0, empty stdout" — and on session-start the stdout
+/// IS the text injected into the model's context. A config warning that leaked
+/// into it would be a worse defect than the silence leg A removes.
+///
+/// The two arms compare ABSENT against BROKEN, not healthy against broken, and
+/// that choice is the whole point: both produce `BaseConfig::default()`, so the
+/// effective settings are identical and the only difference between the runs is
+/// whether a fault exists. Anything that moves in stdout is therefore the fault
+/// leaking, and nothing else.
+///
+/// Each arm gets its OWN fake home so both are first runs and neither inherits
+/// warm state from the other. The home path is then normalised out, because the
+/// two tempdirs have different names and every absolute path in the block would
+/// otherwise differ for a reason that has nothing to do with this test.
+#[test]
+fn a_hook_stdout_is_byte_identical_with_and_without_a_config_fault() {
+    let quiet = home();
+    let broken = home();
+    std::fs::write(global_toml(broken.path()), "[update]\nauto = \n").unwrap();
+
+    let (code_q, out_q, err_q) = run_hook(
+        quiet.path(),
+        "session-start",
+        &session_start_payload(quiet.path()),
+    );
+    let (code_b, out_b, err_b) = run_hook(
+        broken.path(),
+        "session-start",
+        &session_start_payload(broken.path()),
+    );
+
+    assert_eq!(code_q, 0, "hooks fail open: {err_q}");
+    assert_eq!(code_b, 0, "and a config fault must not change that: {err_b}");
+
+    let norm_q = out_q.replace(&quiet.path().display().to_string(), "<HOME>");
+    let norm_b = out_b.replace(&broken.path().display().to_string(), "<HOME>");
+
+    // Without this the test would pass over two empty strings and measure nothing,
+    // which is exactly the failure shape it exists to catch.
+    assert!(
+        norm_q.contains("<operator>"),
+        "precondition: session-start really did emit a stdout block to compare.\nstdout: {out_q}\nstderr: {err_q}"
+    );
+
+    assert_eq!(
+        norm_q, norm_b,
+        "a config fault must not add, remove or move ONE byte of hook stdout.\n\
+         stderr with the fault: {err_b}"
+    );
+
+    // And the run that had something to say did say it — on the other channel.
+    assert!(
+        err_b.contains(CONSEQUENCE),
+        "the broken arm has to have actually faulted, or this proved nothing: {err_b}"
+    );
+    assert!(
+        !err_q.contains(CONSEQUENCE),
+        "and the quiet arm has to have actually been quiet: {err_q}"
+    );
+}
+
+// ─── DoD 15: the pinned machine, on the shipped channel ────────────────────
+
+/// N3, the shipped claim. `config.rs` documents `base config set update.auto
+/// false` as the way to pin a machine; an unparseable file resets that to `true`
+/// and the machine silently resumes updating itself.
+///
+/// The pin is genuinely lost — a file that will not parse cannot say `false` —
+/// so what this proves is the second half of DoD 15: the fault is surfaced before
+/// `auto_update` can act. The ORDERING is structural and is pinned separately by
+/// `the_config_load_precedes_auto_update_in_the_hook_path`; what is measured here
+/// is that the operator is told at all, on the channel they can see.
+#[test]
+fn a_pinned_machine_that_loses_its_config_is_told_on_the_real_binary() {
+    let h = home();
+    let root = h.path();
+
+    // Pinned and readable: silent.
+    std::fs::write(global_toml(root), "[update]\nauto = false\n").unwrap();
+    let (_, _, err_pinned) = run_hook(root, "session-start", &session_start_payload(root));
+    assert!(
+        !err_pinned.contains(CONSEQUENCE),
+        "precondition: a working pin reports nothing: {err_pinned}"
+    );
+
+    // The file stops parsing. The pin is lost; the silence must not be.
+    std::fs::write(global_toml(root), "[update]\nauto = false\n[[[ broken\n").unwrap();
+    let (code, _, err_broken) = run_hook(root, "session-start", &session_start_payload(root));
+
+    assert_eq!(code, 0, "still fails open: {err_broken}");
+    assert!(
+        err_broken.contains(CONSEQUENCE) && err_broken.contains("cannot parse"),
+        "the machine just un-pinned itself and the operator has to hear about it: {err_broken}"
+    );
+}
+
+/// The ordering DoD 15 depends on, pinned in the source rather than observed.
+///
+/// It cannot honestly be observed: stdout is block-buffered when piped and stderr
+/// is not, so interleaving two streams from one child proves nothing about the
+/// order the writes were issued in. Reading the structure is the sound
+/// instrument, and `tests/hook_output_channel_test.rs` already uses it in this
+/// tree, so this is the established mechanism and not a new one.
+///
+/// What it pins: `run_event` loads the config — and therefore reports — before it
+/// dispatches to any handler, and `auto_update` is reached only from inside
+/// `session_start::handle`, which is one of those handlers.
+#[test]
+fn the_config_load_precedes_auto_update_in_the_hook_path() {
+    let hook_mod =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/hook/mod.rs")).unwrap();
+    let session_start = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/hook/session_start.rs"
+    ))
+    .unwrap();
+
+    let run_event = hook_mod
+        .find("fn run_event(")
+        .expect("run_event is where a hook decides anything");
+    let body = &hook_mod[run_event..];
+
+    let load_at = body
+        .find("BaseConfig::load(")
+        .expect("run_event loads the config");
+    let dispatch_at = body
+        .find("match event {")
+        .expect("run_event dispatches on the event");
+    assert!(
+        load_at < dispatch_at,
+        "the config is loaded, and any fault reported, BEFORE any handler runs"
+    );
+
+    let handler_at = body
+        .find("session_start::handle(")
+        .expect("session-start reaches its handler");
+    assert!(
+        load_at < handler_at,
+        "and specifically before session_start::handle"
+    );
+
+    // `auto_update` lives behind that handler, so the report necessarily precedes it.
+    assert!(
+        session_start.contains("auto_update(config)"),
+        "auto_update is still called from session_start::handle"
+    );
+    let handle_at = session_start
+        .find("pub fn handle(")
+        .expect("handle is the entry point");
+    let auto_at = session_start
+        .find("auto_update(config)")
+        .expect("auto_update call site");
+    assert!(
+        handle_at < auto_at,
+        "auto_update runs inside handle, which runs after the load"
+    );
+}

--- a/tests/config_fault_surface_test.rs
+++ b/tests/config_fault_surface_test.rs
@@ -13,6 +13,18 @@
 //! `CLAUDE.md` — resolves its home through that same function. Nothing here can
 //! reach the operator's real `~/.base-gbl/base.toml` or `~/.claude/CLAUDE.md`,
 //! which is the lane's first hard boundary.
+//!
+//! ONE HARNESS TRAP THIS FILE CANNOT GUARD AGAINST ITSELF, named so the next
+//! reader does not lose an hour to it. `CARGO_BIN_EXE_base` can name a STALE
+//! binary: cargo builds the bin with one feature set for `cargo build` and
+//! another for `cargo test` (the self-dev-dependency turns on
+//! `isolation-guard`) and both uplift to the same `target/debug/base`, so
+//! running one after the other can leave that path holding the other build.
+//! Measured 2026-09-11 with an mtime NEWER than every source file, so an mtime
+//! check passes it. `cargo test --no-run` does not correct it; `cargo clean -p
+//! base` does. The tests below assert behaviour only the current code produces,
+//! so a stale binary shows up as a red here rather than a false green — but the
+//! red will blame the product, and the fix is `cargo clean -p base && cargo test`.
 
 use std::io::Write;
 use std::path::Path;

--- a/tests/update_release_request_test.rs
+++ b/tests/update_release_request_test.rs
@@ -114,19 +114,19 @@ fn ok_release_response() -> ureq::Response {
 
 /// A 403 that is out of API budget. `x-ratelimit-remaining: 0` is the only thing
 /// that distinguishes this from a plain refusal.
-fn rate_limited_403() -> ureq::Error {
+fn rate_limited_403() -> Box<ureq::Error> {
     let resp: ureq::Response = "HTTP/1.1 403 Forbidden\r\nx-ratelimit-remaining: 0\r\n\r\n"
         .parse()
         .expect("canned 403 parses");
-    ureq::Error::Status(403, resp)
+    Box::new(ureq::Error::Status(403, resp))
 }
 
 /// A 403 with budget to spare: a real refusal, not a rate limit.
-fn plain_403() -> ureq::Error {
+fn plain_403() -> Box<ureq::Error> {
     let resp: ureq::Response = "HTTP/1.1 403 Forbidden\r\nx-ratelimit-remaining: 4999\r\n\r\n"
         .parse()
         .expect("canned 403 parses");
-    ureq::Error::Status(403, resp)
+    Box::new(ureq::Error::Status(403, resp))
 }
 
 /// A genuine `ureq` transport failure.
@@ -137,7 +137,7 @@ fn plain_403() -> ureq::Error {
 /// `parse_url()?` before it constructs a `Unit` or calls `unit::connect`, and a
 /// URL with no host fails that parse. ureq's own `disallow_empty_host` test
 /// asserts this same call yields `ErrorKind::InvalidUrl`.
-fn transport_failure() -> ureq::Error {
+fn transport_failure() -> Box<ureq::Error> {
     let err = ureq::get("file:///some/path")
         .call()
         .expect_err("a url with no host cannot succeed");
@@ -145,14 +145,14 @@ fn transport_failure() -> ureq::Error {
         matches!(err, ureq::Error::Transport(_)),
         "expected a transport failure, got {err:?}"
     );
-    err
+    Box::new(err)
 }
 
 /// Drive the product and collect the `authorization` header off every request it
 /// actually built, in order.
 fn auth_headers_seen<F>(answer: F) -> (Vec<Option<String>>, anyhow::Result<(String, String)>)
 where
-    F: Fn(usize) -> std::result::Result<ureq::Response, ureq::Error>,
+    F: Fn(usize) -> std::result::Result<ureq::Response, Box<ureq::Error>>,
 {
     let seen: RefCell<Vec<Option<String>>> = RefCell::new(Vec::new());
     let out = fetch_latest_release(|req| {
@@ -168,14 +168,21 @@ where
 
 // ── D-2: the token reaches the request the product builds ──────────────────
 
+/// The `authorization`, `user-agent` and `accept` headers read off one request
+/// the product built, in that order.
+///
+/// Named rather than written inline because `clippy::type_complexity` is right:
+/// `RefCell<Vec<(Option<String>, Option<String>, Option<String>)>>` says nothing
+/// about what the three slots hold, and the asserts below index them by number.
+type HeadersSeen = (Option<String>, Option<String>, Option<String>);
+
 #[test]
 fn token_in_the_environment_reaches_the_request_the_updater_builds() {
     let _lock = env_lock();
     let env = TokenEnv::cleared();
     env.set("GITHUB_TOKEN", "gho_shrike_github_token");
 
-    let seen: RefCell<Vec<(Option<String>, Option<String>, Option<String>)>> =
-        RefCell::new(Vec::new());
+    let seen: RefCell<Vec<HeadersSeen>> = RefCell::new(Vec::new());
     let out = fetch_latest_release(|req| {
         seen.borrow_mut().push((
             req.header("authorization").map(str::to_string),
@@ -344,7 +351,7 @@ fn a_status_that_is_not_403_names_the_status() {
         let resp: ureq::Response = "HTTP/1.1 500 Internal Server Error\r\n\r\n"
             .parse()
             .expect("canned 500 parses");
-        Err(ureq::Error::Status(500, resp))
+        Err(Box::new(ureq::Error::Status(500, resp)))
     })
     .expect_err("500 is not a release");
     let msg = err.to_string();

--- a/tests/update_release_request_test.rs
+++ b/tests/update_release_request_test.rs
@@ -1,0 +1,444 @@
+//! #158 leg D: `base update` sends a token the operator already has, and a 403
+//! that is a rate limit says so instead of blaming the network.
+//!
+//! ── WHY THIS FILE IS SHAPED THE WAY IT IS ──
+//!
+//! `GITHUB_TOKEN` and `GH_TOKEN` are ALREADY in the shipped binary, twice each,
+//! from `src/plugin/dist.rs`. A `strings` or `git grep` detector for this leg
+//! therefore passes on a tree where this leg does not exist. Nothing in this file
+//! greps for a token name, and nothing here would pass before the change.
+//!
+//! The grading criterion, from `tanager`: a test must observe the request THE
+//! PRODUCT CONSTRUCTS on its real code path, not one the test built by calling a
+//! helper. Calling a header-building helper and inspecting what it handed back is
+//! still a helper test, and the wiring gap survives it untouched.
+//!
+//! So `fetch_latest_release` takes its transport as a parameter. Production
+//! passes `|req| req.call()`. Every test here passes a closure that captures the
+//! `ureq::Request` the product itself just built, asserts on that object, and
+//! answers it from memory. No test in this file opens a socket.
+//!
+//! ── THE HOLE A SEAM TEST LEAVES, AND HOW IT IS CLOSED ──
+//!
+//! A seam proves the header is right and that the builder gets called. It cannot
+//! prove production still routes through the builder, and a delegating one-liner
+//! is exactly the kind of thing a later refactor drops. `auk` ruled that closed
+//! by construction rather than by another test: there is exactly ONE place in
+//! `src/update/mod.rs` that builds a release-API request, so there is nowhere
+//! else for a second request to come from. `the_release_request_has_exactly_one_
+//! construction_site` is that guard.
+//!
+//! That guard counts over CODE lines, with comment lines stripped first. A
+//! whole-file count would also match this module's own prose, so it could read 3
+//! on a correct tree and 1 on a broken one — worse than no guard at all.
+//!
+//! ── THE MUTATION THAT SETTLES IT ──
+//!
+//! Strip the `authorization` wiring out of `fetch_latest_release`, rebuild cold,
+//! and the three token tests below must go RED. If they stay green they are
+//! reading a helper rather than the product, and leg D is not done however green
+//! it looks.
+//!
+//! ── ISOLATION ──
+//!
+//! `GITHUB_TOKEN` and `GH_TOKEN` are process-global and every test here runs in
+//! one binary, so the tests that touch them take `ENV_LOCK` first and put the
+//! variables back afterwards — including restoring "was not set at all", which is
+//! a different state from "was set to empty".
+//!
+//! Nothing here reads or writes a file, a home directory, or a config. The
+//! update path resolves its token from two environment variables and nothing
+//! else, so there is no other state for a test to reach or to have to isolate.
+
+use std::cell::RefCell;
+use std::sync::{Mutex, MutexGuard};
+
+use base::update::{asset_name, fetch_latest_release};
+
+/// `std::env::set_var` changes the whole process. Without this lock two tests in
+/// this binary would read each other's environment, and the failure would look
+/// like a bug in the code under test rather than in the harness.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn env_lock() -> MutexGuard<'static, ()> {
+    // A panicking test must not poison the lock for every test after it: that
+    // turns one real failure into a screenful of unrelated ones.
+    ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Both token variables, cleared for the duration of a test and put back exactly
+/// as they were when it ends.
+struct TokenEnv {
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl TokenEnv {
+    fn cleared() -> Self {
+        let saved: Vec<(&'static str, Option<String>)> = ["GITHUB_TOKEN", "GH_TOKEN"]
+            .iter()
+            .map(|k| (*k, std::env::var(k).ok()))
+            .collect();
+        for (k, _) in &saved {
+            unsafe { std::env::remove_var(k) };
+        }
+        Self { saved }
+    }
+
+    fn set(&self, key: &str, value: &str) {
+        unsafe { std::env::set_var(key, value) };
+    }
+}
+
+impl Drop for TokenEnv {
+    fn drop(&mut self) {
+        for (k, v) in &self.saved {
+            match v {
+                Some(val) => unsafe { std::env::set_var(k, val) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+    }
+}
+
+/// A releases-API answer the real parser can read: a tag, and an asset named for
+/// whatever platform this test is running on.
+fn ok_release_response() -> ureq::Response {
+    let asset = asset_name().expect("this platform has a published asset name");
+    let body = format!(
+        r#"{{"tag_name":"v9.9.9","assets":[{{"name":"{asset}","browser_download_url":"https://example.invalid/{asset}"}}]}}"#
+    );
+    format!("HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n{body}")
+        .parse()
+        .expect("canned 200 parses")
+}
+
+/// A 403 that is out of API budget. `x-ratelimit-remaining: 0` is the only thing
+/// that distinguishes this from a plain refusal.
+fn rate_limited_403() -> ureq::Error {
+    let resp: ureq::Response = "HTTP/1.1 403 Forbidden\r\nx-ratelimit-remaining: 0\r\n\r\n"
+        .parse()
+        .expect("canned 403 parses");
+    ureq::Error::Status(403, resp)
+}
+
+/// A 403 with budget to spare: a real refusal, not a rate limit.
+fn plain_403() -> ureq::Error {
+    let resp: ureq::Response = "HTTP/1.1 403 Forbidden\r\nx-ratelimit-remaining: 4999\r\n\r\n"
+        .parse()
+        .expect("canned 403 parses");
+    ureq::Error::Status(403, resp)
+}
+
+/// A genuine `ureq` transport failure.
+///
+/// `ureq::Error::Transport` cannot be constructed from outside ureq —
+/// `ErrorKind::msg` and `ErrorKind::new` are both `pub(crate)` in 2.12.1 — so
+/// this raises a real one instead. It opens no socket: `Request::call` runs
+/// `parse_url()?` before it constructs a `Unit` or calls `unit::connect`, and a
+/// URL with no host fails that parse. ureq's own `disallow_empty_host` test
+/// asserts this same call yields `ErrorKind::InvalidUrl`.
+fn transport_failure() -> ureq::Error {
+    let err = ureq::get("file:///some/path")
+        .call()
+        .expect_err("a url with no host cannot succeed");
+    assert!(
+        matches!(err, ureq::Error::Transport(_)),
+        "expected a transport failure, got {err:?}"
+    );
+    err
+}
+
+/// Drive the product and collect the `authorization` header off every request it
+/// actually built, in order.
+fn auth_headers_seen<F>(answer: F) -> (Vec<Option<String>>, anyhow::Result<(String, String)>)
+where
+    F: Fn(usize) -> std::result::Result<ureq::Response, ureq::Error>,
+{
+    let seen: RefCell<Vec<Option<String>>> = RefCell::new(Vec::new());
+    let out = fetch_latest_release(|req| {
+        let n = {
+            let mut s = seen.borrow_mut();
+            s.push(req.header("authorization").map(str::to_string));
+            s.len()
+        };
+        answer(n)
+    });
+    (seen.into_inner(), out)
+}
+
+// ── D-2: the token reaches the request the product builds ──────────────────
+
+#[test]
+fn token_in_the_environment_reaches_the_request_the_updater_builds() {
+    let _lock = env_lock();
+    let env = TokenEnv::cleared();
+    env.set("GITHUB_TOKEN", "gho_shrike_github_token");
+
+    let seen: RefCell<Vec<(Option<String>, Option<String>, Option<String>)>> =
+        RefCell::new(Vec::new());
+    let out = fetch_latest_release(|req| {
+        seen.borrow_mut().push((
+            req.header("authorization").map(str::to_string),
+            req.header("user-agent").map(str::to_string),
+            req.header("accept").map(str::to_string),
+        ));
+        Ok(ok_release_response())
+    });
+
+    let calls = seen.into_inner();
+    assert_eq!(calls.len(), 1, "the healthy path must send exactly one request");
+    assert_eq!(
+        calls[0].0.as_deref(),
+        Some("Bearer gho_shrike_github_token"),
+        "the request the updater built carried no Authorization header"
+    );
+    // HEALTHY control: the headers that were already right must survive the change.
+    assert_eq!(calls[0].1.as_deref(), Some("base-cli-updater"), "user-agent was lost");
+    assert_eq!(
+        calls[0].2.as_deref(),
+        Some("application/vnd.github+json"),
+        "accept was lost"
+    );
+    assert_eq!(out.expect("canned 200 parses into a release").0, "9.9.9");
+}
+
+#[test]
+fn gh_token_is_read_when_github_token_is_not_set() {
+    let _lock = env_lock();
+    let env = TokenEnv::cleared();
+    env.set("GH_TOKEN", "gho_shrike_gh_token");
+
+    let (calls, out) = auth_headers_seen(|_| Ok(ok_release_response()));
+
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0].as_deref(),
+        Some("Bearer gho_shrike_gh_token"),
+        "GH_TOKEN was not read when GITHUB_TOKEN was absent"
+    );
+    assert!(out.is_ok());
+}
+
+#[test]
+fn github_token_wins_when_both_are_set() {
+    let _lock = env_lock();
+    let env = TokenEnv::cleared();
+    env.set("GITHUB_TOKEN", "gho_first");
+    env.set("GH_TOKEN", "gho_second");
+
+    let (calls, _) = auth_headers_seen(|_| Ok(ok_release_response()));
+
+    assert_eq!(
+        calls[0].as_deref(),
+        Some("Bearer gho_first"),
+        "resolution order must be GITHUB_TOKEN then GH_TOKEN"
+    );
+}
+
+/// ABSENT control. Without it the suite could not tell "sends the token" from
+/// "sends an Authorization header no matter what".
+#[test]
+fn no_token_in_the_environment_sends_no_authorization_header() {
+    let _lock = env_lock();
+    let _env = TokenEnv::cleared();
+
+    let (calls, out) = auth_headers_seen(|_| Ok(ok_release_response()));
+
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0], None,
+        "an anonymous check must send no Authorization header at all"
+    );
+    assert!(out.is_ok(), "the anonymous path must still work");
+}
+
+/// An empty variable is not a token. Exporting `GITHUB_TOKEN=` is a common way to
+/// mean "no token", and sending `Bearer ` would turn a working anonymous check
+/// into a 401.
+#[test]
+fn an_empty_token_variable_is_treated_as_no_token() {
+    let _lock = env_lock();
+    let env = TokenEnv::cleared();
+    env.set("GITHUB_TOKEN", "");
+
+    let (calls, _) = auth_headers_seen(|_| Ok(ok_release_response()));
+
+    assert_eq!(calls[0], None, "an empty GITHUB_TOKEN must not become a Bearer header");
+}
+
+// ── DoD 17: `base update` spawns no subprocess on the common path ──────────
+
+/// One request per check, whatever the outcome.
+///
+/// `base update` runs from `hook/session_start.rs` on EVERY session start, so
+/// anything per-check is paid on every session. A retry is the shape that would
+/// reintroduce a second request and, with it, the temptation to reach for a
+/// token source that shells out. Counting requests pins that shut: the update
+/// path resolves its token from two environment variables, which cannot spawn
+/// anything, and it asks once.
+#[test]
+fn every_outcome_sends_exactly_one_request() {
+    let _lock = env_lock();
+    let _env = TokenEnv::cleared();
+
+    let (healthy, out) = auth_headers_seen(|_| Ok(ok_release_response()));
+    assert_eq!(healthy.len(), 1, "a healthy check made {} requests", healthy.len());
+    assert!(out.is_ok());
+
+    let (limited, err) = auth_headers_seen(|_| Err(rate_limited_403()));
+    assert_eq!(
+        limited.len(),
+        1,
+        "a rate-limited check made {} requests; there is no retry on this path",
+        limited.len()
+    );
+    assert!(err.is_err());
+}
+
+// ── D-1: a 403 says what actually happened ─────────────────────────────────
+
+#[test]
+fn a_rate_limited_403_says_rate_limit_and_does_not_blame_the_network() {
+    let _lock = env_lock();
+    let env = TokenEnv::cleared();
+    // A token is present, so the rate limit is terminal: there is nothing wider
+    // left to consult and no retry to confuse the message being measured.
+    env.set("GITHUB_TOKEN", "gho_already_using_a_token");
+
+    let err = fetch_latest_release(|_req| Err(rate_limited_403()))
+        .expect_err("a 403 cannot yield a release");
+    let msg = err.to_string();
+
+    assert!(msg.contains("rate limit"), "a 403 rate limit did not say rate limit: {msg}");
+    assert!(
+        !msg.contains("could not reach"),
+        "a 403 rate limit still blamed the network: {msg}"
+    );
+    assert!(
+        msg.contains("GITHUB_TOKEN") || msg.contains("GH_TOKEN"),
+        "the message names no way out of the rate limit: {msg}"
+    );
+}
+
+#[test]
+fn a_403_that_is_not_a_rate_limit_says_forbidden_rather_than_rate_limit() {
+    let _lock = env_lock();
+    let env = TokenEnv::cleared();
+    env.set("GITHUB_TOKEN", "gho_token");
+
+    let err = fetch_latest_release(|_req| Err(plain_403())).expect_err("403 is not a release");
+    let msg = err.to_string();
+
+    assert!(msg.contains("403") || msg.contains("forbidden"), "unclear 403 message: {msg}");
+    assert!(!msg.contains("rate limit"), "a plain 403 was reported as a rate limit: {msg}");
+    assert!(!msg.contains("could not reach"), "a plain 403 blamed the network: {msg}");
+}
+
+#[test]
+fn a_status_that_is_not_403_names_the_status() {
+    let _lock = env_lock();
+    let env = TokenEnv::cleared();
+    env.set("GITHUB_TOKEN", "gho_token");
+
+    let err = fetch_latest_release(|_req| {
+        let resp: ureq::Response = "HTTP/1.1 500 Internal Server Error\r\n\r\n"
+            .parse()
+            .expect("canned 500 parses");
+        Err(ureq::Error::Status(500, resp))
+    })
+    .expect_err("500 is not a release");
+    let msg = err.to_string();
+
+    assert!(msg.contains("500"), "a 500 did not name its status: {msg}");
+    assert!(!msg.contains("rate limit"), "a 500 was reported as a rate limit: {msg}");
+}
+
+/// HEALTHY control for the sentence that was there before. "could not reach the
+/// GitHub releases API" is true of a transport failure and of nothing else, so it
+/// has to survive this change for exactly that case.
+#[test]
+fn a_transport_failure_still_says_could_not_reach() {
+    let _lock = env_lock();
+    let env = TokenEnv::cleared();
+    env.set("GITHUB_TOKEN", "gho_token");
+
+    let err =
+        fetch_latest_release(|_req| Err(transport_failure())).expect_err("no response, no release");
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("could not reach the GitHub releases API"),
+        "a transport failure lost the only message that is true of it: {msg}"
+    );
+    assert!(!msg.contains("rate limit"), "a transport failure claimed a rate limit: {msg}");
+}
+
+/// The case the user actually hits: no token set, rate limit reached.
+///
+/// This is the whole reason the message matters. An operator with no token, on a
+/// shared or busy IP, gets refused — and the old sentence told them their network
+/// was down. The new one tells them what is true and what fixes it.
+#[test]
+fn a_rate_limit_with_no_token_set_reports_the_rate_limit_and_points_at_the_fix() {
+    let _lock = env_lock();
+    let _env = TokenEnv::cleared();
+
+    let (calls, out) = auth_headers_seen(|_| Err(rate_limited_403()));
+
+    assert_eq!(calls.len(), 1, "one check, one request");
+    assert_eq!(calls[0], None, "no token was set, so the request must be anonymous");
+
+    let msg = out.expect_err("a rate limit is not a release").to_string();
+    assert!(msg.contains("rate limit"), "the rate limit was not reported: {msg}");
+    assert!(!msg.contains("could not reach"), "it still blamed the network: {msg}");
+    assert!(
+        msg.contains("GITHUB_TOKEN") || msg.contains("GH_TOKEN"),
+        "the operator is not told what would fix it: {msg}"
+    );
+}
+
+// ── The guard that makes a second request impossible ───────────────────────
+
+/// There must be exactly ONE place in `src/update/mod.rs` that builds a
+/// release-API request.
+///
+/// This is the only structural assertion in the file, and it earns its place:
+/// the seam tests above prove the header is built correctly and that production
+/// calls the builder, but they cannot prove production has not grown a SECOND
+/// request that skips it. With one construction site that question cannot arise,
+/// because there is nowhere else to build one.
+///
+/// It counts occurrences rather than presence, which is what makes it safe here.
+/// A presence check on a token name would pass today on a tree with no leg D at
+/// all, because `GITHUB_TOKEN` and `GH_TOKEN` already appear in the binary from
+/// `src/plugin/dist.rs`. A uniqueness check on a symbol that exists in exactly
+/// one module cannot pass by accident.
+///
+/// Comment lines are stripped before counting. The module header and the
+/// constant's own doc comment discuss this request in prose, so a whole-file
+/// count would mix the author's writing in with the code and could read 3 on a
+/// correct tree.
+#[test]
+fn the_release_request_has_exactly_one_construction_site() {
+    let src = include_str!("../src/update/mod.rs");
+    let code_only: String = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let sites = code_only.matches("ureq::get(LATEST_RELEASE_API)").count();
+    assert_eq!(
+        sites, 1,
+        "expected exactly 1 release-API request construction site in code, found {sites}. \
+         More than one means production can build a request that skips the Authorization \
+         wiring; zero means the request moved and this guard no longer measures anything."
+    );
+
+    // The guard must be measuring code, not prose. If stripping comments removed
+    // every occurrence, the count above would be meaningless.
+    assert!(
+        code_only.contains("fn fetch_latest_release"),
+        "comment stripping removed the code region this guard is supposed to scan"
+    );
+}


### PR DESCRIPTION
### All four legs, and what each one was

#158 is one defect wearing four faces: **the tool acted, reported success, and the operator
could not tell that anything had gone wrong.** Each leg is that shape on a different surface.

- **Leg A** — a `base.toml` that cannot be read was silently replaced by defaults.
- **Leg B** — a config command that failed still exited `0`.
- **Leg C** — `workspace sync` erased the registry and printed `✓ synced 0 workspace(s)`.
- **Leg D** — `base update` sent no token it already had, and reported a rate-limit **403** as
  *"could not reach the GitHub releases API"*, sending the operator to check a working network.

Leg 1 is separately out of scope: it was fixed at `0e743307`, and what the reporter needs is
0.13.3 or newer — a reply on the issue rather than a code change.

### Leg D — `base update` sends a token it already has, and a 403 says what it is

`fetch_latest_release` now takes its **transport as a parameter**. Production passes
`|req| req.call()`; a test passes a closure that reads the `ureq::Request` **the product
itself built**, with no socket opened anywhere. The request is constructed in exactly one
place, and a test counts those construction sites to keep it that way.

- `GITHUB_TOKEN`, then `GH_TOKEN`, read from the environment and sent as an `Authorization`
  header. Nothing else is read: no `.env` file, no `gh` subprocess. The update check runs on
  **every session start**, so a subprocess here would be one spawn per session — and on a
  machine with no `gh`, one *failed* spawn per session, forever, to learn nothing.
- An exported-but-empty variable is treated as **no token**, not as a bare `Bearer `. An empty
  `GITHUB_TOKEN` is common in CI, and a malformed credential earns a 401 where sending nothing
  would have been served anonymously.
- A 403 carrying `x-ratelimit-remaining: 0` now says **rate limit** and names the fix. A bare
  403 says forbidden. Any other status names the status. A transport failure still says
  **could not reach** — the two failures stay distinguishable, which is the half a careless
  fix breaks.
- The token can only ever reach `api.github.com`: the URL is a hardcoded constant with no
  setting and no environment override. **That is deliberate.** There is no signature check and
  no checksum check in the download path, so the constant is the only thing vouching for what
  gets installed, and making it overridable would turn a redirected update into arbitrary code
  execution. Refusing the override is precisely what makes sending a token safe.
- The module header claimed *"The only request is an anonymous GET"*. Leg D makes that false,
  and it is corrected in the same commit.

### Leg A — the failure is reported instead of swallowed

`BaseConfig::load` no longer hands back `BaseConfig::default()` after a read or parse failure
without saying so. `absent`, `empty` and `unreadable` had all collapsed into one `None` inside
`load_toml_table` via two different `.ok()` calls, so the three states were not even
distinguishable to report.

On an unparseable global config the CLI now writes to **stderr**:

```
base: cannot parse <path> (TOML parse error at line N, column M
   …
) -- base is running on DEFAULT settings, not yours
```

On `main` the same config produced **0 bytes and rc 0**.

### Leg B — a config command that fails exits non-zero

| command | `main` | this branch |
|---|---|---|
| `base config list` | 0 | **1** |
| `base config get` | 0 | **1** |
| `base config set` | 0 | **1** |

The exit code is the whole of what moved on this leg: `config set` already printed no success
line and already left the file unchanged on `main`, so a leg testing only file corruption
would have closed leg B falsely.

### Leg C — `workspace sync` refuses rather than erasing the registry

**This is the data-loss leg.** `registered_workspace_paths()` returned `Vec<String>` and
answered *no home*, *no file*, *unreadable file* and *unparseable file* all with an empty vec.
That empty vec reached `build_workspace_block`, which wrote `- (none registered)` over the
operator's real registrations in `~/.claude/CLAUDE.md`.

It is now a three-state `RegistryRead` — `Paths` / `Absent` / `Fault` — and a `Fault` refuses
the write:

```
Failed: refusing to rewrite <…>/.claude/CLAUDE.md: cannot parse <…>/.base-gbl/base.toml
(TOML parse error …). The registered-workspaces block is generated from that file, so
rewriting it now would replace your registrations with '(none registered)'.
```

`workspace sync` exits **1** and writes **zero bytes to stdout**.

### Why the earlier fix was not enough, and this is the point of the leg

After legs A and B alone, an unparseable config produced **all three of these at once**:

- stderr, 293 bytes: *"base is running on DEFAULT settings, not yours"*
- stdout, 51 bytes: `✓ synced 0 workspace(s) into ~/.claude/CLAUDE.md`
- the file on disk: registrations **3 → 0**, `- (none registered)` written in

`synced 0 workspace(s)` reads as *there were none*, not as *I have just deleted your three*.
A reader who sees the warning and the green check together concludes the sync was a no-op.
Leg A had made the data loss **louder but not safer**.

### `scaffold` no longer reports success over a refusal

`base scaffold` is the command the reporter actually ran, so a refusal it reports as success
leaves the filed surface still broken.

| config state | before | now |
|---|---|---|
| unparseable | rc 0 | **rc 1** |
| unreadable | rc 0 | **rc 1** |
| healthy | rc 0 | rc 0 |

Both steps also terminate their own stdout line, so a reader of stdout alone never sees a step
begin and never finish:

```
step 4b, unparseable:  ↳ sync CLAUDE.md registry ... REFUSED — see stderr
step 4,  unreadable:   4. Register workspace ... FAILED — see stderr
```

Before this, step 4b's line ran straight into `5. Sync domains to graph`, and on the unreadable
path stdout ended mid-line at 381 bytes with no trailing newline at all.

### A count is not a loss — `RegistrySync`

No condition asked for this, and it is what actually cures the misleading message on the
**legitimate** removal path, not only on the refusal path. `sync_claude_md_registry` now
returns `RegistrySync { written, previous }` and the message names what it removed.

Measured on all three branches, with the shrunken `base.toml` asserted to **still parse** each
time so the legitimate path was not silently re-testing the refusal path:

| case | before | now |
|---|---|---|
| 3 → 1 registered | `✓ synced 1 workspace(s)` | `✓ ~/.claude/CLAUDE.md now lists 1 workspace(s) — REMOVED 2 that ~/.base-gbl/base.toml no longer registers (it listed 3 before)` |
| 3 → 0 registered | `✓ synced 0 workspace(s)` | `✓ … now lists 0 workspace(s) — REMOVED 3 … (it listed 3 before)` |
| 3 → 3, nothing removed | `✓ synced 3 workspace(s)` | `✓ synced 3 workspace(s)` |

The last row is the negative control: when nothing was removed the message does not cry wolf,
and both arms agree.

### Validation

Graded independently by `tanager` against conditions written and timestamped **before** any
builder green, on binaries built cold by the validator from clean worktrees with the previous
artifact deleted first.

- **C-1 … C-10: PASS.** Full record: `verification/base-0.15.2-tanager/conditions-rank-00-158.md`.
- **Leg D: D-1 … D-5 PASS.** Full record:
  `verification/base-0.15.2-tanager/conditions-legd-187534ae.md`. Graded against criteria
  written and pinged to the orchestrator **before the builder pushed**, with the per-test
  predictions fixed before either mutation arm ran.
- **Leg D's two mutation arms both went RED with their controls GREEN**, which is what a
  passing suite on its own cannot show. Strip the `Authorization` wiring out of
  `fetch_latest_release`, leaving the token helper defined and perfect, and three token tests
  fail with `left: None` — read off the request the product built. A test reading a helper's
  return value would have stayed green. Revert the error call site to the flat context, leaving
  the describer defined and perfect, and four message tests fail with
  `unclear 403 message: could not reach the GitHub releases API` — the original defect walking
  back in. **No mutation of either function's body could have shown that production reaches
  it.**
- **Leg D measured against the product, not only in tests:** `base update` driven with five
  token states — unset, `GITHUB_TOKEN`, `GH_TOKEN`, both, and exported-empty — against an
  unreachable API inside a private mount namespace. Every state still reported *could not
  reach*, none was relabelled a rate limit, and all five were **byte-identical**, so an empty
  variable behaves exactly like an unset one in the shipped binary and not merely in a unit
  test. The connect-failure message also lost a duplicated `Connection refused (os error 111)`
  tail it had been printing twice, and kept the URL.
- The leg C fixture is minted **by `base` itself** and asserted a **byte fixed point** under a
  healthy sync. Without that, the byte-compare reports `CHANGED` on every cell including the
  healthy ones and the condition cannot fail.
- **Positive control:** the loss reproduces on `main` **and** on the legs-A+B commit, in the
  same run, from the identical fixture.
- **Live-writer control:** healthy `scaffold` takes registrations 3 → 4, proving the write path
  is live — so 3 → 3 on the broken arm is a deliberate refusal, not a broken writer.
- **Both halves of the exit-code fix proven load-bearing** by mutation: reverting only
  `scaffold::run`'s `Err` return, or only the `cli.rs` arm, each alone returns rc to 0. Each
  mutation carried a post-condition before building — old text absent, new text present once,
  the other site untouched — so a mutation that failed to mutate could not pass as a guard that
  cannot fire.
- Every cell ran cold and warm with identical results. Four real operator files were md5-guarded
  on both filesystems in every run and were unchanged every time.

### Logged, not gated

On the unreadable path the stderr summary line reads `Scaffold failed: Permission denied (os
error 13)` and names no file. The line above it does name the `base.toml`, so the information
is present. Recorded rather than fixed, to keep this row from widening.

### Commits

```
187534ae  #158 leg D: base update sends a token it already has, and a 403 rate limit says so
9b55fb1b  fix(scaffold): #158 C-10 — step 4 terminates its own stdout line when it aborts
852b45d2  fix(scaffold): #158 C-8 and C-9 — scaffold must not report success over a refusal
5b463f2   fix(scaffold): leg C of #158 — workspace sync refuses rather than erasing the registry
20928c9   fix(config): leg B of #158 — a config command that fails now exits non-zero
0c72c47   test(config): prove leg A of #158, on the channel an operator actually reads
e592f61   fix(config): report a base.toml that cannot be read instead of silently defaulting
```

Ten files, `+2826 −82`.

Closes #158.