### PR TITLE
The prompt-time walk: five ranked rows, one seam

### DIFF
--- a/src/domain/query.rs
+++ b/src/domain/query.rs
@@ -340,9 +340,12 @@ pub fn context_pull(config: &BaseConfig, cwd: &Path, text: &str) {
     let graph_store = crate::store::load_merged(cwd);
 
     let matched = domain::matcher::match_domains(text, &domains, &[], &domain::matcher::TriggerContext::default());
-    if matched.is_empty() {
-        return;
-    }
+    // NO EARLY RETURN on an empty match. The walk below resolves what the TEXT names,
+    // which has nothing to do with whether a domain trigger fired, and returning here
+    // made `base context` dead on any machine without an always-on domain -- the same
+    // shape as `N-WALK-DEAD-WITHOUT-A-MATCHED-DOMAIN` in the prompt hook. The loop over
+    // `matched` below is simply a no-op when it is empty, and the store was already
+    // parsed above, so nothing extra is paid to reach here.
 
     let base_dir = crate::config::find_workspace_base(cwd);
     let mut session = base_dir
@@ -350,13 +353,22 @@ pub fn context_pull(config: &BaseConfig, cwd: &Path, text: &str) {
         .map(SessionState::load)
         .unwrap_or_default();
     let mut session_dirty = false;
+    // Every record IRI the domain blocks serve on this call. The walk dedups against it.
+    let mut domain_served: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for dm in &matched {
         let domain_def = dm.domain;
 
         let (rules_text, neighborhood_text) = match &graph_store {
             Some(store) => {
-                let (r, n, _served) = query_domain_from_graph(store, config, domain_def);
+                // The served list is COLLECTED, not discarded. Without it the walk below
+                // reprints, four lines later and under a `<base-context>` heading, a
+                // record the domain block just printed -- which the prompt hook
+                // deliberately does not do, and this command claims to be the same
+                // engine. Records dedup; a served ROOT still walks and is never listed as
+                // its own record (the binding 0.14.2 ruling).
+                let (r, n, served) = query_domain_from_graph(store, config, domain_def);
+                domain_served.extend(served);
                 (r, n)
             }
             None => (format_toml_rules(domain_def), String::new()),
@@ -398,6 +410,22 @@ pub fn context_pull(config: &BaseConfig, cwd: &Path, text: &str) {
             };
             session.mark_injected(&domain_def.name, combined_hash);
             session_dirty = true;
+        }
+    }
+
+    // ─── The walk, after the domain blocks, exactly as the hook orders them ───
+    //
+    // NO session dedup, in either direction. This is a preview, not a session: a
+    // `walk:<id>` key marked here would silently suppress the hook's block on the
+    // operator's NEXT REAL PROMPT, which is the failure the hook's own comment about the
+    // byte budget was written to avoid. Repeated calls therefore give the same answer.
+    //
+    // Lean mode does not apply -- there is no prompt count on this path.
+    if let Some(store) = &graph_store {
+        let walked = crate::hook::walk::walk_from_text(store, cwd, config, text, &domain_served);
+        let (block, _dropped) = crate::hook::walk::render(&walked, config.injection.walk_budget);
+        if !block.is_empty() {
+            print!("{block}");
         }
     }
 

--- a/src/hook/user_prompt_submit.rs
+++ b/src/hook/user_prompt_submit.rs
@@ -121,28 +121,52 @@ pub fn handle(config: &BaseConfig, cwd: &Path, event: &serde_json::Value) -> Res
         // always-on domain. Same shape, and the same fix, as the early return
         // `base context` used to take in `domain::query`.
         //
-        // THE WALK BLOCK ONLY. The `<context-bracket>` line and the bracket
-        // rules stay skipped on this path. Serving them here costs 2931 bytes
-        // at FRESH and 3696 at DEPLETED against 125 for the walk, and the walk
-        // is scoped "query based, surgical, relevant" -- so their absence is a
-        // separate question, tracked as N-BRACKET-DEAD-WITHOUT-A-MATCHED-DOMAIN
-        // and deliberately not answered here.
+        // AND N-BRACKET-DEAD-WITHOUT-A-MATCHED-DOMAIN, the same early return
+        // costing the same users a second feature. The bracket line and its
+        // rules are tier-gated, never domain-gated: they are re-sent every
+        // prompt precisely because they are the layer that must not erode as
+        // context fills, which a once-per-session injection cannot guarantee.
+        // Skipping them here made them erode fastest for the user with the
+        // fewest domains -- and on an install whose domains are all
+        // `mode = "triggered"`, erode to nothing.
+        //
+        // `prompt_count_for(session_id)`, NOT the raw `session.prompt_count`.
+        // Of the four return sites in this function this was the only one
+        // reaching for the raw counter, and the main path below prints the
+        // per-session number -- so the raw one would show a user two different
+        // prompt numbers depending on whether a domain happened to match, each
+        // inflated by every concurrent session sharing the workspace.
+        //
+        // The returned `HookEventData` keeps `session.prompt_count` unchanged.
+        // That field feeds the JSONL log rather than the prompt, it has always
+        // carried that number here, and whether it should is a separate
+        // question from what the reader sees.
+        //
+        // Built as one string and printed once, like the main path below. Two
+        // `print!` calls would do the same thing, but a literal ending in a
+        // newline trips clippy's `print_with_newline` under `-D warnings`.
         //
         // Nothing to dedup against: `domain_served` is filled by the domain
         // loop below, which an empty `matched` makes a no-op.
         //
-        // No lean-mode gate either. `lean_mode` needs `prompt_num`, computed
-        // below this return -- and the walk on the main path is not gated on
-        // it either, so gating here would be the one place in the hook where
+        // No lean-mode gate either. `lean_mode` needs the prompt number
+        // computed below this return -- and the walk on the main path is not
+        // gated on it, so gating here would be the one place in the hook where
         // the walk still consulted it.
+        let nomatch_prompt_num = session.prompt_count_for(session_id);
+        let mut out = format!(
+            "<context-bracket>[{bracket}] (prompt {nomatch_prompt_num})</context-bracket>\n\n"
+        );
+        out.push_str(&bracket_rules);
         if let Some(ref store) = graph_store {
             let nothing_served = std::collections::HashSet::new();
             let walked =
                 crate::hook::walk::walk_from_text(store, cwd, config, &prompt, &nothing_served);
             // Dedup, render and mark as one unit -- see `render_walk_block`.
             let w = render_walk_block(&mut session, walked, config.injection.walk_budget);
-            print!("{}", w.block);
+            out.push_str(&w.block);
         }
+        print!("{out}");
         // Still save session state (prompt_count) even if nothing matched.
         // AFTER the walk, so the marks it just wrote are in what gets saved --
         // otherwise dedup resets every prompt and the walk re-serves forever.

--- a/src/hook/user_prompt_submit.rs
+++ b/src/hook/user_prompt_submit.rs
@@ -131,10 +131,10 @@ pub fn handle(config: &BaseConfig, cwd: &Path, event: &serde_json::Value) -> Res
         // Nothing to dedup against: `domain_served` is filled by the domain
         // loop below, which an empty `matched` makes a no-op.
         //
-        // No lean-mode gate either: `lean_mode` needs `prompt_num`, computed
-        // below this return, and the next commit removes the walk's lean gate
-        // on the main path. Adding one here would be building what that commit
-        // deletes.
+        // No lean-mode gate either. `lean_mode` needs `prompt_num`, computed
+        // below this return -- and the walk on the main path is not gated on
+        // it either, so gating here would be the one place in the hook where
+        // the walk still consulted it.
         if let Some(ref store) = graph_store {
             let nothing_served = std::collections::HashSet::new();
             let walked =
@@ -332,22 +332,31 @@ pub fn handle(config: &BaseConfig, cwd: &Path, event: &serde_json::Value) -> Res
 
     // ─── Prompt-time traversal ───────────────────────────────────────────
     // AFTER the domain loop, not before: it dedups against the IRIs those
-    // blocks served, and it cannot do that before they have run. Skipped in
-    // lean mode with the neighbourhood, for the same reason.
+    // blocks served, and it cannot do that before they have run.
+    //
+    // NOT gated on lean mode, deliberately. The flag it used to sit behind was
+    // introduced by fb1cd48 (2026-06-01) for the NEIGHBOURHOOD, three months
+    // before this walk existed -- `git show fb1cd48:src/hook/user_prompt_submit.rs`
+    // contains no walk at all. 29ff99a (2026-09-07) then hung the walk on the
+    // same flag without the question being asked, so there was never a design
+    // intent here to preserve.
+    //
+    // And the saving was not real. Skipping the injection does not reduce what
+    // the session consumes, it moves the cost and makes it larger: the session
+    // then spends more than the block's bytes running recall, greps and file
+    // reads to find by hand what the block would have handed it. An injection is
+    // cheaper than the search it replaces. Prompts 1 and 2 are usually where
+    // someone starts work, which is where that signal is worth most.
+    //
+    // The NEIGHBOURHOOD skip above still honours lean mode. That is what the
+    // flag was built for and it is untouched.
     //
     // The maps, the closures and the reasons for both now live in
     // `walk::walk_from_text`, which `base context` calls as well. One seam, so the
     // command and the prompt path cannot answer differently about the same graph.
-    let walked = match (&graph_store, lean_mode) {
-        (Some(store), false) => Some(crate::hook::walk::walk_from_text(
-            store,
-            cwd,
-            config,
-            &prompt,
-            &domain_served,
-        )),
-        _ => None,
-    };
+    let walked = graph_store.as_ref().map(|store| {
+        crate::hook::walk::walk_from_text(store, cwd, config, &prompt, &domain_served)
+    });
 
     // The walk's block rides after the domain blocks, so a reader sees the
     // configured layer first and the named-thing layer as the specific addition.

--- a/src/hook/user_prompt_submit.rs
+++ b/src/hook/user_prompt_submit.rs
@@ -113,7 +113,39 @@ pub fn handle(config: &BaseConfig, cwd: &Path, event: &serde_json::Value) -> Res
     };
     let matched = match_domains_auto(&prompt, &domains, &active_paths, &trigger_ctx);
     if matched.is_empty() {
-        // Still save session state (prompt_count) even if nothing matched
+        // N-WALK-DEAD-WITHOUT-A-MATCHED-DOMAIN. The walk resolves what the
+        // PROMPT TEXT names, which has nothing to do with whether a domain
+        // trigger fired. Returning here without running it left every machine
+        // whose domains are all `mode = "triggered"` with no prompt-time
+        // traversal at all -- the headline claim dead on any install with no
+        // always-on domain. Same shape, and the same fix, as the early return
+        // `base context` used to take in `domain::query`.
+        //
+        // THE WALK BLOCK ONLY. The `<context-bracket>` line and the bracket
+        // rules stay skipped on this path. Serving them here costs 2931 bytes
+        // at FRESH and 3696 at DEPLETED against 125 for the walk, and the walk
+        // is scoped "query based, surgical, relevant" -- so their absence is a
+        // separate question, tracked as N-BRACKET-DEAD-WITHOUT-A-MATCHED-DOMAIN
+        // and deliberately not answered here.
+        //
+        // Nothing to dedup against: `domain_served` is filled by the domain
+        // loop below, which an empty `matched` makes a no-op.
+        //
+        // No lean-mode gate either: `lean_mode` needs `prompt_num`, computed
+        // below this return, and the next commit removes the walk's lean gate
+        // on the main path. Adding one here would be building what that commit
+        // deletes.
+        if let Some(ref store) = graph_store {
+            let nothing_served = std::collections::HashSet::new();
+            let walked =
+                crate::hook::walk::walk_from_text(store, cwd, config, &prompt, &nothing_served);
+            // Dedup, render and mark as one unit -- see `render_walk_block`.
+            let w = render_walk_block(&mut session, walked, config.injection.walk_budget);
+            print!("{}", w.block);
+        }
+        // Still save session state (prompt_count) even if nothing matched.
+        // AFTER the walk, so the marks it just wrote are in what gets saved --
+        // otherwise dedup resets every prompt and the walk re-serves forever.
         if let Some(ref base_dir) = base_dir {
             let _ = session.save(base_dir);
         }
@@ -321,48 +353,19 @@ pub fn handle(config: &BaseConfig, cwd: &Path, event: &serde_json::Value) -> Res
     // configured layer first and the named-thing layer as the specific addition.
     let mut walk_note = String::new();
     if let Some(walked) = walked {
-        // Once per session per node, not once per prompt. Naming the same
-        // project in five consecutive prompts is one context, not five: the
-        // domain layer above has always worked this way and the record layer
-        // has no reason to be noisier. Keyed on the resolved IRI rather than the
-        // spelling, so "First Client Kit" and "first-client-kit" are one entry.
-        let mut fresh: Vec<(crate::hook::walk::Resolved, Vec<crate::hook::walk::Record>)> = Vec::new();
-        let mut walk_deduped = 0usize;
-        for (r, recs) in walked {
-            let key = format!("walk:{}", r.id);
-            let h = crate::domain::session::rules_hash(std::slice::from_ref(&r.id));
-            if session.is_injected(&key, h) {
-                walk_deduped += 1;
-                continue;
-            }
-            // NOT marked here. Marking before the render means a name whose
-            // records are all cut by the byte budget is recorded as injected and
-            // never shown again this session -- the budget quietly becoming a
-            // permanent suppression, which looks exactly like dedup working.
-            // Marked below, against what actually rendered.
-            fresh.push((r, recs));
+        // Dedup, render and mark as one unit -- see `render_walk_block`. The
+        // no-match return above is the other caller, and it needs all three for
+        // the same reasons this path does.
+        let w = render_walk_block(&mut session, walked, config.injection.walk_budget);
+        if config.devmode.enabled && w.deduped > 0 {
+            walk_note.push_str(&format!("  walk: {} name(s) already injected this session\n", w.deduped));
         }
-        let walked = fresh;
-        if config.devmode.enabled && walk_deduped > 0 {
-            walk_note.push_str(&format!("  walk: {walk_deduped} name(s) already injected this session\n"));
-        }
-        let walked = &walked;
-        let (block, dropped) = crate::hook::walk::render(walked, config.injection.walk_budget);
-        if !block.is_empty() {
-            output.push_str(&block);
+        if !w.block.is_empty() {
+            output.push_str(&w.block);
             injected_any = true;
         }
-        // Mark only what the reader actually got. A name the budget squeezed out
-        // entirely was not served, so it must be free to come back next prompt.
-        for (r, _) in walked {
-            if block.contains(&format!("name=\"{}\"", r.name)) {
-                let key = format!("walk:{}", r.id);
-                session
-                    .mark_injected(&key, crate::domain::session::rules_hash(std::slice::from_ref(&r.id)));
-            }
-        }
         if config.devmode.enabled {
-            for (r, recs) in walked {
+            for (r, recs) in &w.served {
                 walk_note.push_str(&format!(
                     "  walk: {} → {} ({}) {} hop(s), {} record(s){}\n",
                     r.name,
@@ -373,8 +376,8 @@ pub fn handle(config: &BaseConfig, cwd: &Path, event: &serde_json::Value) -> Res
                     if r.ties > 1 { format!(", {} same-kind ties", r.ties) } else { String::new() },
                 ));
             }
-            if dropped > 0 {
-                walk_note.push_str(&format!("  walk: {dropped} record(s) dropped by walk_budget\n"));
+            if w.dropped > 0 {
+                walk_note.push_str(&format!("  walk: {} record(s) dropped by walk_budget\n", w.dropped));
             }
         }
     }
@@ -466,6 +469,68 @@ pub fn handle(config: &BaseConfig, cwd: &Path, event: &serde_json::Value) -> Res
         session_id: None, // populated by run() after handle returns
         ..Default::default()
     })
+}
+
+/// The walk's three steps as one unit: dedup against what this session already
+/// served, render under the byte budget, then mark only what the reader
+/// actually got.
+///
+/// They are a unit because splitting them produces a defect in one of two
+/// directions, and a single-prompt test sees neither. Drop the dedup and a name
+/// resolved once is re-served on every following prompt. Mark before the render
+/// rather than after, and a name whose records were all cut by the budget is
+/// recorded as injected and never shown again this session -- the budget
+/// quietly becoming a permanent suppression, which looks exactly like dedup
+/// working.
+///
+/// Two callers, both in `handle`: the no-match early return and the main path
+/// below it. `domain::query::context_pull` is deliberately not a third -- it
+/// has no session, so it has nothing to dedup against and nothing to mark.
+struct WalkBlock {
+    /// The rendered block. Empty when nothing survived dedup or the budget.
+    block: String,
+    /// How many names dedup dropped, for the devmode note.
+    deduped: usize,
+    /// How many records the budget dropped, for the devmode note.
+    dropped: usize,
+    /// What survived dedup, in render order, for the devmode per-name lines.
+    served: Vec<(crate::hook::walk::Resolved, Vec<crate::hook::walk::Record>)>,
+}
+
+fn render_walk_block(
+    session: &mut SessionState,
+    walked: Vec<(crate::hook::walk::Resolved, Vec<crate::hook::walk::Record>)>,
+    budget: usize,
+) -> WalkBlock {
+    // Once per session per node, not once per prompt. Naming the same project
+    // in five consecutive prompts is one context, not five: the domain layer
+    // has always worked this way and the record layer has no reason to be
+    // noisier. Keyed on the resolved IRI rather than the spelling, so
+    // "First Client Kit" and "first-client-kit" are one entry.
+    let mut served: Vec<(crate::hook::walk::Resolved, Vec<crate::hook::walk::Record>)> = Vec::new();
+    let mut deduped = 0usize;
+    for (r, recs) in walked {
+        let key = format!("walk:{}", r.id);
+        let h = crate::domain::session::rules_hash(std::slice::from_ref(&r.id));
+        if session.is_injected(&key, h) {
+            deduped += 1;
+            continue;
+        }
+        // NOT marked here -- see the doc comment above. Marked below, against
+        // what actually rendered.
+        served.push((r, recs));
+    }
+    let (block, dropped) = crate::hook::walk::render(&served, budget);
+    // Mark only what the reader actually got. A name the budget squeezed out
+    // entirely was not served, so it must be free to come back next prompt.
+    for (r, _) in &served {
+        if block.contains(&format!("name=\"{}\"", r.name)) {
+            let key = format!("walk:{}", r.id);
+            session
+                .mark_injected(&key, crate::domain::session::rules_hash(std::slice::from_ref(&r.id)));
+        }
+    }
+    WalkBlock { block, deduped, dropped, served }
 }
 
 // ─── DEVMODE output ─────────────────────────────────────────

--- a/src/hook/user_prompt_submit.rs
+++ b/src/hook/user_prompt_submit.rs
@@ -303,47 +303,17 @@ pub fn handle(config: &BaseConfig, cwd: &Path, event: &serde_json::Value) -> Res
     // blocks served, and it cannot do that before they have run. Skipped in
     // lean mode with the neighbourhood, for the same reason.
     //
-    // `maps_from_store` and not `graph_query::load_graph`: the store is already
-    // parsed above, and load_graph would parse it a second time AND read the
-    // workspace graph only, so this layer would disagree with the domain layer
-    // beside it about what the graph contains.
-    //
-    // include_ast = false. The CLI passes true because `base graph neighbors`
-    // is expected to walk into call graphs; this walk resolves projects,
-    // decisions, people and documents, and parsing a 23.6 MB AST sidecar on
-    // every prompt to serve none of it is the kind of cost nobody sees.
+    // The maps, the closures and the reasons for both now live in
+    // `walk::walk_from_text`, which `base context` calls as well. One seam, so the
+    // command and the prompt path cannot answer differently about the same graph.
     let walked = match (&graph_store, lean_mode) {
-        (Some(store), false) => crate::graph_query::maps_from_store(store, cwd, &config.namespace, false)
-            .ok()
-            .map(|maps| {
-                crate::hook::walk::walk(
-                    &maps,
-                    &config.namespace,
-                    &prompt,
-                    &domain_served,
-                    // One list, every reader (ruling 4): the same seam the graph
-                    // commands, recall, the domain block and the dashboard consult.
-                    // A substring test stood here until PR #50 landed (kite F4).
-                    &|id: &str| crate::ontology::transient::is_transient_iri(&config.namespace, id),
-                    // The drift fork's fill. `None` means the record still stands;
-                    // `Some(head)` is the record that replaced it, so the walk
-                    // re-anchors rather than dropping the edge that reached it.
-                    //
-                    // `store` is the one `load_merged` already parsed above — the
-                    // whole reason this closure takes it rather than calling
-                    // `load_graph`. A load here would be a second full parse on
-                    // every prompt, and `store::GRAPH_LOADS` would catch it as a
-                    // red test rather than as a session that got quietly slower.
-                    //
-                    // `graph_query` ids carry angle brackets and `resolve_head`
-                    // walks bare IRIs, so the brackets come off and go back on.
-                    &|id: &str| {
-                        let bare = id.trim_start_matches('<').trim_end_matches('>');
-                        let head = crate::supersede::resolve_head(store, &config.namespace, bare);
-                        (head != bare).then(|| format!("<{head}>"))
-                    },
-                )
-            }),
+        (Some(store), false) => Some(crate::hook::walk::walk_from_text(
+            store,
+            cwd,
+            config,
+            &prompt,
+            &domain_served,
+        )),
         _ => None,
     };
 

--- a/src/hook/walk.rs
+++ b/src/hook/walk.rs
@@ -61,6 +61,29 @@ fn hops_for(kind: &str) -> usize {
     if matches!(kind, "project" | "domain") { 2 } else { 1 }
 }
 
+/// Does this token look like a slug rather than an ordinary word?
+///
+/// A slug carries a separator: `-` or `_`, which is what `crud::slugify` emits, or a `.`
+/// sitting BETWEEN two alphanumerics, which is how a filename reads.
+///
+/// The dot has to be fenced that way. The word split in `candidates` keeps `.` inside a
+/// token, so a sentence-final `base.` arrives with its full stop attached; an unfenced
+/// test would call that slug-shaped and re-open the exact case the single-word rule
+/// exists to close.
+fn is_slug_shaped(s: &str) -> bool {
+    if s.contains('-') || s.contains('_') {
+        return true;
+    }
+    let c: Vec<char> = s.chars().collect();
+    c.iter().enumerate().any(|(i, ch)| {
+        *ch == '.'
+            && i > 0
+            && i + 1 < c.len()
+            && c[i - 1].is_alphanumeric()
+            && c[i + 1].is_alphanumeric()
+    })
+}
+
 /// Candidate spans from a prompt: longest match wins, per start position.
 ///
 /// `known` answers "is this a name the graph has?". Without it there is nothing
@@ -127,7 +150,23 @@ pub fn candidates(prompt: &str, known: &dyn Fn(&str) -> bool) -> Vec<String> {
             let span = words[i..i + n].join(" ");
             // The single-word rule. Quoted / backticked / path-shaped words were
             // already taken above and do not come through here.
-            if n == 1 && span.chars().next().is_some_and(char::is_lowercase) {
+            //
+            // A SLUG-SHAPED token is exempt from it. `renda-group` is not a word: it is
+            // what `base domain list` and `base project list` print, and it is what a
+            // user types back at us. The rule was written for `base` mid-sentence and
+            // caught the slug as collateral, so at 0.15.0 `Renda-Group` resolved and
+            // `renda-group` did not -- the only difference being the case of the first
+            // letter, which nothing documents and no user would guess.
+            //
+            // The exemption is still gated by `known()` immediately below, so a
+            // hyphenated English word the graph has never heard of stays a word. That
+            // gate is not decoration: without it every `well-known` and `state-of-the-art`
+            // in every prompt would buy a `resolve_strict` scan over the whole node map,
+            // on a path that runs on every prompt.
+            if n == 1
+                && span.chars().next().is_some_and(char::is_lowercase)
+                && !is_slug_shaped(&span)
+            {
                 continue;
             }
             if known(&span) {
@@ -673,5 +712,79 @@ mod tests {
     #[test]
     fn an_empty_walk_renders_nothing() {
         assert_eq!(render(&[], 1000).0, "");
+    }
+
+    // ─── Gap A: a slug is not a bare lowercase word ──────────────────────
+
+    /// The four acceptance rows, at the level the cut happens.
+    #[test]
+    fn a_lowercase_slug_survives_the_candidate_cut_when_the_graph_has_it() {
+        for spelling in ["renda-group", "renda_group"] {
+            let n = names(&format!("status of {spelling} today"), &[spelling]);
+            assert!(
+                n.contains(&spelling.to_string()),
+                "{spelling:?} was dropped by the single-word rule: {n:?}"
+            );
+        }
+    }
+
+    /// The gate that keeps the exemption honest. A hyphenated English word the graph
+    /// does not have must not become a candidate.
+    #[test]
+    fn a_slug_shaped_word_the_graph_lacks_is_not_a_name() {
+        assert!(names("a well-known issue arrived", &["renda-group"]).is_empty());
+    }
+
+    /// The rule the exemption must NOT weaken.
+    #[test]
+    fn a_bare_lowercase_word_is_still_not_a_name() {
+        assert!(!names("what did we decide about base", &["base"]).contains(&"base".to_string()));
+    }
+
+    /// `Renda-Group` already resolved at 0.15.0 and must keep resolving. This is the
+    /// blindness control: it passes before and after, so it discriminates nothing about
+    /// the fix and everything about a regression.
+    #[test]
+    fn an_uppercase_slug_still_resolves() {
+        assert!(names("Renda-Group today", &["Renda-Group"]).contains(&"Renda-Group".to_string()));
+    }
+
+    #[test]
+    fn is_slug_shaped_fences_the_dot_between_alphanumerics() {
+        assert!(is_slug_shaped("renda-group"));
+        assert!(is_slug_shaped("renda_group"));
+        assert!(is_slug_shaped("walk.rs"), "a filename is an explicit reference");
+        assert!(!is_slug_shaped("base"));
+        assert!(!is_slug_shaped("base."), "a sentence-final stop is not a separator");
+        assert!(!is_slug_shaped(".base"), "a leading dot is not a separator");
+        assert!(!is_slug_shaped(""));
+    }
+
+    /// End to end through `walk`, because the sentence-final case depends on the REAL
+    /// `known` closure: `index.contains(&slugify(span))` absorbs the trailing stop, and
+    /// `push` then trims it. The unit-test `idx` helper does not slugify, so this case
+    /// cannot be proved at `candidates` level without testing a different function.
+    #[test]
+    fn a_slug_at_the_end_of_a_sentence_resolves_through_the_real_index() {
+        let id = format!("<{}project/renda-group>", ns().uri);
+        let mut nodes: HashMap<String, Node> = HashMap::new();
+        put(&mut nodes, &id, "Renda Group");
+        put(&mut nodes, "<x/decision/d1>", "pick postgres");
+        let mut adj: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        adj.insert(id.clone(), vec![("<x/decision/d1>".into(), "belongsTo".into())]);
+        let maps = (nodes, adj);
+
+        for spelling in ["renda-group", "we shipped renda-group.", "status of renda-group today"] {
+            let out = walk(&maps, &ns(), spelling, &HashSet::new(), &no, &live);
+            assert_eq!(out.len(), 1, "{spelling:?} resolved to {} things", out.len());
+            assert_eq!(out[0].0.id, id, "{spelling:?}");
+        }
+
+        // And the control: a slug-shaped word with no record behind it resolves to
+        // nothing, so the exemption cannot fabricate a block.
+        assert!(
+            walk(&maps, &ns(), "a well-known issue", &HashSet::new(), &no, &live).is_empty(),
+            "a slug-shaped English word fabricated a resolution"
+        );
     }
 }

--- a/src/hook/walk.rs
+++ b/src/hook/walk.rs
@@ -15,8 +15,9 @@
 //! prompt, so it is hash lookups over maps the hook already built.
 
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
-use crate::config::NamespaceConfig;
+use crate::config::{BaseConfig, NamespaceConfig};
 use crate::graph_query::{iri_kind, GraphMaps, Node};
 
 /// A name the prompt used, and what it resolved to.
@@ -313,6 +314,52 @@ pub fn walk(
         ));
     }
     out
+}
+
+/// Build the maps and the two seam closures, then walk. The one place either caller
+/// does this, so the prompt hook and `base context` cannot drift apart -- and drift in
+/// exactly this seam is what produced `N-WALK-DEAD-WITHOUT-A-MATCHED-DOMAIN`.
+///
+/// `maps_from_store` and not `graph_query::load_graph`: the caller has already parsed a
+/// store, and `load_graph` would parse it a SECOND time AND read the workspace graph
+/// only, so this layer would disagree with the domain layer beside it about what the
+/// graph contains.
+///
+/// `include_ast = false`. The CLI passes true because `base graph neighbors` is expected
+/// to walk into call graphs; this walk resolves projects, decisions, people and
+/// documents, and parsing a 23.6 MB AST sidecar to serve none of it is the kind of cost
+/// nobody sees.
+///
+/// A store that will not project returns NO names rather than an error: this is an
+/// injection layer, and a prompt that fails to gain context must still be a prompt.
+pub fn walk_from_text(
+    store: &oxigraph::store::Store,
+    cwd: &Path,
+    config: &BaseConfig,
+    text: &str,
+    already_served: &HashSet<String>,
+) -> Vec<(Resolved, Vec<Record>)> {
+    let Ok(maps) = crate::graph_query::maps_from_store(store, cwd, &config.namespace, false) else {
+        return Vec::new();
+    };
+    walk(
+        &maps,
+        &config.namespace,
+        text,
+        already_served,
+        // One list, every reader (ruling 4): the same seam the graph commands, recall,
+        // the domain block and the dashboard consult.
+        &|id: &str| crate::ontology::transient::is_transient_iri(&config.namespace, id),
+        // `None` means the record still stands; `Some(head)` is what replaced it, so the
+        // walk re-anchors rather than dropping the edge that reached it. `graph_query`
+        // ids carry angle brackets and `resolve_head` walks bare IRIs, so the brackets
+        // come off and go back on.
+        &|id: &str| {
+            let bare = id.trim_start_matches('<').trim_end_matches('>');
+            let head = crate::supersede::resolve_head(store, &config.namespace, bare);
+            (head != bare).then(|| format!("<{head}>"))
+        },
+    )
 }
 
 fn label_of(nodes: &HashMap<String, Node>, id: &str) -> String {

--- a/tests/prove_context_walk.sh
+++ b/tests/prove_context_walk.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# b3_hermetic.sh — acceptance leg B3, on a FROZEN input. This is the gate.
+# Becomes tests/prove_context_walk.sh (granted by auk 2026-09-10).
+#
+# THE CLAIM: `base context <text>` and the prompt hook, same binary, store, budget and
+# text, emit the SAME SET of walk record lines. That is the help string's "same engine as
+# hook injection" promise turned into something that can fail.
+#
+# WHY FROZEN AND NOT LIVE. The first version ran on the operator's live store and refused
+# once, reading 4 records from the command and 0 from the hook. It did not reproduce: three
+# consecutive re-runs read 4 v 4, and control, gapA and gapB binaries all read 4 on that
+# text. Four sessions write that graph during a round. A two-call comparison over an input
+# that moves between the two calls cannot be a bar, however good its controls are. The live
+# run stays useful as a REPORTED FIGURE; this one is the gate.
+#
+# CONTROLS:
+#   C1 neither side empty, both counts printed every run. Two empty sets are not a pass.
+#   C2 both arms must have matched the SAME domains. The two paths use different matchers
+#      (match_domains_auto with session paths vs match_domains with an empty list), so a
+#      difference there means different served sets and the diff cannot judge the walk.
+#      Reported as NOT COMPARABLE, never as a code defect.
+#   C3 must-fail canary: perturb one line, the comparator must go red.
+#   C4 zero parse errors, so no invocation is silently skipped.
+set -uo pipefail
+B="${BASE_BIN:?BASE_BIN required — a binary copied ASIDE from the target dir}"
+[ -x "$B" ] || { echo "BASE_BIN not executable: $B"; exit 2; }
+case "$B" in */target/*) echo "BASE_BIN is inside a cargo target dir; copy it aside."; exit 2;; esac
+fail=0
+
+echo "== provenance =="
+echo "  binary  = $B"
+echo "  md5     = $(md5sum "$B" | cut -d' ' -f1)"
+echo "  version = $("$B" --version 2>&1 | head -1)"
+printf '  symbol %-16s count=%s\n' walk_from_text "$(nm -C "$B" 2>/dev/null | grep -c walk_from_text)"
+
+NS="http://ops-sys.local/ontology#"; G="${NS}graph/global"
+ROOT=$(mktemp -d /tmp/b3h-XXXXXX)
+mkdir -p "$ROOT/.base-gbl/.base" "$ROOT/nowhere"
+# The domain node carries hasDecision, so the DOMAIN BLOCK serves records of its own. That
+# is what makes the served-set half of this leg meaningful: without it the walk would have
+# nothing to dedup against and the comparison would be trivially equal.
+cat > "$ROOT/.base-gbl/.base/graph.nq" <<NQ
+<${NS}domain/global> <${NS}name> "GLOBAL" <$G> .
+<${NS}domain/global> <${NS}hasDecision> <${NS}decision/served-one> <$G> .
+<${NS}decision/served-one> <${NS}name> "a decision the domain block serves" <$G> .
+<${NS}project/aurora-borealis> <${NS}name> "Aurora Borealis" <$G> .
+<${NS}project/aurora-borealis> <${NS}hasDomain> <${NS}domain/global> <$G> .
+<${NS}decision/pick-postgres> <${NS}name> "pick postgres over mysql" <$G> .
+<${NS}decision/pick-postgres> <${NS}belongsTo> <${NS}project/aurora-borealis> <$G> .
+<${NS}decision/pick-postgres> <${NS}updatedAt> "2026-09-01T00:00:00Z" <$G> .
+<${NS}decision/ship-friday> <${NS}name> "ship on friday" <$G> .
+<${NS}decision/ship-friday> <${NS}belongsTo> <${NS}project/aurora-borealis> <$G> .
+<${NS}decision/ship-friday> <${NS}updatedAt> "2026-09-02T00:00:00Z" <$G> .
+NQ
+printf '[[domain]]\nname = "GLOBAL"\nmode = "always"\nprompt_keywords = []\nrules = ["a standing rule"]\n' \
+  > "$ROOT/.base-gbl/domains.toml"
+# Relay off: with it on the hook prints a wake-contract block naming a RANDOM codename, so
+# two runs of one binary differ and nothing here is reproducible.
+printf '[relay]\nenabled = false\n' > "$ROOT/.base-gbl/base.toml"
+echo "  frozen store = $ROOT ($(wc -l < "$ROOT/.base-gbl/.base/graph.nq") quads)"
+
+pairs() {
+  awk '
+    /^<base-context / { n=$0; sub(/^<base-context name="/,"",n); sub(/".*$/,"",n); blk=n; next }
+    /^<\/base-context>/ { blk=""; next }
+    blk!="" && / — / { lab=$0; sub(/^  [a-z]+  */,"",lab); sub(/ — .*$/,"",lab);
+                       gsub(/^[[:space:]]+|[[:space:]]+$/,"",lab); print blk "\t" lab }
+  ' | sort -u
+}
+domains_of() { grep -o '^\[DOMAIN: [^]]*\]\|^\[[A-Za-z ]* CONTEXT\]' | sort -u; }
+
+leg() {
+  local text="$1" tag="$2"
+  echo
+  echo "──────── B3: $text ────────"
+  rm -f "$ROOT/.base-gbl/.base/.session"
+  (cd "$ROOT/nowhere" && BASE_HOME="$ROOT" BASE_NO_AUTO_UPDATE=1 "$B" context "$text") > "$ROOT/$tag.ctx" 2>&1
+  rm -f "$ROOT/.base-gbl/.base/.session"
+  local s="b3h-$tag-$$" i
+  : > "$ROOT/$tag.hook"
+  for i in 1 2; do
+    python3 -c 'import json,sys; print(json.dumps({"session_id":sys.argv[1],"prompt":"hello"}))' "$s" \
+      | (cd "$ROOT/nowhere" && BASE_HOME="$ROOT" BASE_NO_AUTO_UPDATE=1 "$B" hook user-prompt-submit) >/dev/null 2>&1
+  done
+  python3 -c 'import json,sys; print(json.dumps({"session_id":sys.argv[1],"prompt":sys.argv[2]}))' "$s" "$text" \
+    | (cd "$ROOT/nowhere" && BASE_HOME="$ROOT" BASE_NO_AUTO_UPDATE=1 "$B" hook user-prompt-submit) > "$ROOT/$tag.hook" 2>&1
+
+  pairs < "$ROOT/$tag.ctx"  > "$ROOT/$tag.ctx.p"
+  pairs < "$ROOT/$tag.hook" > "$ROOT/$tag.hook.p"
+  local nc nh
+  nc=$(wc -l < "$ROOT/$tag.ctx.p"); nh=$(wc -l < "$ROOT/$tag.hook.p")
+  echo "  context walk records = $nc"
+  echo "  hook    walk records = $nh"
+
+  # C4
+  if grep -qE 'expected `,`|expected `\}`|hook user-prompt-submit:' "$ROOT/$tag.hook"; then
+    echo "  REFUSE (C4): an invocation failed to parse its event and never ran."; fail=$((fail+1)); return
+  fi
+  # C1
+  if [ "$nc" -eq 0 ] || [ "$nh" -eq 0 ]; then
+    echo "  REFUSE (C1): a side is empty — $nc vs $nh. A diff of two empty sets is not a pass."
+    fail=$((fail+1)); return
+  fi
+  # C2
+  domains_of < "$ROOT/$tag.ctx" > "$ROOT/$tag.ctx.d"; domains_of < "$ROOT/$tag.hook" > "$ROOT/$tag.hook.d"
+  if ! diff -q "$ROOT/$tag.ctx.d" "$ROOT/$tag.hook.d" >/dev/null; then
+    echo "  NOT COMPARABLE (C2): the arms matched different domains, so their served sets"
+    echo "  differ and this diff cannot judge the walk."
+    diff "$ROOT/$tag.ctx.d" "$ROOT/$tag.hook.d" | sed 's/^/    /'; fail=$((fail+1)); return
+  fi
+  echo "  C2 ok: both arms matched the same domains"
+  if diff -q "$ROOT/$tag.ctx.p" "$ROOT/$tag.hook.p" >/dev/null; then
+    echo "  PASS: identical sets of (block, record) pairs."
+  else
+    echo "  FAIL: the two paths disagree —"; diff "$ROOT/$tag.ctx.p" "$ROOT/$tag.hook.p" | sed 's/^/    /' | head -12
+    fail=$((fail+1))
+  fi
+  # C3
+  sed '1s/$/ CANARY/' "$ROOT/$tag.ctx.p" > "$ROOT/$tag.can"
+  if diff -q "$ROOT/$tag.can" "$ROOT/$tag.hook.p" >/dev/null; then
+    echo "  CANARY FAILED (C3): a perturbed set read as equal. This leg cannot fail."; fail=$((fail+1))
+  else
+    echo "  C3 ok: a one-line change made the comparator go red."
+  fi
+}
+
+leg 'where are we on `Aurora Borealis`' backticked
+leg 'aurora-borealis' slug
+leg 'status of aurora-borealis today' insentence
+
+echo
+echo "legs=3 problems=$fail  frozen store kept at $ROOT"
+exit "$fail"

--- a/tests/prove_walk_hook.sh
+++ b/tests/prove_walk_hook.sh
@@ -89,31 +89,68 @@ H="$OUT/global"; seed_home "$H"
 # Run from a directory that is NOT a workspace: load_graph would have errored
 # here, which is exactly the divergence maps_from_store was split to avoid.
 cd /tmp || exit 1
-# lean_mode is `bracket == Fresh && prompt_num <= 2`, so prompts 1 AND 2 are
-# lean and the walk does not run in either. Two fires were not "past lean mode",
-# they were lean mode; this row and two below failed for that one reason.
+# ONE FIRE, AT PROMPT 1. This row used to fire three times on one session and
+# read the third, because prompts 1 and 2 were lean and the walk did not run in
+# either. Now it does, and the warmups became actively harmful: they resolved
+# `aurora` at prompt 1 and MARKED it, so the third fire was deduped and this row
+# read a blank. Worse, the two absence-control rows below would have gone GREEN
+# over a regression, because a rule that started resolving would have been
+# marked at prompt 1 and deduped out of the third fire. Every row reads prompt 1.
 out=$(fire "$H" 'where are we on `aurora`' s1)
-out=$(fire "$H" 'where are we on `aurora`' s1)
-out=$(fire "$H" 'where are we on `aurora`' s1)  # prompt 3: the first non-lean one
 grep -q "pick postgres over mysql" <<<"$out" \
   && ok "a decision in the global tier reached the prompt" \
   || { bad "global-tier record never arrived"; sed -n '1,15p' <<<"$out"; }
 echo
 
-echo "── row: lean mode skips the walk ──"
+echo "── row: prompt 1 of a FRESH session DOES serve the walk ──"
+# INVERTED, not deleted. This row used to assert the defect.
+#
+# `lean_mode` was introduced by fb1cd48 (2026-06-01) for the NEIGHBOURHOOD --
+# `git show fb1cd48:src/hook/user_prompt_submit.rs` contains no walk at all,
+# because the walk did not exist for another three months. 29ff99a (2026-09-07)
+# then hung the walk on that same flag, so the gate this row protected was never
+# reasoned about for the walk.
+#
+# Chris ruled it off: skipping the injection does not save context, it moves the
+# cost and makes it bigger, because the session then spends more than the block's
+# bytes finding the same thing by hand. Prompt 1 is usually where someone starts
+# work, which is where that signal is worth most.
+#
+# TWO ARMS, and the second is what makes the first mean anything. An assertion
+# that a block APPEARS passes just as happily on a build that emits one
+# unconditionally. So a prompt naming nothing in the graph is fired at the same
+# position and must stay silent. Both arms were measured on the pre-change and
+# post-change binaries before this row was written: the control reads 0 blocks
+# on both, so it can genuinely see a zero.
 H2="$OUT/lean"; seed_home "$H2"
 first=$(fire "$H2" 'where are we on `aurora`' s-lean)
 grep -q "<base-context" <<<"$first" \
-  && bad "the walk ran on prompt 1, which is lean mode" \
-  || ok "prompt 1 (FRESH, lean) has no base-context block"
+  && ok "prompt 1 (FRESH) serves a base-context block" \
+  || { bad "prompt 1 served no walk block — the walk is gated again"; sed -n '1,15p' <<<"$first"; }
+
+H2b="$OUT/lean-control"; seed_home "$H2b"
+none=$(fire "$H2b" 'a name the graph does not have' s-lean-none)
+grep -q "<base-context" <<<"$none" \
+  && { bad "prompt 1 served a block for a prompt naming nothing — this row cannot see a zero"; sed -n '1,15p' <<<"$none"; } \
+  || ok "control: prompt 1 naming nothing still serves no block"
+
+# Prompt 2 is the other position the old gate covered. Asserted separately rather
+# than assumed from prompt 1: `lean_mode` was `prompt_num <= 2`, so a partial
+# revert that restored the gate for only one of the two positions would pass a
+# row that tested prompt 1 alone.
+H2c="$OUT/lean-p2"; seed_home "$H2c"
+_=$(fire "$H2c" 'an opening prompt that names nothing' s-lean-p2)
+second=$(fire "$H2c" 'where are we on `aurora`' s-lean-p2)
+grep -q "<base-context" <<<"$second" \
+  && ok "prompt 2 (FRESH) serves a base-context block" \
+  || { bad "prompt 2 served no walk block — the walk is gated again"; sed -n '1,15p' <<<"$second"; }
 echo
 
 echo "── row: the devmode line names what was resolved ──"
 H3="$OUT/dev"; seed_home "$H3"
 printf '[devmode]\nenabled = true\n' > "$H3/.base-gbl/base.toml"
-_=$(fire "$H3" 'where are we on `aurora`' s-dev)
-_=$(fire "$H3" 'where are we on `aurora`' s-dev)
-d=$(fire "$H3" 'where are we on `aurora`' s-dev)  # prompt 3
+# Prompt 1, for the reason on the GLOBAL-tier row above.
+d=$(fire "$H3" 'where are we on `aurora`' s-dev)
 grep -q "walk: aurora" <<<"$d" \
   && ok "devmode names the resolved node" \
   || { bad "no devmode walk line"; grep -n "DEVMODE" -A6 <<<"$d" | head -10; }
@@ -130,9 +167,12 @@ echo "── F19: a name the budget squeezed out is NOT suppressed for the sessi
 H4="$OUT/budget"; seed_home "$H4"
 # A budget of 1 byte cannot fit any record, so the walk renders nothing at all.
 printf '[injection]\nwalk_budget = 1\n' > "$H4/.base-gbl/base.toml"
-_=$(fire "$H4" 'where are we on `aurora`' s-bud)
-_=$(fire "$H4" 'where are we on `aurora`' s-bud)
-squeezed=$(fire "$H4" 'where are we on `aurora`' s-bud)  # prompt 3
+# Prompt 1. This row was sound either way -- a 1-byte budget renders nothing at
+# any position, so no warmup could have marked anything -- but its trailing
+# position comment would have been the only surviving claim that lean mode still
+# gates the walk, and a stale comment is how the next reader inherits a false
+# premise.
+squeezed=$(fire "$H4" 'where are we on `aurora`' s-bud)
 grep -q "<base-context" <<<"$squeezed" \
   && bad "a 1-byte budget still rendered a block" \
   || ok "the budget rendered nothing, as set up"
@@ -152,9 +192,8 @@ echo "── a bare lowercase SLUG resolves; a bare lowercase WORD still does no
 # was consulted, so it never resolved -- while `Aurora-Borealis` did, on nothing but the
 # case of the first letter.
 H5="$OUT/slug"; seed_home "$H5"
-_=$(fire "$H5" 'aurora-borealis' s-slug)
-_=$(fire "$H5" 'aurora-borealis' s-slug)
-slug=$(fire "$H5" 'aurora-borealis' s-slug)   # prompt 3: the first non-lean one
+# Prompt 1, for the reason on the GLOBAL-tier row above.
+slug=$(fire "$H5" 'aurora-borealis' s-slug)
 grep -q "ship on friday" <<<"$slug" \
   && ok "a bare lowercase slug resolved" \
   || { bad "a bare lowercase slug did not resolve"; sed -n '1,12p' <<<"$slug"; }
@@ -162,16 +201,16 @@ grep -q "ship on friday" <<<"$slug" \
 # The control that keeps the exemption honest, and it needs a node named `base` in the
 # graph or it reads 0 for the WRONG REASON: known() would miss, the single-word rule would
 # never be the thing under test, and no regression of that rule could redden this row.
-_=$(fire "$H5" 'base mid-sentence here' s-word)
-_=$(fire "$H5" 'base mid-sentence here' s-word)
+# Prompt 1, and here it is load-bearing rather than tidy: warming this row would
+# mark `base` at prompt 1 if the single-word rule ever regressed, and the read
+# below would then be a deduped blank -- printing ok over the regression.
 word=$(fire "$H5" 'base mid-sentence here' s-word)
 grep -q "keep it small" <<<"$word" \
   && bad "a bare lowercase WORD resolved; the single-word rule is gone" \
   || ok "a bare lowercase word is still a word"
 
 # And no fabrication: a slug-shaped English word the graph does not have stays a word.
-_=$(fire "$H5" 'a well-known thing entirely' s-fab)
-_=$(fire "$H5" 'a well-known thing entirely' s-fab)
+# Prompt 1, load-bearing for the same reason as the row above.
 fab=$(fire "$H5" 'a well-known thing entirely' s-fab)
 grep -q "<base-context" <<<"$fab" \
   && bad "a slug-shaped word with no record behind it fabricated a block" \

--- a/tests/prove_walk_hook.sh
+++ b/tests/prove_walk_hook.sh
@@ -67,6 +67,12 @@ seed_home() {
 <http://ops-sys.local/ontology#decision/pick-postgres> <http://ops-sys.local/ontology#name> "pick postgres over mysql" <http://ops-sys.local/ontology#graph/global> .
 <http://ops-sys.local/ontology#decision/pick-postgres> <http://ops-sys.local/ontology#belongsTo> <http://ops-sys.local/ontology#project/aurora> <http://ops-sys.local/ontology#graph/global> .
 <http://ops-sys.local/ontology#decision/pick-postgres> <http://ops-sys.local/ontology#updatedAt> "2026-09-01T00:00:00Z" <http://ops-sys.local/ontology#graph/global> .
+<http://ops-sys.local/ontology#project/aurora-borealis> <http://ops-sys.local/ontology#name> "Aurora Borealis" <http://ops-sys.local/ontology#graph/global> .
+<http://ops-sys.local/ontology#decision/ship-friday> <http://ops-sys.local/ontology#name> "ship on friday" <http://ops-sys.local/ontology#graph/global> .
+<http://ops-sys.local/ontology#decision/ship-friday> <http://ops-sys.local/ontology#belongsTo> <http://ops-sys.local/ontology#project/aurora-borealis> <http://ops-sys.local/ontology#graph/global> .
+<http://ops-sys.local/ontology#project/base> <http://ops-sys.local/ontology#name> "base" <http://ops-sys.local/ontology#graph/global> .
+<http://ops-sys.local/ontology#decision/keep-it-small> <http://ops-sys.local/ontology#name> "keep it small" <http://ops-sys.local/ontology#graph/global> .
+<http://ops-sys.local/ontology#decision/keep-it-small> <http://ops-sys.local/ontology#belongsTo> <http://ops-sys.local/ontology#project/base> <http://ops-sys.local/ontology#graph/global> .
 NQ
   printf '[[domain]]\nname = "GLOBAL"\nmode = "always"\nprompt_keywords = []\n' > "$h/.base-gbl/domains.toml"
 }
@@ -140,5 +146,37 @@ grep -q "pick postgres over mysql" <<<"$roomy" \
   || bad "the budget permanently suppressed a name that was never served"
 echo
 
-[ "$fail" -eq 0 ] && { echo "PASS — the three hook rows plus the budget-suppression leg."; exit 0; }
+echo "── a bare lowercase SLUG resolves; a bare lowercase WORD still does not ──"
+# `aurora-borealis` is what `base domain list` and `base project list` print and what a
+# user types back. Before this row existed the single-word rule dropped it before known()
+# was consulted, so it never resolved -- while `Aurora-Borealis` did, on nothing but the
+# case of the first letter.
+H5="$OUT/slug"; seed_home "$H5"
+_=$(fire "$H5" 'aurora-borealis' s-slug)
+_=$(fire "$H5" 'aurora-borealis' s-slug)
+slug=$(fire "$H5" 'aurora-borealis' s-slug)   # prompt 3: the first non-lean one
+grep -q "ship on friday" <<<"$slug" \
+  && ok "a bare lowercase slug resolved" \
+  || { bad "a bare lowercase slug did not resolve"; sed -n '1,12p' <<<"$slug"; }
+
+# The control that keeps the exemption honest, and it needs a node named `base` in the
+# graph or it reads 0 for the WRONG REASON: known() would miss, the single-word rule would
+# never be the thing under test, and no regression of that rule could redden this row.
+_=$(fire "$H5" 'base mid-sentence here' s-word)
+_=$(fire "$H5" 'base mid-sentence here' s-word)
+word=$(fire "$H5" 'base mid-sentence here' s-word)
+grep -q "keep it small" <<<"$word" \
+  && bad "a bare lowercase WORD resolved; the single-word rule is gone" \
+  || ok "a bare lowercase word is still a word"
+
+# And no fabrication: a slug-shaped English word the graph does not have stays a word.
+_=$(fire "$H5" 'a well-known thing entirely' s-fab)
+_=$(fire "$H5" 'a well-known thing entirely' s-fab)
+fab=$(fire "$H5" 'a well-known thing entirely' s-fab)
+grep -q "<base-context" <<<"$fab" \
+  && bad "a slug-shaped word with no record behind it fabricated a block" \
+  || ok "no fabrication from a slug-shaped English word"
+echo
+
+[ "$fail" -eq 0 ] && { echo "PASS — the hook rows, the budget-suppression leg and the slug rows."; exit 0; }
 echo "FAIL — $fail problem(s)."; exit 1


### PR DESCRIPTION
Ranks **03**, **04**, **02b**, **01** and **02c**. They are one pull request because they are
one seam — the path from a prompt to what the hook injects — and splitting them would mean
five rebases over the same three files.

### The scoped claim, stated up front so no one has to infer it

**This does not mean a fresh install gets the walk.** The honest claim is narrower:

> a fresh install **that has a `domains.toml` with no always-on domain** now gets the walk and
> the context bracket.

With **no `domains.toml` on disk at all**, a third early return in
`src/hook/user_prompt_submit.rs` fires **before the graph is even loaded**, and the hook serves
**walk 0, bracket 0** — identically before and after this branch. That gate is **not** touched
here, deliberately, under the standing order not to widen a ranked row.

It was measured by the builder, refused rather than quietly fixed, and reproduced independently
by the validator on its own builds. Two independent measurements agree.

### Rank 03 — a slug-shaped token is not a bare lowercase word

Typing the slug that `base` itself prints used to get silence. `9d677c2`.

### Rank 04 — `base context` runs the same walk the hook runs

The preview command showed less than the hook injected while its help claimed the same engine.
It now runs the walk through a seam the hook shares, so the two cannot drift. `ec51a6d`.

### Rank 02b — the walk runs when no domain matched

The early return that skipped the walk when no domain matched is gone. `58c2295`.

### Rank 01 — the walk runs on every prompt, not from prompt 3

`lean_mode` suppressed the walk at prompt positions 1 and 2, so a documented headline feature
served nothing on the prompts a user types first. `5df8b16`.

Measured, one binary per arm, eight prompts at three positions:

| arm | position 1 | position 2 | position 3 |
|---|---|---|---|
| before | 0 | 0 | 7 |
| after | **7** | **7** | 7 |

Position 3 is **byte-identical** across the two arms — 1671 bytes, 46 lines. Prompts that
already walked are untouched, and the after arm serves **the same count at every position**.
This changed **when** the walk runs, not **what** it returns.

**The neighbourhood skip is untouched.** `lean_mode`'s other reader still skips the
neighbourhood block at positions 1 and 2; only the walk came off the gate. That is asserted
behaviourally on a seed that actually emits a neighbourhood block, not inferred from the diff.

### Rank 02c — the context bracket reaches a prompt no domain matched

The same early return also withheld the `<context-bracket>` line and the whole bracket-rules
block, so a user whose prompt matched no domain got nothing at all — not merely no walk.
`366d1a0`.

Measured on a home with a `domains.toml` present and **no domain matching**:

| arm | walk blocks | context bracket | stdout |
|---|---|---|---|
| before | 1 | **0** | 119 B |
| after | 1 | **1** | **228 B** |

And on a home **with** a matched domain, every prompt position is **byte-identical** across the
two arms — p1 1564 bytes, p2 1369, p3 1369. The unmatched path changed; the matched path did
not move by a single byte.

### Validation

Graded independently by `tanager` as the proof of record — a builder green does not settle a
row in this round. Full record: `verification/base-0.15.2-tanager/conditions-walk-01-02c.md`
and `conditions-walk-02b-03-04.md`.

**The binaries reproduce.** The validator rebuilt all three arms cold from clean worktrees in
its own target directory and got the builder's binaries **byte for byte**:
`8a22f862…` (`58c2295`), `184b1896…` (`5df8b16`), `4f0555b8…` (`366d1a0`).

**The gates were shown to fail before their passes were believed:**

- Swapping the arms, and running two pre-rank-01 arms against each other, each made the rank 01
  gate **refuse** rather than pass. It cannot go green without the change present in the branch
  arm.
- The rank 01 gate's canary perturbs one byte and requires the position-3 comparator to go red,
  with a post-condition on the perturbation itself so a no-op edit cannot pass as a comparator
  that cannot fail.
- The neighbourhood instrument **failed on the pre-change arm** — it reports *"the hook is
  silent, so the zeros above prove nothing"* when the walk serves nothing at those positions.
  That failure is what makes its zeros on the after arm a result rather than an absence.
- One assertion in the rank 01 gate is reported **INERT by the script itself**, because its seed
  emits no neighbourhood block at any position and the assertion therefore cannot fail. It is
  **not counted** toward the verdict; the neighbourhood invariant rests on the dedicated
  instrument instead.

**An instrument note worth carrying:** any multi-position instrument driven on **one** session
reads a false zero at later positions, because the walk marks a node once per session. A zero
there means *already served*, not *never walked*. Each position in these gates gets its own
session. The older draft gate is retired for any binary carrying rank 01, for exactly this
reason.

### Commits

```
366d1a0  fix(hook): the context bracket reaches a prompt no domain matched
5df8b16  feat(walk): the walk runs on every prompt, not from prompt 3
58c2295  fix(walk): the walk runs when no domain matched
2d6fefe  test(walk): put both new guards where CI can reach them
ec51a6d  feat(context): base context runs the walk, through a seam the hook shares
9d677c2  fix(walk): a slug-shaped token is not a bare lowercase word
```

Five files, `+572 −106`: `src/domain/query.rs`, `src/hook/user_prompt_submit.rs`,
`src/hook/walk.rs`, `tests/prove_context_walk.sh`, `tests/prove_walk_hook.sh`.